### PR TITLE
S1: verify SMSv2 numeric input-validation (probe tests + live)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,10 +13,10 @@ name: Terraform
 on:
   pull_request:
     branches: [main]
-    paths: ['terraform/**', '.github/workflows/terraform.yml']
+    paths: ['terraform/**', 'coverage/**', '.github/workflows/terraform.yml']
   push:
     branches: [main]
-    paths: ['terraform/**', '.github/workflows/terraform.yml']
+    paths: ['terraform/**', 'coverage/**', '.github/workflows/terraform.yml']
 
 permissions:
   contents: read
@@ -52,3 +52,30 @@ jobs:
 
       - name: Plan-level module tests (all providers mocked)
         run: terraform test
+
+  # SMSv2 coverage-probe validation gate. Credential-free: the numeric-leaf tests mock the
+  # xcsh provider, so the provider's own schema validators fire at plan with no XC API call.
+  # NOTE: unlike the `validate` job (which pins the provider via terraform/.terraform-version
+  # and vendored config), this job resolves f5-sales-demo/xcsh from the public registry, so it
+  # only turns green once provider v3.75.0 (which ships the SMSv2 numeric validators) is
+  # published there. Locally the same tests run against the dev_overrides build via verify.sh.
+  coverage-smsv2:
+    name: coverage-smsv2
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: coverage/smsv2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.10.5
+
+      - name: Init (no backend; provider resolved from the registry)
+        run: terraform init -input=false -backend=false
+
+      - name: Numeric-validator gate (accept valid bounds + reject out-of-range)
+        run: ./verify.sh

--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -1,6 +1,6 @@
 # SMSv2 Coverage Matrix (xcsh_securemesh_site_v2)
 
-Legend: ✅ done · ⏳ in progress · ⬜ not started · ➖ n/a
+Legend: ✅ done · ⏳ in progress · ⬜ not started · ➖ n/a · ⚠️ done with a documented caveat
 
 Columns:
 
@@ -14,10 +14,10 @@ Columns:
 | Branch / leaf | Structural | Validated | Applied | Idempotent | Import-clean | Notes |
 |---|---|---|---|---|---|---|
 | azure.not_managed.node_list[].interface_list[] | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1 (live N=3) |
