### PR TITLE
feat(terraform): M3 live-deploy enablement (namespace, CE config.yaml, version pinning, idempotency)

### DIFF
--- a/terraform/cloud-init/ce-node.yaml
+++ b/terraform/cloud-init/ce-node.yaml
@@ -1,23 +1,33 @@
 #cloud-config
 # volterra-node (F5 XC Secure Mesh v2 Customer Edge) bootstrap.
 #
-# Canonical SMSv2 format (verified live against the token GetCloudInitConfig API,
-# provider=azure): the node reads its registration token from
-# /etc/vpm/user_data. The key is lowercase `token:` — YAML is case-sensitive; a
-# capitalized `Token:` is NOT parsed by the VPM and the node never registers. No
-# ClusterName is needed: the site binding is automatic via the node's
-# hostname/MAC pre-declared in securemesh_site_v2.azure.not_managed.node_list.
+# Writes the full VPM config to /etc/vpm/config.yaml — the format the
+# volterra-node daemon (vpmd, default --config /etc/vpm/config.yaml) actually
+# consumes. Verified byte-for-byte against a live, ONLINE reference CE in the
+# same Azure subscription. The token-only /etc/vpm/user_data form returned by
+# the GetCloudInitConfig API is for newer node images; the marketplace
+# volterra-node image (9.2024.x) needs this config.yaml, and specifically the
+# CertifiedHardwareEndpoint — without it vpmd exits with
+# "fail to match certified hardware" and never registers.
 #
-# The registration token is provider-generated: ${token} is the Computed
-# xcsh_token.ce.uid (or var.registration_token when set as an override). Site
-# registration approval remains console-only (deferred, xcsh #1206 / #1210).
-#
-# Rendered via templatefile() at the root with { token }.
+# ${token} = generated xcsh_token.ce.uid (or var.registration_token override);
+# ${cluster_name} = the XC site name (ar-bgp-eastus0N). 0600 root-only: the
+# Token is a credential and vpmd runs as root.
 write_files:
-  # 0600 (root-only): the file holds the site registration token, a credential.
-  # The VPM daemon runs as root, so root-only read is sufficient.
-  - path: /etc/vpm/user_data
+  - path: /etc/vpm/config.yaml
     permissions: "0600"
     owner: root
     content: |
-      token: ${token}
+      Vpm:
+        ClusterType: ce
+        ClusterName: ${cluster_name}
+        Token: ${token}
+        MauriceEndpoint: https://register.ves.volterra.io
+        MauricePrivateEndpoint: https://register-tls.ves.volterra.io
+        CertifiedHardwareEndpoint: https://vesio.blob.core.windows.net/releases/certified-hardware/azure.yml
+        Latitude: 0.0
+        Longitude: 0.0
+      Kubernetes:
+        EtcdUseTLS: true
+        Server: vip
+        CloudProvider: disabled

--- a/terraform/cloud-init/ce-node.yaml
+++ b/terraform/cloud-init/ce-node.yaml
@@ -1,20 +1,23 @@
 #cloud-config
 # volterra-node (F5 XC Secure Mesh v2 Customer Edge) bootstrap.
 #
-# The node reads its registration config from /etc/vpm/user_data. It needs the
-# tenant-scoped site registration Token and the ClusterName (the XC site name).
+# Canonical SMSv2 format (verified live against the token GetCloudInitConfig API,
+# provider=azure): the node reads its registration token from
+# /etc/vpm/user_data. The key is lowercase `token:` — YAML is case-sensitive; a
+# capitalized `Token:` is NOT parsed by the VPM and the node never registers. No
+# ClusterName is needed: the site binding is automatic via the node's
+# hostname/MAC pre-declared in securemesh_site_v2.azure.not_managed.node_list.
 #
 # The registration token is provider-generated: ${token} is the Computed
 # xcsh_token.ce.uid (or var.registration_token when set as an override). Site
 # registration approval remains console-only (deferred, xcsh #1206 / #1210).
 #
-# Rendered via templatefile() at the root with { cluster_name, token }.
+# Rendered via templatefile() at the root with { token }.
 write_files:
-  # 0600 (root-only): the file holds the site registration Token, a credential.
+  # 0600 (root-only): the file holds the site registration token, a credential.
   # The VPM daemon runs as root, so root-only read is sufficient.
   - path: /etc/vpm/user_data
     permissions: "0600"
     owner: root
     content: |
-      Token: ${token}
-      ClusterName: ${cluster_name}
+      token: ${token}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,8 +78,7 @@ module "ce_node" {
   ssh_public_key      = local.ssh_public_key
 
   custom_data = base64encode(templatefile("${path.module}/cloud-init/ce-node.yaml", {
-    cluster_name = each.value.site_name
-    token        = local.ce_registration_token
+    token = local.ce_registration_token
   }))
 
   tags = local.tags

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,7 +78,8 @@ module "ce_node" {
   ssh_public_key      = local.ssh_public_key
 
   custom_data = base64encode(templatefile("${path.module}/cloud-init/ce-node.yaml", {
-    token = local.ce_registration_token
+    cluster_name = each.value.site_name
+    token        = local.ce_registration_token
   }))
 
   tags = local.tags

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -98,6 +98,8 @@ module "xc_site" {
   rs_peer_ips    = module.azure_hub.rs_peer_ips
   ce_asn         = var.ce_asn
   rs_asn         = var.rs_asn
+  os_version     = var.ce_os_version
+  sw_version     = var.ce_sw_version
   enable_bgp     = var.enable_bgp
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -128,10 +128,22 @@ module "client_vm" {
 # F5 XC data-plane (app tier)
 # ---------------------------------------------------------
 
+# The deployment owns its application namespace (origin pool + VIP load balancer
+# live here). Referencing xcsh_namespace.mcn.name from the pool/LB creates the
+# apply-time ordering so the namespace exists before its members. (XC sites/bgp
+# live in the fixed `system` namespace and are unaffected.)
+resource "xcsh_namespace" "mcn" {
+  name        = var.xc_app_namespace
+  description = "MCN CE-HA (BGP/ECMP) demo: origin pool + VIP-advertising load balancer."
+}
+
 resource "xcsh_origin_pool" "this" {
   name        = var.origin_pool_name
   namespace   = var.xc_app_namespace
   description = "MCN reference origin pool -> ${var.origin_ip}:${var.origin_port}"
+
+  # xcsh_namespace.mcn owns var.xc_app_namespace; depend on it so it exists first.
+  depends_on = [xcsh_namespace.mcn]
 
   port = var.origin_port
 
@@ -151,6 +163,8 @@ resource "xcsh_http_loadbalancer" "this" {
   name        = var.lb_name
   namespace   = var.xc_app_namespace
   description = "BGP/ECMP HA: custom VIP ${var.vip} advertised from every CE site."
+
+  depends_on = [xcsh_namespace.mcn]
 
   domains = [var.lb_domain]
 

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -8,6 +8,14 @@ resource "xcsh_securemesh_site_v2" "this" {
   description = "MCN CE-HA (BGP/ECMP) single-node SMSv2 site ${var.site_name} — explicit eth0 SLO interface for BGP peer binding."
   labels      = var.labels
 
+  # The provider reads empty labels back as absent, so an unset/empty labels map
+  # perpetually re-plans as `+ labels = {}` (empty-map round-trip drift, same class
+  # as xcsh #1103). Ignore label drift to keep the site idempotent — labels are not
+  # managed by this demo. Root-cause fix belongs in the provider (read-back suppression).
+  lifecycle {
+    ignore_changes = [labels]
+  }
+
   azure {
     not_managed {
       node_list {
@@ -65,12 +73,22 @@ resource "xcsh_securemesh_site_v2" "this" {
     geo_proximity {}
   }
 
+  # Pin OS/SW versions to avoid the fresh-image force-upgrade (9.2024.6 -> latest)
+  # whose churn stalls CE provisioning. Empty vars = use the server default (latest).
   software_settings {
     os {
-      default_os_version {}
+      dynamic "default_os_version" {
+        for_each = var.os_version == "" ? [1] : []
+        content {}
+      }
+      operating_system_version = var.os_version == "" ? null : var.os_version
     }
     sw {
-      default_sw_version {}
+      dynamic "default_sw_version" {
+        for_each = var.sw_version == "" ? [1] : []
+        content {}
+      }
+      volterra_software_version = var.sw_version == "" ? null : var.sw_version
     }
   }
 }

--- a/terraform/modules/xc-site/variables.tf
+++ b/terraform/modules/xc-site/variables.tf
@@ -58,3 +58,15 @@ variable "enable_bgp" {
   type        = bool
   default     = true
 }
+
+variable "os_version" {
+  description = "Pin the CE operating_system_version (e.g. 9.2024.6) to avoid a force-upgrade; empty = server default (latest)."
+  type        = string
+  default     = ""
+}
+
+variable "sw_version" {
+  description = "Pin the CE volterra_software_version (e.g. crt-20250613-3382) to avoid a force-upgrade; empty = server default (latest)."
+  type        = string
+  default     = ""
+}

--- a/terraform/tests/http_lb.tftest.hcl
+++ b/terraform/tests/http_lb.tftest.hcl
@@ -22,8 +22,8 @@ run "loadbalancer_advertise_and_pool" {
   # this run planning cleanly at N=3 — an expansion error would fail the run.
 
   assert {
-    condition     = xcsh_http_loadbalancer.this.namespace == "r-mordasiewicz"
-    error_message = "LB must live in the app namespace r-mordasiewicz."
+    condition     = xcsh_http_loadbalancer.this.namespace == "multi-cloud-networking"
+    error_message = "LB must live in the app namespace multi-cloud-networking."
   }
 
   assert {
@@ -32,8 +32,8 @@ run "loadbalancer_advertise_and_pool" {
   }
 
   assert {
-    condition     = xcsh_origin_pool.this.namespace == "r-mordasiewicz"
-    error_message = "Origin pool must live in the app namespace r-mordasiewicz."
+    condition     = xcsh_origin_pool.this.namespace == "multi-cloud-networking"
+    error_message = "Origin pool must live in the app namespace multi-cloud-networking."
   }
 
   assert {

--- a/terraform/variables_ce.tf
+++ b/terraform/variables_ce.tf
@@ -50,3 +50,15 @@ variable "registration_token" {
   default     = ""
   sensitive   = true
 }
+
+variable "ce_os_version" {
+  description = "Pin CE OS version (e.g. 9.2024.6) to avoid force-upgrade churn; empty = latest."
+  type        = string
+  default     = ""
+}
+
+variable "ce_sw_version" {
+  description = "Pin CE F5XC software version (e.g. crt-20250613-3382) to avoid force-upgrade churn; empty = latest."
+  type        = string
+  default     = ""
+}

--- a/terraform/variables_xc.tf
+++ b/terraform/variables_xc.tf
@@ -5,7 +5,7 @@
 variable "xc_app_namespace" {
   description = "F5 XC namespace for the app-tier objects (origin pool + HTTP load balancer)."
   type        = string
-  default     = "r-mordasiewicz"
+  default     = "multi-cloud-networking"
 }
 
 variable "origin_pool_name" {


### PR DESCRIPTION
Closes #574. Part of epic f5-sales-demo/terraform-provider-xcsh#1207.

Makes the pure-Terraform CE-HA bring-up work end-to-end. **Verified live at N=3** in f5-sales-demo: 3 SMSv2 CEs ONLINE, Route Server learns VIP `10.250.0.10/32` from all 3 next-hops (`10.0.1.4/.5/.6`, client route Active = active/active ECMP), 30/30 requests through the VIP succeed. Registration approval fully API-automated (no console).

## Commits
- `xcsh_namespace` for the app tier (default `multi-cloud-networking`)
- CE cloud-init → full `/etc/vpm/config.yaml` (CertifiedHardwareEndpoint etc.)
- `ce_os_version`/`ce_sw_version` pinning (avoid upgrade-churn stalls)
- `securemesh_site_v2` labels idempotency (`ignore_changes`)

## Verification
fmt/validate clean; `terraform test` 10/10; repeat plan **0-change** against the running N=3 deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)