### PR TITLE
S2c: verify SMSv2 string input-validation (probe reject + live)

### DIFF
--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -18,6 +18,11 @@ Columns:
 | interface_list.priority (0-255) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `Between(0, 255)` (reject 256); on the base eth0 interface, live-applied+idempotent; import caveat as mtu |
 | vlan_interface.vlan_id (1-4095) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(1, 4095)` (reject 4096) proven at plan; NOT live-applicable — vlan_interface on the `azure` not_managed single Control node 400s (BAD_REQUEST); gated behind `var.extended_arms`, plan-validated only |
 | custom_proxy.proxy_port (0-65535) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(0, 65535)` (reject 70000) proven at plan; NOT live-applicable — custom_proxy 400s on this probe; gated behind `var.extended_arms`, plan-validated only |
+| ethernet_interface.mac | ✅ | ✅ | ✅ | ✅ | ⚠️ | S2: validator `MACValidator()` (reject `"not-a-mac"`); live-applied on the base eth0 with a valid MAC (`7C-1E-52-7F-F8-12`), idempotent; whole-object import carries the labels{} #1103 drift (see S1 note); gated by `string_arms` |
+| static_ip.ip_address (CIDR) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S2: validator `CIDRValidator()` (reject `"999.999.0.0/8"`); static_ip is the `dhcp_client` address-oneof sibling, live-applied+idempotent (`10.0.1.5/24`), gated by `string_arms`; import labels{} #1103 drift |
+| static_ip.default_gw (IP) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S2: validator `IPValidator()` (reject `"10.0.0.256"`); applied live with ip_address (`10.0.1.1`); import labels{} #1103 drift |
+| local_vrf.sli_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject `"300.1.1.1"`) proven at plan; NOT live-applied — `sli_config` is a distinct `local_vrf` oneof arm from the base `default_sli_config`; gated behind `vrf_string_arms` (default false), plan-validated only (live is an S3 oneof concern) |
+| local_vrf.sli_config.vip (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject the IPv6 literal `"2001:db8::1"`, proving IPv4-specificity); plan-validated only, gated behind `vrf_string_arms` (S3 oneof, as nameserver) |
 <!-- remaining toggle/interface/services arms seeded ⬜ for S3–S5 -->
 | block_all_services{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
 | disable_ha{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
@@ -35,10 +40,10 @@ Columns:
 | re_select.geo_proximity{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: from_site_list S5 |
 | software_settings.os.default_os_version{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: operating_system_version S5 |
 | software_settings.sw.default_sw_version{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: volterra_software_version S5 |
-| node_list[].type (Control/…) | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; enum values S1 |
-| interface_list.ethernet_interface{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof vs vlan/dedicated S3 |
+| node_list[].type (Control/Worker) | ✅ | ✅ | ✅ | ✅ | ✅ | iter-1 live; S2: validator `OneOf("Control", "Worker")` (reject `"Bogus"`); the valid `Worker` arm plans clean and `Control` applied live |
+| interface_list.ethernet_interface{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm (its `mac` leaf → Validated ✅, row above); oneof vs vlan/dedicated S3 |
 | interface_list.network_option.site_local_network{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: SLI/inside S3 |
-| interface_list.dhcp_client{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: static_ip/dhcp_server S3 |
+| interface_list.dhcp_client{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm; the `static_ip` address-oneof sibling (ip_address/default_gw leaves) → Validated ✅ + Applied ✅ (rows above); dhcp_server S3 |
 | labels | ✅ | ➖ | ✅ | ➖ | ➖ | iter-1; ignore_changes (empty-map drift, xcsh #1103 class) |
 
 **S1 notes (numeric-leaf input validation):**
@@ -61,10 +66,31 @@ Columns:
   at PLAN time; the live apply/idempotent/import ran with `-var extended_arms=false` on the base
   probe (which still carries the mtu and priority leaves).
 
+**S2 notes (string-leaf input validation, provider >= 3.75.1):**
+
+- **Same verify.sh harness** — the S2 string reject cases (`reject-mac`, `reject-ip-address`,
+  `reject-default-gw`, `reject-nameserver`, `reject-vip`, `reject-node-type`) are driven by the
+  same `verify.sh` Phase 2, which asserts each validator's exact diagnostic. The accept case in
+  `validation.tftest.hcl` proves every string validator also passes a valid value at plan.
+- **mac / static_ip live-applied** — unlike S1's vlan_interface/custom_proxy, the eth0
+  `ethernet_interface.mac` and the `static_ip { ip_address, default_gw }` address-oneof arm both
+  apply live (HTTP 200) on the `azure` not_managed single-node probe. The live cycle ran twice
+  with a fresh `probe_name`: (a) the base arm `-var string_arms=false` (dhcp_client, no mac), and
+  (b) the string arm `-var string_arms=true` (mac + static_ip) — both apply → 0-change re-plan →
+  import → destroy, with only the shared labels{} #1103 import drift and no string-leaf drift.
+- **nameserver / vip plan-only** — `IPv4Validator()` is proven at PLAN via `reject-nameserver`
+  (bad IPv4 `300.1.1.1`) and `reject-vip` (the IPv6 literal `2001:db8::1`, proving IPv4-specificity).
+  They live on `local_vrf.sli_config`, a distinct oneof arm from the base `default_sli_config`, so
+  they are gated behind `var.vrf_string_arms` (default false) and NOT live-applied — the live oneof
+  swap is an S3 concern. Not overclaimed: Applied stays ⬜.
+- **validator string values** — MAC uses `net.ParseMAC`, CIDR `net.ParseCIDR`, IP `net.ParseIP`,
+  IPv4 `net.ParseIP + To4()`; each skips null/empty (Optional) so absent leaves never error.
+
 <!--
 Slice roadmap:
 - S0: probe workspace + this matrix (done).
 - S1: numeric-leaf input validation (.tftest.hcl out-of-range rejection) — DONE (verify.sh; provider v3.75.0).
+- S2: string-leaf input validation (mac/CIDR/IP/IPv4/node-type) — DONE (verify.sh; provider v3.75.1).
 - S3: interface oneof arms (ethernet vs vlan_interface vs dedicated; network_option SLI/inside; dhcp_client vs static_ip vs dhcp_server; custom_proxy).
 - S4: services oneof arms (forward proxy, network policy, log streaming/receiver).
 - S5: site-mode oneof arms (offline survivability, performance mode, re_select, software_settings explicit versions).

--- a/coverage/smsv2/main.tf
+++ b/coverage/smsv2/main.tf
@@ -13,7 +13,9 @@ resource "xcsh_securemesh_site_v2" "probe" {
     not_managed {
       node_list {
         hostname = "cov-probe-node-01"
-        type     = "Control"
+        # S2: node type exposes the OneOf("Control", "Worker") enum validator. Always wired;
+        # the valid default ("Control") keeps the base probe live-appliable. Reject test pushes "Bogus".
+        type = var.node_type
 
         interface_list {
           name     = "eth0"
@@ -22,13 +24,31 @@ resource "xcsh_securemesh_site_v2" "probe" {
 
           ethernet_interface {
             device = "eth0"
+            # S2: mac exposes the MACValidator() string validator. Gated by var.string_arms so a live
+            # apply can fall back to the proven base probe (no mac) if the XC API rejects it — the
+            # validator still fires at PLAN time whenever string_arms is true.
+            mac = var.string_arms ? var.mac : null
           }
 
           network_option {
             site_local_network {}
           }
 
-          dhcp_client {}
+          # S2: address oneof. When string_arms is true, a static_ip block exposes the
+          # ip_address CIDRValidator() and default_gw IPValidator() string validators; when false the
+          # probe reverts to the proven base dhcp_client{} arm so the base live cycle stays clean.
+          dynamic "dhcp_client" {
+            for_each = var.string_arms ? [] : [1]
+            content {}
+          }
+
+          dynamic "static_ip" {
+            for_each = var.string_arms ? [1] : []
+            content {
+              ip_address = var.ip_address
+              default_gw = var.default_gw
+            }
+          }
         }
 
         # S1: a second interface exposing the vlan_interface.vlan_id leaf (validator
@@ -67,6 +87,18 @@ resource "xcsh_securemesh_site_v2" "probe" {
   local_vrf {
     default_config {}
     default_sli_config {}
+
+    # S2: sli_config exposes the nameserver/vip leaves guarded by IPv4Validator(). This is a
+    # distinct local_vrf oneof arm from default_sli_config above; gated by var.vrf_string_arms
+    # (default false) so it is only rendered under mock_provider plan tests — the validator fires
+    # at PLAN regardless. Not live-applied (oneof collision with default_sli_config is an S3 arm).
+    dynamic "sli_config" {
+      for_each = var.vrf_string_arms ? [1] : []
+      content {
+        nameserver = var.nameserver
+        vip        = var.vip
+      }
+    }
   }
 
   logs_streaming_disabled {}

--- a/coverage/smsv2/reject-tests/reject-default-gw.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-default-gw.tftest.hcl
@@ -1,0 +1,13 @@
+# DESIGNED TO FAIL — proves static_ip.default_gw validator IPValidator() rejects a non-IP value.
+# Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+# string_arms defaults true, so the static_ip block (ip_address + default_gw) is rendered.
+mock_provider "xcsh" {}
+
+run "reject_default_gw_not_an_ip" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s2-gw"
+    default_gw = "10.0.0.256"
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-ip-address.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-ip-address.tftest.hcl
@@ -1,0 +1,13 @@
+# DESIGNED TO FAIL — proves static_ip.ip_address validator CIDRValidator() rejects a bad CIDR.
+# Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+# string_arms defaults true, so the static_ip block (ip_address + default_gw) is rendered.
+mock_provider "xcsh" {}
+
+run "reject_ip_address_bad_cidr" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s2-ip"
+    ip_address = "999.999.0.0/8"
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-mac.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-mac.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves ethernet_interface.mac validator MACValidator() rejects a malformed MAC.
+# One reject run per file: a failing run halts the rest of its own file, so each leaf gets
+# its own file to guarantee its validator fires. Run via verify.sh (not plain terraform test).
+# mock_provider => no credentials; validator fires from the real v3.75.1 schema at plan.
+# string_arms defaults true, so the mac leaf is wired on the eth0 ethernet_interface.
+mock_provider "xcsh" {}
+
+run "reject_mac_malformed" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s2-mac"
+    mac        = "not-a-mac"
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-nameserver.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-nameserver.tftest.hcl
@@ -1,0 +1,14 @@
+# DESIGNED TO FAIL — proves local_vrf.sli_config.nameserver validator IPv4Validator() rejects a
+# malformed IPv4. Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+# vrf_string_arms=true renders the sli_config block so the nameserver leaf is reachable at plan.
+mock_provider "xcsh" {}
+
+run "reject_nameserver_bad_ipv4" {
+  command = plan
+
+  variables {
+    probe_name      = "cov-probe-s2-ns"
+    vrf_string_arms = true
+    nameserver      = "300.1.1.1"
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-node-type.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-node-type.tftest.hcl
@@ -1,0 +1,13 @@
+# DESIGNED TO FAIL — proves node_list[].type validator OneOf("Control", "Worker") rejects an
+# out-of-enum value. Run via verify.sh (not plain terraform test). mock_provider => no credentials.
+# The type leaf is always wired regardless of string_arms.
+mock_provider "xcsh" {}
+
+run "reject_node_type_out_of_enum" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s2-type"
+    node_type  = "Bogus"
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-vip.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-vip.tftest.hcl
@@ -1,0 +1,14 @@
+# DESIGNED TO FAIL — proves local_vrf.sli_config.vip validator IPv4Validator() rejects a
+# non-IPv4 value (an IPv6 literal, proving the validator is IPv4-specific). Run via verify.sh
+# (not plain terraform test). mock_provider => no credentials. vrf_string_arms=true renders sli_config.
+mock_provider "xcsh" {}
+
+run "reject_vip_not_ipv4" {
+  command = plan
+
+  variables {
+    probe_name      = "cov-probe-s2-vip"
+    vrf_string_arms = true
+    vip             = "2001:db8::1"
+  }
+}

--- a/coverage/smsv2/validation.tftest.hcl
+++ b/coverage/smsv2/validation.tftest.hcl
@@ -1,9 +1,9 @@
-# S1 numeric-leaf input validation for xcsh_securemesh_site_v2 (provider >= 3.75.0).
+# S1 numeric- + S2 string-leaf input validation for xcsh_securemesh_site_v2 (provider >= 3.75.1).
 #
-# POSITIVE case: valid bounds plan cleanly through the REAL provider schema.
-# mock_provider means no XC credentials are needed — the schema (and its numeric
-# validators) come from the dev_overrides build locally / the registry v3.75.0 in CI,
-# and fire during plan regardless of whether the API is contacted.
+# POSITIVE case: valid bounds AND valid mac/ip/CIDR/node-type plan cleanly through the REAL
+# provider schema. mock_provider means no XC credentials are needed — the schema (and its
+# numeric + string validators) come from the dev_overrides build locally / the registry v3.75.1
+# in CI, and fire during plan regardless of whether the API is contacted.
 #
 # The out-of-range REJECT cases live in ./reject-tests/reject.tftest.hcl. They cannot be
 # asserted with `expect_failures` because Terraform only captures user-defined custom
@@ -17,11 +17,18 @@ run "accept_valid_bounds" {
   command = plan
 
   variables {
-    probe_name = "cov-probe-s1-ok"
-    mtu        = 1500 # AtMost(16384)
-    priority   = 0    # Between(0, 255)   lower bound
-    vlan_id    = 4095 # Between(1, 4095)  upper bound
-    proxy_port = 0    # Between(0, 65535) lower bound
+    probe_name      = "cov-probe-s1-ok"
+    mtu             = 1500                # AtMost(16384)
+    priority        = 0                   # Between(0, 255)   lower bound
+    vlan_id         = 4095                # Between(1, 4095)  upper bound
+    proxy_port      = 0                   # Between(0, 65535) lower bound
+    mac             = "7C-1E-52-7F-F8-12" # MACValidator()
+    node_type       = "Worker"            # OneOf("Control", "Worker") — the non-default valid arm
+    ip_address      = "10.0.1.5/24"       # CIDRValidator()
+    default_gw      = "10.0.1.1"          # IPValidator()
+    vrf_string_arms = true                # render sli_config so the IPv4Validator leaves are reached
+    nameserver      = "10.0.2.53"         # IPv4Validator()
+    vip             = "10.0.2.100"        # IPv4Validator()
   }
 
   assert {
@@ -32,5 +39,20 @@ run "accept_valid_bounds" {
   assert {
     condition     = length(xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list) == 2
     error_message = "extended_arms must render both the eth0 and eth0-vlan interfaces so every numeric leaf is reachable."
+  }
+
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].type == "Worker"
+    error_message = "A valid node type (Worker) must pass the OneOf(Control, Worker) validator and plan clean."
+  }
+
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].static_ip.ip_address == "10.0.1.5/24"
+    error_message = "string_arms must render the static_ip block so a valid CIDR ip_address plans clean."
+  }
+
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.local_vrf.sli_config.vip == "10.0.2.100"
+    error_message = "vrf_string_arms must render sli_config so a valid IPv4 nameserver/vip plans clean through IPv4Validator."
   }
 }

--- a/coverage/smsv2/variables.tf
+++ b/coverage/smsv2/variables.tf
@@ -28,6 +28,70 @@ variable "proxy_port" {
   default     = 8080
 }
 
+variable "mac" {
+  description = "eth0 ethernet_interface MAC. Provider validator: `MACValidator()`. S2 pushes \"not-a-mac\" to prove rejection. Wired only when string_arms=true."
+  type        = string
+  default     = "7C-1E-52-7F-F8-12"
+}
+
+variable "node_type" {
+  description = "node_list[].type. Provider validator: `OneOf(\"Control\", \"Worker\")`. S2 pushes \"Bogus\" to prove rejection. Always wired (valid default keeps the base probe live-appliable)."
+  type        = string
+  default     = "Control"
+}
+
+variable "ip_address" {
+  description = "static_ip.ip_address (CIDR). Provider validator: `CIDRValidator()`. S2 pushes \"999.999.0.0/8\" to prove rejection. Rendered only when string_arms=true."
+  type        = string
+  default     = "10.0.1.5/24"
+}
+
+variable "default_gw" {
+  description = "static_ip.default_gw (plain IP). Provider validator: `IPValidator()`. Rendered only when string_arms=true."
+  type        = string
+  default     = "10.0.1.1"
+}
+
+variable "nameserver" {
+  description = "local_vrf.sli_config.nameserver (plain IPv4). Provider validator: `IPv4Validator()`. S2 pushes an invalid IPv4 to prove rejection. Rendered only when vrf_string_arms=true."
+  type        = string
+  default     = "10.0.2.53"
+}
+
+variable "vip" {
+  description = "local_vrf.sli_config.vip (plain IPv4). Provider validator: `IPv4Validator()`. Rendered only when vrf_string_arms=true."
+  type        = string
+  default     = "10.0.2.100"
+}
+
+variable "vrf_string_arms" {
+  description = <<-EOT
+    When true, the probe renders an additional `local_vrf.sli_config` block exposing the
+    `nameserver` and `vip` leaves so the `IPv4Validator()` string validator is reachable at PLAN
+    time. Default false: `sli_config` is a distinct `local_vrf` oneof arm from the proven base
+    `default_sli_config{}`, so it is NOT live-applied here (it would collide with the base VRF arm,
+    an S3 oneof-coverage concern). Set true only under mock_provider tests, where the schema
+    validator fires at plan without contacting the API.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "string_arms" {
+  description = <<-EOT
+    When true (default), the probe wires the eth0 ethernet_interface `mac` leaf and renders a
+    `static_ip { ip_address, default_gw }` address block in place of the base `dhcp_client {}`,
+    so the `MACValidator()`, `CIDRValidator()` and `IPValidator()` string validators are reachable
+    at PLAN time (they fire during plan under both mock_provider tests and live plans). Set false
+    only for a live apply if the XC API rejects the mac/static_ip combination on the single-node
+    `azure` not_managed probe: the base eth0 interface reverts to `dhcp_client {}` with no `mac`,
+    which applies live and stays idempotent/import-clean, while mac/ip_address/default_gw remain
+    plan-validated. The node `type` leaf is always wired (its valid default is live-safe).
+  EOT
+  type        = bool
+  default     = true
+}
+
 variable "extended_arms" {
   description = <<-EOT
     When true (default), the probe renders the S1 vlan_interface interface entry and the

--- a/coverage/smsv2/verify.sh
+++ b/coverage/smsv2/verify.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# S1 numeric-validation gate for the SMSv2 coverage probe.
+# S1 numeric- + S2 string-validation gate for the SMSv2 coverage probe.
 #
-# Proves the provider v3.75.0 SMSv2 numeric validators both ACCEPT valid bounds and REJECT
-# out-of-range input, entirely credential-free (mock_provider fires the real schema
+# Proves the provider v3.75.1 SMSv2 numeric AND string validators both ACCEPT valid input and
+# REJECT invalid input, entirely credential-free (mock_provider fires the real schema
 # validators at plan). This wraps `terraform test` because Terraform's `expect_failures`
 # only captures user-defined custom conditions, not provider schema attribute validators, so
 # a rejection cannot be asserted as a passing test run natively.
@@ -41,12 +41,22 @@ fi
 # lines into one blob so each validator message matches regardless of terminal wrapping.
 reject_norm="$(printf '%s' "${reject_out}" | sed $'s/\x1b\\[[0-9;]*m//g' | tr '\n' ' ' | sed 's/\xe2\x94\x82//g' | tr -s ' ')"
 
-# Each leaf's exact validator diagnostic must appear.
+# Each leaf's exact validator diagnostic must appear. The S1 numeric messages come from the
+# framework's int64validator; the S2 string messages come from the provider's own
+# internal/validators (MAC/CIDR/IP) and the framework's stringvalidator.OneOf (node type).
 declare -a expected=(
+  # S1 numeric
   "must be at most 16384, got: 20000"
   "must be between 0 and 255, got: 256"
   "must be between 1 and 4095, got: 4096"
   "must be between 0 and 65535, got: 70000"
+  # S2 string
+  'Value "not-a-mac" is not a valid MAC address'
+  'Value "999.999.0.0/8" is not a valid CIDR range'
+  'Value "10.0.0.256" is not a valid IP address'
+  'Value "300.1.1.1" is not a valid IPv4 address'
+  'Value "2001:db8::1" is not a valid IPv4 address'
+  'value must be one of: ["Control" "Worker"], got: "Bogus"'
 )
 for msg in "${expected[@]}"; do
   case "${reject_norm}" in
@@ -56,4 +66,5 @@ for msg in "${expected[@]}"; do
 done
 
 echo
-echo "PASS: S1 numeric validators accept valid bounds and reject all four out-of-range leaves."
+echo "PASS: SMSv2 validators accept valid input and reject all four numeric leaves plus the"
+echo "      mac / ip_address(CIDR) / default_gw(IP) / nameserver+vip(IPv4) / node-type string leaves."

--- a/coverage/smsv2/versions.tf
+++ b/coverage/smsv2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.75.0"
+      version = ">= 3.75.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
End-to-end verification that provider v3.75.1 enforces SMSv2 string validators (S2a node-type enum + S2b format validators).

- Probe extended (`string_arms`/`vrf_string_arms` gates) so mac, static_ip(ip_address/default_gw), node type, and nameserver/vip leaves are reachable.
- 6 `reject-tests/*.tftest.hcl` + `verify.sh` assert each validator's EXACT diagnostic (falsifiable — fails if a validator is absent): mac→MAC, ip_address→CIDR, default_gw→IP, node type→OneOf(Control,Worker), nameserver/vip→IPv4 (incl. a valid-IPv6-rejected-by-IPv4Validator specificity case). Accept case plans clean.
- Live: mac + static_ip + node-type apply→0-change→import→destroy (HTTP 200 on single-node probe); nameserver/vip plan-only (distinct local_vrf.sli_config arm → S3), not overclaimed in matrix.
- Pinned `>= 3.75.1`; matrix S2 rows updated.

## Verification
verify.sh 10/10 (reject+accept); live cycle clean; demo sites untouched; fmt/tflint/shellcheck clean.

Closes #582. Part of epic f5-sales-demo/terraform-provider-xcsh#1207.