-| interface_list.mtu (max 16384) | ✅ | ⬜ | ⬜ | ⬜ | ⬜ | S1: ranges "0,512-16384" |
-| interface_list.priority (0-255) | ✅ | ⬜ | ⬜ | ⬜ | ⬜ | S1 |
-| vlan_interface.vlan_id (1-4095) | ✅ | ⬜ | ⬜ | ⬜ | ⬜ | S1 |
-| custom_proxy.proxy_port (0-65535) | ✅ | ⬜ | ⬜ | ⬜ | ⬜ | S1 |
+| interface_list.mtu (max 16384) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `AtMost(16384)` (reject 20000); base probe live-applied+idempotent; leaf does not drift on import but the object import carries the labels{} #1103 drift (see below) |
+| interface_list.priority (0-255) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `Between(0, 255)` (reject 256); on the base eth0 interface, live-applied+idempotent; import caveat as mtu |
+| vlan_interface.vlan_id (1-4095) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(1, 4095)` (reject 4096) proven at plan; NOT live-applicable — vlan_interface on the azure not_managed single Control node 400s (BAD_REQUEST); gated behind `var.extended_arms`, plan-validated only |
+| custom_proxy.proxy_port (0-65535) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(0, 65535)` (reject 70000) proven at plan; NOT live-applicable — custom_proxy 400s on this probe; gated behind `var.extended_arms`, plan-validated only |
 <!-- remaining toggle/interface/services arms seeded ⬜ for S3–S5 -->
 | block_all_services{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
 | disable_ha{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
@@ -41,10 +41,30 @@ Columns:
 | interface_list.dhcp_client{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: static_ip/dhcp_server S3 |
 | labels | ✅ | ➖ | ✅ | ➖ | ➖ | iter-1; ignore_changes (empty-map drift, xcsh #1103 class) |
 
+**S1 notes (numeric-leaf input validation):**
+
+- **How "Validated" is proven** — `coverage/smsv2/verify.sh` drives `terraform test` with a
+  mocked `xcsh` provider (credential-free; the real v3.75.0 schema validators still fire at
+  plan). `validation.tftest.hcl` asserts valid bounds plan clean; `reject-tests/*.tftest.hcl`
+  each push one leaf out of range and are *designed to fail* — `expect_failures` cannot capture
+  provider schema validators (only user custom conditions), so verify.sh asserts the exact
+  validator diagnostic per leaf instead.
+- **mtu is `AtMost(16384)` only** — the API's discontinuous rule {0} ∪ [512,16384] has no single
+  minimum, so the failing test uses `mtu = 20000` (a small value like 200 is *not* rejected).
+- **⚠️ import caveat (mtu, priority)** — a whole-object `terraform import` re-plans with one
+  in-place change: `- labels {}` on the interface (xcsh #1103 empty-marker class, still present
+  on v3.75.0 for `securemesh_site_v2` interface labels). The numeric leaves themselves do not
+  drift; the base probe is apply-clean and idempotent. Out of scope for S1 (numeric validators).
+- **vlan_id / proxy_port not live-applied** — `vlan_interface` and top-level `custom_proxy` both
+  return `[BAD_REQUEST] Invalid request parameters (400)` on the azure not_managed single Control
+  node. They are gated behind `var.extended_arms` (default true) so their validators are reached
+  at PLAN time; the live apply/idempotent/import ran with `-var extended_arms=false` on the base
+  probe (which still carries the mtu and priority leaves).
+
 <!--
 Slice roadmap:
 - S0: probe workspace + this matrix (done).
-- S1: numeric-leaf input validation (.tftest.hcl out-of-range rejection).
+- S1: numeric-leaf input validation (.tftest.hcl out-of-range rejection) — DONE (verify.sh; provider v3.75.0).
 - S3: interface oneof arms (ethernet vs vlan_interface vs dedicated; network_option SLI/inside; dhcp_client vs static_ip vs dhcp_server; custom_proxy).
 - S4: services oneof arms (forward proxy, network policy, log streaming/receiver).
 - S5: site-mode oneof arms (offline survivability, performance mode, re_select, software_settings explicit versions).

--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -16,7 +16,7 @@ Columns:
 | azure.not_managed.node_list[].interface_list[] | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1 (live N=3) |
 | interface_list.mtu (max 16384) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `AtMost(16384)` (reject 20000); base probe live-applied+idempotent; leaf does not drift on import but the object import carries the labels{} #1103 drift (see below) |
 | interface_list.priority (0-255) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `Between(0, 255)` (reject 256); on the base eth0 interface, live-applied+idempotent; import caveat as mtu |
-| vlan_interface.vlan_id (1-4095) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(1, 4095)` (reject 4096) proven at plan; NOT live-applicable — vlan_interface on the azure not_managed single Control node 400s (BAD_REQUEST); gated behind `var.extended_arms`, plan-validated only |
+| vlan_interface.vlan_id (1-4095) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(1, 4095)` (reject 4096) proven at plan; NOT live-applicable — vlan_interface on the `azure` not_managed single Control node 400s (BAD_REQUEST); gated behind `var.extended_arms`, plan-validated only |
 | custom_proxy.proxy_port (0-65535) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(0, 65535)` (reject 70000) proven at plan; NOT live-applicable — custom_proxy 400s on this probe; gated behind `var.extended_arms`, plan-validated only |
 <!-- remaining toggle/interface/services arms seeded ⬜ for S3–S5 -->
 | block_all_services{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
@@ -56,7 +56,7 @@ Columns:
   on v3.75.0 for `securemesh_site_v2` interface labels). The numeric leaves themselves do not
   drift; the base probe is apply-clean and idempotent. Out of scope for S1 (numeric validators).
 - **vlan_id / proxy_port not live-applied** — `vlan_interface` and top-level `custom_proxy` both
-  return `[BAD_REQUEST] Invalid request parameters (400)` on the azure not_managed single Control
+  return `[BAD_REQUEST] Invalid request parameters (400)` on the `azure` not_managed single Control
   node. They are gated behind `var.extended_arms` (default true) so their validators are reached
   at PLAN time; the live apply/idempotent/import ran with `-var extended_arms=false` on the base
   probe (which still carries the mtu and priority leaves).

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -27,9 +27,24 @@ existing StatusObject and 500s on create.
 | Variable | Default | Purpose |
 |---|---|---|
 | `probe_name` | `cov-probe-01` | Throwaway site name (override per run). |
-| `mtu` | `1500` | SLO interface MTU (0 or 512-16384). |
-| `vlan_id` | `100` | vlan_interface id (1-4095) — wired for S3. |
-| `priority` | `10` | Interface priority (0-255) — wired for S1/S3. |
-| `proxy_port` | `8080` | custom_proxy port (0-65535) — wired for S3. |
+| `mtu` | `1500` | eth0 interface MTU. Validator `AtMost(16384)`. |
+| `priority` | `10` | eth0 interface priority. Validator `Between(0, 255)`. |
+| `vlan_id` | `100` | vlan_interface VLAN tag. Validator `Between(1, 4095)`. |
+| `proxy_port` | `8080` | custom_proxy port. Validator `Between(0, 65535)`. |
+| `extended_arms` | `true` | Render the `vlan_interface` interface + top-level `custom_proxy` so the `vlan_id`/`proxy_port` leaves are reachable at plan. Set `false` for a live apply — those two arms 400 on this single-node probe, but the base eth0 interface (carrying `mtu`/`priority`) still applies live. |
+
+## S1 numeric-validation gate
+
+```bash
+cd coverage/smsv2
+./verify.sh   # credential-free: mocks the xcsh provider; the real v3.75.0 schema validators fire at plan
+```
+
+`verify.sh` proves the SMSv2 numeric validators both accept valid bounds and reject
+out-of-range input. It wraps `terraform test` because Terraform's `expect_failures` only
+captures user custom conditions, not provider schema validators: `validation.tftest.hcl`
+asserts the accept case, and `reject-tests/*.tftest.hcl` (one leaf per file, *designed to
+fail*) are driven with `-test-directory=reject-tests` while verify.sh asserts each leaf's
+exact validator diagnostic. This is the gate the `coverage-smsv2` CI job runs.
 
 Coverage progress is tracked in `../smsv2-coverage-matrix.md`.

--- a/coverage/smsv2/main.tf
+++ b/coverage/smsv2/main.tf
@@ -16,8 +16,9 @@ resource "xcsh_securemesh_site_v2" "probe" {
         type     = "Control"
 
         interface_list {
-          name = "eth0"
-          mtu  = var.mtu
+          name     = "eth0"
+          mtu      = var.mtu
+          priority = var.priority
 
           ethernet_interface {
             device = "eth0"
@@ -28,6 +29,28 @@ resource "xcsh_securemesh_site_v2" "probe" {
           }
 
           dhcp_client {}
+        }
+
+        # S1: a second interface exposing the vlan_interface.vlan_id leaf (validator
+        # Between(1, 4095)). Gated by var.extended_arms so a live apply can fall back to
+        # the proven base-only probe if the XC API rejects the vlan/proxy combination —
+        # the schema validator still fires at PLAN time regardless of this toggle.
+        dynamic "interface_list" {
+          for_each = var.extended_arms ? [1] : []
+          content {
+            name = "eth0-vlan"
+
+            vlan_interface {
+              device  = "eth0"
+              vlan_id = var.vlan_id
+            }
+
+            network_option {
+              site_local_network {}
+            }
+
+            dhcp_client {}
+          }
         }
       }
     }
@@ -70,6 +93,17 @@ resource "xcsh_securemesh_site_v2" "probe" {
     }
     sw {
       default_sw_version {}
+    }
+  }
+
+  # S1: custom_proxy exposes the proxy_port leaf (validator Between(0, 65535)). This is the
+  # custom_proxy|f5_proxy oneof, distinct from the no_forward_proxy oneof set above. Gated by
+  # var.extended_arms (see the vlan_interface note); the validator fires at PLAN time regardless.
+  dynamic "custom_proxy" {
+    for_each = var.extended_arms ? [1] : []
+    content {
+      proxy_ip_address = "10.0.0.10"
+      proxy_port       = var.proxy_port
     }
   }
 }

--- a/coverage/smsv2/reject-tests/reject-mtu.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-mtu.tftest.hcl
@@ -1,0 +1,19 @@
+# DESIGNED TO FAIL — proves interface_list.mtu validator AtMost(16384) rejects >16384.
+# One reject run per file: a failing run halts the rest of its own file, so each leaf gets
+# its own file to guarantee its validator fires. Run via verify.sh (not plain terraform test).
+# mock_provider => no credentials; validator fires from the real v3.75.0 schema at plan.
+mock_provider "xcsh" {}
+
+run "reject_mtu_over_max" {
+  command = plan
+
+  # mtu is AtMost(16384) ONLY (API rule {0} u [512,16384] has no single min), so the failing
+  # value must EXCEED the max — a small value like 200 would NOT be rejected.
+  variables {
+    probe_name = "cov-probe-s1-mtu"
+    mtu        = 20000
+    priority   = 10
+    vlan_id    = 100
+    proxy_port = 8080
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-priority.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-priority.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves interface_list.priority validator Between(0, 255) rejects >255.
+# Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+mock_provider "xcsh" {}
+
+run "reject_priority_over_max" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s1-prio"
+    mtu        = 1500
+    priority   = 256
+    vlan_id    = 100
+    proxy_port = 8080
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-proxy-port.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-proxy-port.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves custom_proxy.proxy_port validator Between(0, 65535) rejects >65535.
+# Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+mock_provider "xcsh" {}
+
+run "reject_proxy_port_over_max" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s1-proxy"
+    mtu        = 1500
+    priority   = 10
+    vlan_id    = 100
+    proxy_port = 70000
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-vlan-id.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-vlan-id.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves vlan_interface.vlan_id validator Between(1, 4095) rejects >4095.
+# Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+mock_provider "xcsh" {}
+
+run "reject_vlan_id_over_max" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s1-vlan"
+    mtu        = 1500
+    priority   = 10
+    vlan_id    = 4096
+    proxy_port = 8080
+  }
+}

--- a/coverage/smsv2/validation.tftest.hcl
+++ b/coverage/smsv2/validation.tftest.hcl
@@ -1,0 +1,36 @@
+# S1 numeric-leaf input validation for xcsh_securemesh_site_v2 (provider >= 3.75.0).
+#
+# POSITIVE case: valid bounds plan cleanly through the REAL provider schema.
+# mock_provider means no XC credentials are needed — the schema (and its numeric
+# validators) come from the dev_overrides build locally / the registry v3.75.0 in CI,
+# and fire during plan regardless of whether the API is contacted.
+#
+# The out-of-range REJECT cases live in ./reject-tests/reject.tftest.hcl. They cannot be
+# asserted with `expect_failures` because Terraform only captures user-defined custom
+# conditions there, not provider schema attribute validators (verified: TF 1.15 reports
+# "was expected to report an error but did not"). They are instead proven by verify.sh,
+# which runs them expecting failure and asserts the exact validator message for each leaf.
+
+mock_provider "xcsh" {}
+
+run "accept_valid_bounds" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s1-ok"
+    mtu        = 1500 # AtMost(16384)
+    priority   = 0    # Between(0, 255)   lower bound
+    vlan_id    = 4095 # Between(1, 4095)  upper bound
+    proxy_port = 0    # Between(0, 65535) lower bound
+  }
+
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.namespace == "system"
+    error_message = "Probe must plan in the system namespace."
+  }
+
+  assert {
+    condition     = length(xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list) == 2
+    error_message = "extended_arms must render both the eth0 and eth0-vlan interfaces so every numeric leaf is reachable."
+  }
+}

--- a/coverage/smsv2/variables.tf
+++ b/coverage/smsv2/variables.tf
@@ -5,12 +5,38 @@ variable "probe_name" {
 }
 
 variable "mtu" {
-  description = "SLO interface MTU. Valid range per API: 0 or 512-16384 (S1 pushes out-of-range values)."
+  description = "SLO interface MTU. Provider validator: AtMost(16384) (API rule is 0 or 512-16384). S1 pushes >16384 to prove rejection."
   type        = number
   default     = 1500
 }
 
-# NOTE: vlan_id / priority / proxy_port variables are intentionally NOT declared here.
-# tflint (terraform_unused_declarations) rejects declared-but-unused variables. They are
-# re-introduced in S1/S3 together with the vlan_interface and custom_proxy blocks that
-# consume them (see the coverage plan Task 11), so declaration and use land together.
+variable "priority" {
+  description = "eth0 interface priority. Provider validator: Between(0, 255). S1 pushes >255 to prove rejection."
+  type        = number
+  default     = 10
+}
+
+variable "vlan_id" {
+  description = "vlan_interface VLAN tag. Provider validator: Between(1, 4095). S1 pushes >4095 to prove rejection."
+  type        = number
+  default     = 100
+}
+
+variable "proxy_port" {
+  description = "custom_proxy port. Provider validator: Between(0, 65535). S1 pushes >65535 to prove rejection."
+  type        = number
+  default     = 8080
+}
+
+variable "extended_arms" {
+  description = <<-EOT
+    When true (default), the probe renders the S1 vlan_interface interface entry and the
+    top-level custom_proxy block so the vlan_id and proxy_port numeric leaves are reachable
+    at PLAN time (schema validators fire during plan under both mock_provider tests and live
+    plans). Set false only for a live apply if the XC API rejects the vlan/proxy combination:
+    the base eth0 interface (which carries the mtu and priority leaves) still applies live and
+    stays idempotent/import-clean, while vlan_id/proxy_port remain plan-validated.
+  EOT
+  type        = bool
+  default     = true
+}

--- a/coverage/smsv2/verify.sh
+++ b/coverage/smsv2/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# S1 numeric-validation gate for the SMSv2 coverage probe.
+#
+# Proves the provider v3.75.0 SMSv2 numeric validators both ACCEPT valid bounds and REJECT
+# out-of-range input, entirely credential-free (mock_provider fires the real schema
+# validators at plan). This wraps `terraform test` because Terraform's `expect_failures`
+# only captures user-defined custom conditions, not provider schema attribute validators, so
+# a rejection cannot be asserted as a passing test run natively.
+#
+#   Phase 1 (accept): plain `terraform test` runs the root accept case -> must exit 0.
+#   Phase 2 (reject): `terraform test -test-directory=reject-tests` runs the DESIGNED-TO-FAIL
+#                     reject cases -> must exit non-zero AND emit each leaf's exact validator
+#                     message. One reject run per file (a failing run halts its own file).
+#
+# Idempotent and deterministic: no state, no network, same result every run / in CI.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+echo "== Phase 1: accept valid bounds (plain terraform test) =="
+if ! terraform test; then
+  fail "accept_valid_bounds did not pass 'terraform test'"
+fi
+
+echo
+echo "== Phase 2: reject out-of-range input (terraform test -test-directory=reject-tests) =="
+reject_out="$(terraform test -test-directory=reject-tests 2>&1)"
+reject_rc=$?
+echo "${reject_out}"
+
+if [ "${reject_rc}" -eq 0 ]; then
+  fail "reject suite exited 0 — validators did NOT reject out-of-range input"
+fi
+
+# Normalize: strip ANSI colors and box-drawing gutters, then join wrapped diagnostic
+# lines into one blob so each validator message matches regardless of terminal wrapping.
+reject_norm="$(printf '%s' "${reject_out}" | sed $'s/\x1b\\[[0-9;]*m//g' | tr '\n' ' ' | sed 's/\xe2\x94\x82//g' | tr -s ' ')"
+
+# Each leaf's exact validator diagnostic must appear.
+declare -a expected=(
+  "must be at most 16384, got: 20000"
+  "must be between 0 and 255, got: 256"
+  "must be between 1 and 4095, got: 4096"
+  "must be between 0 and 65535, got: 70000"
+)
+for msg in "${expected[@]}"; do
+  case "${reject_norm}" in
+  *"${msg}"*) echo "OK: validator emitted -> ${msg}" ;;
+  *) fail "expected validator message not found -> ${msg}" ;;
+  esac
+done
+
+echo
+echo "PASS: S1 numeric validators accept valid bounds and reject all four out-of-range leaves."

--- a/coverage/smsv2/versions.tf
+++ b/coverage/smsv2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.74.0"
+      version = ">= 3.75.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
End-to-end verification that provider v3.75.0 enforces SMSv2 numeric bounds (S1a spec bounds + S1b min=0 codegen).

- Probe extended (`priority` on eth0; `extended_arms`-gated `vlan_interface`/`custom_proxy`) so mtu/priority/vlan_id/proxy_port leaves are plan-reachable.
- `verify.sh` + `reject-tests/*.tftest.hcl`: credential-free harness proving each validator rejects out-of-range input (mtu>16384, priority>255, vlan_id>4095, proxy_port>65535) with its exact diagnostic; `validation.tftest.hcl` accept case plans clean at boundary values. (Provider schema validators are not capturable by `expect_failures` — hence the diagnostic-asserting wrapper.)
- Live: base probe (mtu+priority) apply → 0-change re-plan → import → destroy; vlan/proxy arms 400 on a single-node not_managed node → plan-validated only (matrix does not claim them live).
- Pinned `>= 3.75.0`; added `coverage-smsv2` CI job (needs registry v3.75.0, releasing).
- Coverage matrix S1 rows updated (no overclaiming).

## Verification
Local verify.sh exits 0 (4 rejects + accept); live cycle clean; demo sites untouched; fmt/tflint/shellcheck/actionlint clean.

Closes #578. Part of epic f5-sales-demo/terraform-provider-xcsh#1207.