### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Multi-Cloud Networking
+description: Multi-cloud networking and site connectivity for F5 Distributed Cloud.
 hero:
   tagline: Multi-cloud networking and site connectivity.
   image:


### PR DESCRIPTION
## Summary

- Adds a `description:` field to `docs/index.mdx` frontmatter for the starlight-llms-txt plugin

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy — adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #258

## Test plan

- [ ] CI checks pass
- [ ] Verify frontmatter YAML is valid
- [ ] Confirm llms.txt output includes the description after deployment