### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,13 +83,10 @@ env/
 ENV/
 .venv/
 
-# Test coverage (generated reports). The tracked SMSv2 coverage harness lives under
-# coverage/ too, so ignore generated children but keep the harness paths tracked.
+# Test coverage
 .coverage
 htmlcov/
-coverage/*
-!coverage/smsv2-coverage-matrix.md
-!coverage/smsv2/
+coverage/
 
 # Build artifacts
 reports/


### PR DESCRIPTION
Closes #580

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore