### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ wheels/
 .installed.cfg
 *.egg
 
+# Docker
+.docker-data/
+
 # Go
 *.exe
 *.exe~


### PR DESCRIPTION
Closes #75

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore