### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,10 @@ reports/
 projects/
 
 # Tool-specific
-.claude/
+.claude/settings.json
+.claude/settings.local.json
+.claude/todos/
+.claude/worktrees/
 .playwright-mcp/
 .serena/
 .auto-claude/


### PR DESCRIPTION
Closes #81

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore