### PR TITLE
S3: SMSv2 interface/addressing arm coverage (9 live + 4 plan-only)

### DIFF
--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -43,8 +43,21 @@ Columns:
 | node_list[].type (Control/Worker) | ✅ | ✅ | ✅ | ✅ | ✅ | iter-1 live; S2: validator `OneOf("Control", "Worker")` (reject `"Bogus"`); the valid `Worker` arm plans clean and `Control` applied live |
 | interface_list.ethernet_interface{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm (its `mac` leaf → Validated ✅, row above); oneof vs vlan/dedicated S3 |
 | interface_list.network_option.site_local_network{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: SLI/inside S3 |
-| interface_list.dhcp_client{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm; the `static_ip` address-oneof sibling (ip_address/default_gw leaves) → Validated ✅ + Applied ✅ (rows above); dhcp_server S3 |
+| interface_list.dhcp_client{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | iter-1 + S3 `address_arm=dhcp_client`; block arm; the `static_ip` address-oneof sibling → Validated ✅ + Applied ✅ (rows above); live-applied+idempotent, labels{} #1244 import drift |
 | labels | ✅ | ➖ | ✅ | ➖ | ➖ | iter-1; ignore_changes (empty-map drift, xcsh #1103 class) |
+<!-- S3: interface / addressing oneof arms (enum selectors; live cycle uses -var extended_arms=false) -->
+| interface_list.static_ip{} (address_choice) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S3 `address_arm=static_ip` (default); ip_address/default_gw validated (rows above); live-applied+idempotent, labels{} #1244 import drift |
+| interface_list.no_ipv4_address{} (address_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `address_arm=no_ipv4_address`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| interface_list.no_ipv6_address{} (ipv6_address_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `ipv6_arm=no_ipv6_address` (default); empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| interface_list.monitor{} (monitoring_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `monitor_arm=monitor`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| interface_list.monitor_disabled{} (monitoring_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `monitor_arm=monitor_disabled` (default); empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| interface_list.site_to_site_connectivity_interface_disabled{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `s2s_iface_arm=disabled` (default); empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| interface_list.site_to_site_connectivity_interface_enabled{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `s2s_iface_arm=enabled`; empty marker; recon expected 400 (s2s wiring) but the single-node `azure` probe ACCEPTS it — live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| interface_list.ethernet_interface{} (interface_choice) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S3 `interface_arm=ethernet` (default); mac leaf validated (row above); live-applied+idempotent, labels{} #1244 import drift |
+| interface_list.bond_interface{} (interface_choice) | ✅ | ✅ | ⬜ | ➖ | ➖ | S3 `interface_arm=bond`; plan-only — 400 (BAD_REQUEST) on single-node `azure` probe (confirmed live); `devices` `SizeBetween(1, 8)` reject proven at plan (reject-bond-devices); `lacp.rate` `Between(1, 30)` + `devices` plan clean |
+| interface_list.vlan_interface{} (interface_choice) | ✅ | ✅ | ⬜ | ➖ | ➖ | S3 `interface_arm=vlan` (primary oneof); plan-only — 400 on single-node `azure` probe (confirmed live); `vlan_id` `Between(1, 4095)` validated (S1 reject-vlan-id via the extended_arms second interface) |
+| interface_list.ipv6_auto_config{} (ipv6_address_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S3 `ipv6_arm=ipv6_auto_config`; plan-only — 400 on single-node IPv4 `azure` probe (confirmed live); renders the `host {}` autoconfig_choice member; plans clean |
+| interface_list.static_ipv6_address{} (ipv6_address_choice) | ✅ | ✅ | ⬜ | ➖ | ➖ | S3 `ipv6_arm=static_ipv6_address`; plan-only — 400 on single-node IPv4 `azure` probe (confirmed live); `node_static_ip.ip_address` `CIDRValidator()` reject proven at plan (reject-static-ipv6) |
 
 **S1 notes (numeric-leaf input validation):**
 
@@ -86,12 +99,35 @@ Columns:
 - **validator string values** — MAC uses `net.ParseMAC`, CIDR `net.ParseCIDR`, IP `net.ParseIP`,
   IPv4 `net.ParseIP + To4()`; each skips null/empty (Optional) so absent leaves never error.
 
+**S3 notes (interface / addressing oneof arms, provider v3.76.0):**
+
+- **Enum selectors, not booleans** — each interface oneof is driven by an enum var
+  (`interface_arm`, `address_arm`, `ipv6_arm`, `monitor_arm`, `s2s_iface_arm`) so exactly one
+  member of each oneof renders and no two siblings coexist (which would trip `ConflictsWith`). The
+  old S2 `string_arms` boolean now gates only the `mac` leaf; the address oneof is `address_arm`.
+- **Live cycle uses `-var extended_arms=false`** — as in S1/S2, the default `extended_arms=true`
+  second interface (vlan/custom_proxy) 400s, so every live apply/idempotent/import ran with
+  `extended_arms=false` on the base probe (which still renders one member of every eth0 oneof).
+- **Live-appliable arms** — `ethernet_interface`, `dhcp_client`, `static_ip`, `no_ipv4_address`,
+  `no_ipv6_address`, `monitor`, `monitor_disabled`, `s2s_..._disabled`, `s2s_..._enabled` all
+  apply (HTTP 200), re-plan clean, and import with only the known `labels {}` #1244 drift (already
+  handled by `ignore_changes`). `s2s_..._enabled` was expected plan-only in recon but the
+  single-node `azure` probe accepts it — reclassified live after verification.
+- **Plan-only arms** — `bond_interface`, `vlan_interface`, `ipv6_auto_config`,
+  `static_ipv6_address` each return `[BAD_REQUEST] Invalid request parameters (status: 400)` on the
+  single-node `azure` not_managed probe (confirmed live), so their schema is proven at PLAN only via
+  `validation.tftest.hcl` positive asserts, and their validated leaves via `verify.sh` reject tests
+  (`reject-bond-devices` = `devices` `SizeBetween(1, 8)`, `reject-static-ipv6` = `node_static_ip`
+  `ip_address` `CIDRValidator()`). `vlan_id` `Between(1, 4095)` reject is already covered by S1.
+- **is_management / is_primary** — out of S3 scope (provider-capability gap, tracked in
+  api-specs-enriched #1049; needs spec injection + regen).
+
 <!--
 Slice roadmap:
 - S0: probe workspace + this matrix (done).
 - S1: numeric-leaf input validation (.tftest.hcl out-of-range rejection) — DONE (verify.sh; provider v3.75.0).
 - S2: string-leaf input validation (mac/CIDR/IP/IPv4/node-type) — DONE (verify.sh; provider v3.75.1).
-- S3: interface oneof arms (ethernet vs vlan_interface vs dedicated; network_option SLI/inside; dhcp_client vs static_ip vs dhcp_server; custom_proxy).
+- S3: interface/addressing oneof arms (interface_choice ethernet/bond/vlan; address_choice dhcp_client/static_ip/no_ipv4_address; ipv6_address_choice; monitoring_choice; s2s_iface_choice) — DONE (verify.sh + live matrix; provider v3.76.0).
 - S4: services oneof arms (forward proxy, network policy, log streaming/receiver).
 - S5: site-mode oneof arms (offline survivability, performance mode, re_select, software_settings explicit versions).
 -->

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -32,6 +32,45 @@ existing StatusObject and 500s on create.
 | `vlan_id` | `100` | vlan_interface VLAN tag. Validator `Between(1, 4095)`. |
 | `proxy_port` | `8080` | custom_proxy port. Validator `Between(0, 65535)`. |
 | `extended_arms` | `true` | Render the `vlan_interface` interface + top-level `custom_proxy` so the `vlan_id`/`proxy_port` leaves are reachable at plan. Set `false` for a live apply — those two arms 400 on this single-node probe, but the base eth0 interface (carrying `mtu`/`priority`) still applies live. |
+| `interface_arm` | `ethernet` | eth0 interface_choice oneof: `ethernet` \| `bond` \| `vlan`. `ethernet` is live; `bond`/`vlan` are plan-only (400 live). |
+| `address_arm` | `static_ip` | eth0 address_choice oneof: `dhcp_client` \| `static_ip` \| `no_ipv4_address`. All three live-appliable. |
+| `ipv6_arm` | `no_ipv6_address` | eth0 ipv6_address_choice oneof: `no_ipv6_address` \| `ipv6_auto_config` \| `static_ipv6_address`. `no_ipv6_address` is live; the other two are plan-only (400 live). |
+| `monitor_arm` | `monitor_disabled` | eth0 monitoring_choice oneof: `monitor` \| `monitor_disabled`. Both live-appliable. |
+| `s2s_iface_arm` | `disabled` | eth0 site_to_site_connectivity_interface_choice oneof: `disabled` \| `enabled`. Both live-appliable. |
+
+## S3 interface / addressing oneof arms
+
+Every eth0 interface oneof is modeled as an **enum selector** (`interface_arm`, `address_arm`,
+`ipv6_arm`, `monitor_arm`, `s2s_iface_arm`) so exactly one member of each oneof renders and no two
+siblings ever coexist (which would trip the provider's `ConflictsWith`). Defaults are the live-safe
+base arm, so a bare apply (with `extended_arms=false`) stays idempotent and import-clean.
+
+**Live-appliable** (HTTP 200, idempotent, import-clean modulo the known `labels {}` #1244 drift):
+`ethernet_interface`, `dhcp_client`, `static_ip`, `no_ipv4_address`, `no_ipv6_address`, `monitor`,
+`monitor_disabled`, `site_to_site_connectivity_interface_disabled`, and
+`site_to_site_connectivity_interface_enabled` (s2s `enabled` was expected to need s2s wiring but the
+single-node `azure` probe accepts it — verified live).
+
+**Plan-only** — these return `[BAD_REQUEST] Invalid request parameters (status: 400)` on the
+single-node `azure` not_managed probe, so their schema is proven at PLAN only (like `vlan_id`/
+`proxy_port`): `bond_interface` (`interface_arm=bond`), `vlan_interface` (`interface_arm=vlan`),
+`static_ipv6_address` (`ipv6_arm=static_ipv6_address`), `ipv6_auto_config`
+(`ipv6_arm=ipv6_auto_config`). Their validated leaves (bond `devices` `SizeBetween(1, 8)`,
+static_ipv6 `node_static_ip.ip_address` `CIDRValidator()`) are proven by `verify.sh` reject tests;
+`vlan_id` `Between(1, 4095)` is already covered by S1.
+
+Live cycle per applyable arm (fresh `probe_name`, `extended_arms=false`):
+
+```bash
+cd coverage/smsv2
+set -a; source /tmp/mcn-xcsh.env; set +a
+terraform apply   -auto-approve -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor
+terraform plan                  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor  # No changes
+terraform state rm xcsh_securemesh_site_v2.probe
+terraform import  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor xcsh_securemesh_site_v2.probe system/cov-probe-s3-x
+terraform plan                  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor  # 0-change modulo labels {}
+terraform destroy -auto-approve -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor
+```
 
 ## S1 numeric-validation gate
 

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -59,7 +59,7 @@ single-node `azure` not_managed probe, so their schema is proven at PLAN only (l
 static_ipv6 `node_static_ip.ip_address` `CIDRValidator()`) are proven by `verify.sh` reject tests;
 `vlan_id` `Between(1, 4095)` is already covered by S1.
 
-Live cycle per applyable arm (fresh `probe_name`, `extended_arms=false`):
+Live cycle per live-appliable arm (fresh `probe_name`, `extended_arms=false`):
 
 ```bash
 cd coverage/smsv2

--- a/coverage/smsv2/main.tf
+++ b/coverage/smsv2/main.tf
@@ -22,32 +22,111 @@ resource "xcsh_securemesh_site_v2" "probe" {
           mtu      = var.mtu
           priority = var.priority
 
-          ethernet_interface {
-            device = "eth0"
-            # S2: mac exposes the MACValidator() string validator. Gated by var.string_arms so a live
-            # apply can fall back to the proven base probe (no mac) if the XC API rejects it — the
-            # validator still fires at PLAN time whenever string_arms is true.
-            mac = var.string_arms ? var.mac : null
+          # S3 interface_choice oneof {ethernet_interface | bond_interface | vlan_interface}. Modeled
+          # as the var.interface_arm enum so exactly ONE member renders (no ConflictsWith trip).
+          # ethernet (default) is live-safe; bond/vlan are plan-only (400 on a single-node probe).
+          dynamic "ethernet_interface" {
+            for_each = var.interface_arm == "ethernet" ? [1] : []
+            content {
+              device = "eth0"
+              # S2: mac exposes the MACValidator() string validator. Gated by var.string_arms so a
+              # live apply can fall back to no-mac if the XC API rejects it — the validator still
+              # fires at PLAN time whenever string_arms is true and interface_arm is ethernet.
+              mac = var.string_arms ? var.mac : null
+            }
+          }
+
+          # S3 bond_interface (plan-only): devices SizeBetween(1, 8), lacp.rate Between(1, 30).
+          dynamic "bond_interface" {
+            for_each = var.interface_arm == "bond" ? [1] : []
+            content {
+              devices = var.bond_devices
+              lacp {
+                rate = var.bond_lacp_rate
+              }
+            }
+          }
+
+          # S3 vlan_interface (plan-only): vlan_id Between(1, 4095) (S1 reject already covers >4095
+          # via the extended_arms second interface below; this arm proves it on the primary oneof).
+          dynamic "vlan_interface" {
+            for_each = var.interface_arm == "vlan" ? [1] : []
+            content {
+              device  = "eth0"
+              vlan_id = var.vlan_id
+            }
           }
 
           network_option {
             site_local_network {}
           }
 
-          # S2: address oneof. When string_arms is true, a static_ip block exposes the
-          # ip_address CIDRValidator() and default_gw IPValidator() string validators; when false the
-          # probe reverts to the proven base dhcp_client{} arm so the base live cycle stays clean.
+          # S3 address_choice oneof {dhcp_client | static_ip | no_ipv4_address}, one per var.address_arm.
+          # static_ip (default) exposes the ip_address CIDRValidator() and default_gw IPValidator()
+          # string validators; all three arms are live-appliable.
           dynamic "dhcp_client" {
-            for_each = var.string_arms ? [] : [1]
+            for_each = var.address_arm == "dhcp_client" ? [1] : []
             content {}
           }
 
           dynamic "static_ip" {
-            for_each = var.string_arms ? [1] : []
+            for_each = var.address_arm == "static_ip" ? [1] : []
             content {
               ip_address = var.ip_address
               default_gw = var.default_gw
             }
+          }
+
+          dynamic "no_ipv4_address" {
+            for_each = var.address_arm == "no_ipv4_address" ? [1] : []
+            content {}
+          }
+
+          # S3 ipv6_address_choice oneof {no_ipv6_address | ipv6_auto_config | static_ipv6_address}.
+          # no_ipv6_address (default) is live-appliable; the other two 400 on a single-node IPv4
+          # probe (plan-only). static_ipv6_address.node_static_ip.ip_address is CIDRValidator()-guarded.
+          dynamic "no_ipv6_address" {
+            for_each = var.ipv6_arm == "no_ipv6_address" ? [1] : []
+            content {}
+          }
+
+          dynamic "ipv6_auto_config" {
+            for_each = var.ipv6_arm == "ipv6_auto_config" ? [1] : []
+            content {
+              host {} # autoconfig_choice: host (empty) — the router arm needs an IPv6 prefix
+            }
+          }
+
+          dynamic "static_ipv6_address" {
+            for_each = var.ipv6_arm == "static_ipv6_address" ? [1] : []
+            content {
+              node_static_ip { # network_prefix_choice: node_static_ip (vs cluster_static_ip)
+                ip_address = var.ipv6_address
+              }
+            }
+          }
+
+          # S3 monitoring_choice oneof {monitor | monitor_disabled}. Both empty, both live-appliable.
+          dynamic "monitor" {
+            for_each = var.monitor_arm == "monitor" ? [1] : []
+            content {}
+          }
+
+          dynamic "monitor_disabled" {
+            for_each = var.monitor_arm == "monitor_disabled" ? [1] : []
+            content {}
+          }
+
+          # S3 site_to_site_connectivity_interface_choice oneof {disabled | enabled}. disabled
+          # (default) is live-appliable; enabled needs site s2s wiring (plan-only).
+          dynamic "site_to_site_connectivity_interface_disabled" {
+            for_each = var.s2s_iface_arm == "disabled" ? [1] : []
+            content {}
+          }
+
+          dynamic "site_to_site_connectivity_interface_enabled" {
+            for_each = var.s2s_iface_arm == "enabled" ? [1] : []
+            content {}
           }
         }
 

--- a/coverage/smsv2/reject-tests/reject-bond-devices.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-bond-devices.tftest.hcl
@@ -1,0 +1,14 @@
+# DESIGNED TO FAIL — proves bond_interface.devices validator SizeBetween(1, 8) rejects an empty
+# list (size 0 < 1). Run via verify.sh (not plain terraform test). mock_provider => no credentials;
+# validator fires from the real v3.76.0 schema at plan. interface_arm=bond renders the bond arm.
+mock_provider "xcsh" {}
+
+run "reject_bond_devices_empty" {
+  command = plan
+
+  variables {
+    probe_name    = "cov-probe-s3-bond-empty"
+    interface_arm = "bond"
+    bond_devices  = []
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-static-ipv6.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-static-ipv6.tftest.hcl
@@ -1,0 +1,16 @@
+# DESIGNED TO FAIL — proves static_ipv6_address.node_static_ip.ip_address validator CIDRValidator()
+# rejects a malformed IPv6 CIDR. Run via verify.sh (not plain terraform test). mock_provider => no
+# credentials; validator fires from the real v3.76.0 schema at plan. ipv6_arm=static_ipv6_address
+# renders node_static_ip so the ip_address leaf is reachable. The malformed value differs from the
+# S2 static_ip reject ("999.999.0.0/8") so its exact diagnostic is unambiguous.
+mock_provider "xcsh" {}
+
+run "reject_static_ipv6_bad_cidr" {
+  command = plan
+
+  variables {
+    probe_name   = "cov-probe-s3-ipv6-bad"
+    ipv6_arm     = "static_ipv6_address"
+    ipv6_address = "2001:db8::gg/64"
+  }
+}

--- a/coverage/smsv2/validation.tftest.hcl
+++ b/coverage/smsv2/validation.tftest.hcl
@@ -56,3 +56,107 @@ run "accept_valid_bounds" {
     error_message = "vrf_string_arms must render sli_config so a valid IPv4 nameserver/vip plans clean through IPv4Validator."
   }
 }
+
+# S3 positive plan asserts — each interface oneof arm PLANS cleanly through the real provider
+# schema (schema-valid) even where it would 400 live on a single-node `azure` probe. This proves the
+# HCL wiring + provider v3.76.0 schema accept every arm; the live/plan split is in the matrix.
+
+run "plan_address_no_ipv4" {
+  command = plan
+  variables {
+    probe_name  = "cov-probe-s3-no-ipv4"
+    address_arm = "no_ipv4_address"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].no_ipv4_address != null
+    error_message = "address_arm=no_ipv4_address must render the no_ipv4_address member of address_choice."
+  }
+}
+
+run "plan_ipv6_no_ipv6" {
+  command = plan
+  variables {
+    probe_name = "cov-probe-s3-no-ipv6"
+    ipv6_arm   = "no_ipv6_address"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].no_ipv6_address != null
+    error_message = "ipv6_arm=no_ipv6_address must render the no_ipv6_address member of ipv6_address_choice."
+  }
+}
+
+run "plan_ipv6_static" {
+  command = plan
+  variables {
+    probe_name = "cov-probe-s3-static-ipv6"
+    ipv6_arm   = "static_ipv6_address"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].static_ipv6_address.node_static_ip.ip_address == "2001:db8::10/64"
+    error_message = "ipv6_arm=static_ipv6_address must render node_static_ip so a valid IPv6 CIDR plans clean through CIDRValidator."
+  }
+}
+
+run "plan_ipv6_autoconfig" {
+  command = plan
+  variables {
+    probe_name = "cov-probe-s3-ipv6-auto"
+    ipv6_arm   = "ipv6_auto_config"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].ipv6_auto_config.host != null
+    error_message = "ipv6_arm=ipv6_auto_config must render the host autoconfig_choice member."
+  }
+}
+
+run "plan_interface_bond" {
+  command = plan
+  variables {
+    probe_name    = "cov-probe-s3-bond"
+    interface_arm = "bond"
+  }
+  assert {
+    condition     = length(xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].bond_interface.devices) == 2
+    error_message = "interface_arm=bond must render bond_interface with 2 devices (SizeBetween(1, 8) passes)."
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].bond_interface.lacp.rate == 1
+    error_message = "bond_interface.lacp.rate must plan clean through Between(1, 30)."
+  }
+}
+
+run "plan_interface_vlan" {
+  command = plan
+  variables {
+    probe_name    = "cov-probe-s3-vlan-arm"
+    interface_arm = "vlan"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].vlan_interface.vlan_id == 100
+    error_message = "interface_arm=vlan must render vlan_interface on the primary oneof so vlan_id plans clean through Between(1, 4095)."
+  }
+}
+
+run "plan_monitor" {
+  command = plan
+  variables {
+    probe_name  = "cov-probe-s3-monitor"
+    monitor_arm = "monitor"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].monitor != null
+    error_message = "monitor_arm=monitor must render the monitor member of monitoring_choice."
+  }
+}
+
+run "plan_s2s_enabled" {
+  command = plan
+  variables {
+    probe_name    = "cov-probe-s3-s2s-enabled"
+    s2s_iface_arm = "enabled"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.azure.not_managed.node_list[0].interface_list[0].site_to_site_connectivity_interface_enabled != null
+    error_message = "s2s_iface_arm=enabled must render the enabled member of site_to_site_connectivity_interface_choice."
+  }
+}

--- a/coverage/smsv2/variables.tf
+++ b/coverage/smsv2/variables.tf
@@ -79,17 +79,114 @@ variable "vrf_string_arms" {
 
 variable "string_arms" {
   description = <<-EOT
-    When true (default), the probe wires the eth0 ethernet_interface `mac` leaf and renders a
-    `static_ip { ip_address, default_gw }` address block in place of the base `dhcp_client {}`,
-    so the `MACValidator()`, `CIDRValidator()` and `IPValidator()` string validators are reachable
-    at PLAN time (they fire during plan under both mock_provider tests and live plans). Set false
-    only for a live apply if the XC API rejects the mac/static_ip combination on the single-node
-    `azure` not_managed probe: the base eth0 interface reverts to `dhcp_client {}` with no `mac`,
-    which applies live and stays idempotent/import-clean, while mac/ip_address/default_gw remain
-    plan-validated. The node `type` leaf is always wired (its valid default is live-safe).
+    When true (default), the probe wires the eth0 `ethernet_interface.mac` leaf so the
+    `MACValidator()` string validator is reachable at PLAN time (it fires during plan under both
+    mock_provider tests and live plans). Set false only for a live apply if the XC API rejects the
+    `mac` value on the single-node `azure` not_managed probe: the eth0 `ethernet_interface` then
+    renders with no `mac`, which applies live and stays idempotent/import-clean, while `mac` remains
+    plan-validated. Applies only when `interface_arm = "ethernet"` (the `mac` leaf lives on the
+    ethernet arm). The node `type` leaf is always wired (its valid default is live-safe).
+
+    NOTE (S3): the address_choice oneof (`dhcp_client`/`static_ip`/`no_ipv4_address`) is now driven
+    by `var.address_arm`, not this toggle — so exactly one address member ever renders. The
+    `static_ip` leaves (`ip_address`/`default_gw`) are reached at plan whenever `address_arm =
+    "static_ip"` (the default), decoupled from `string_arms`.
   EOT
   type        = bool
   default     = true
+}
+
+# --- S3: interface / addressing oneof selectors --------------------------------------------------
+# Each interface oneof is modeled as an enum selector so exactly ONE member renders and no two
+# siblings of a oneof ever coexist (which would trip the provider's ConflictsWith). Defaults are
+# the live-safe base arm so a bare `terraform apply` stays idempotent and import-clean.
+
+variable "interface_arm" {
+  description = <<-EOT
+    interface_choice oneof member for eth0. `ethernet` (default) is the live-safe base arm and
+    carries the `mac` leaf (via `string_arms`). `bond` and `vlan` 400 on a single-node `azure`
+    not_managed probe (bond needs real member devices; vlan needs a parent device) so they are
+    plan-only — their schema (bond `devices` `SizeBetween(1, 8)`, vlan `vlan_id` `Between(1, 4095)`)
+    is proven at PLAN.
+  EOT
+  type        = string
+  default     = "ethernet"
+  validation {
+    condition     = contains(["ethernet", "bond", "vlan"], var.interface_arm)
+    error_message = "interface_arm must be ethernet | bond | vlan."
+  }
+}
+
+variable "address_arm" {
+  description = <<-EOT
+    address_choice oneof member for eth0. `static_ip` (default) and `dhcp_client` and
+    `no_ipv4_address` are all live-appliable. `static_ip` exposes the `ip_address` `CIDRValidator()`
+    and `default_gw` `IPValidator()` leaves at PLAN; `dhcp_client`/`no_ipv4_address` are empty
+    markers. Exactly one address member renders (supersedes the old `string_arms` address swap).
+  EOT
+  type        = string
+  default     = "static_ip"
+  validation {
+    condition     = contains(["dhcp_client", "static_ip", "no_ipv4_address"], var.address_arm)
+    error_message = "address_arm must be dhcp_client | static_ip | no_ipv4_address."
+  }
+}
+
+variable "ipv6_arm" {
+  description = <<-EOT
+    ipv6_address_choice oneof member for eth0. `no_ipv6_address` (default) is live-appliable.
+    `ipv6_auto_config` (renders the `host {}` autoconfig arm) and `static_ipv6_address` (renders
+    `node_static_ip { ip_address }`, `CIDRValidator()`) 400 on a single-node IPv4 `azure` probe, so
+    they are plan-only — their schema is proven at PLAN.
+  EOT
+  type        = string
+  default     = "no_ipv6_address"
+  validation {
+    condition     = contains(["no_ipv6_address", "ipv6_auto_config", "static_ipv6_address"], var.ipv6_arm)
+    error_message = "ipv6_arm must be no_ipv6_address | ipv6_auto_config | static_ipv6_address."
+  }
+}
+
+variable "monitor_arm" {
+  description = "monitoring_choice oneof member for eth0. Both `monitor` and `monitor_disabled` (default) are empty markers and live-appliable."
+  type        = string
+  default     = "monitor_disabled"
+  validation {
+    condition     = contains(["monitor", "monitor_disabled"], var.monitor_arm)
+    error_message = "monitor_arm must be monitor | monitor_disabled."
+  }
+}
+
+variable "s2s_iface_arm" {
+  description = <<-EOT
+    site_to_site_connectivity_interface_choice oneof member for eth0. Both `disabled` (default) and
+    `enabled` are empty markers and both are live-appliable on the single-node `azure` probe
+    (confirmed apply/idempotent/import-clean).
+  EOT
+  type        = string
+  default     = "disabled"
+  validation {
+    condition     = contains(["disabled", "enabled"], var.s2s_iface_arm)
+    error_message = "s2s_iface_arm must be disabled | enabled."
+  }
+}
+
+variable "ipv6_address" {
+  description = "static_ipv6_address.node_static_ip.ip_address (IPv6 CIDR). Provider validator: `CIDRValidator()` + `LengthBetween(7, 1024)`. Rendered only when ipv6_arm=static_ipv6_address. reject-static-ipv6 pushes a malformed CIDR."
+  type        = string
+  default     = "2001:db8::10/64"
+}
+
+variable "bond_devices" {
+  description = "bond_interface.devices (member ethernet devices). Provider validator: `SizeBetween(1, 8)`. Rendered only when interface_arm=bond. reject-bond-devices pushes an empty list."
+  type        = list(string)
+  default     = ["eth1", "eth2"]
+}
+
+variable "bond_lacp_rate" {
+  description = "bond_interface.lacp.rate (LACP transmit interval, seconds). Provider validator: `Between(1, 30)`. Rendered only when interface_arm=bond."
+  type        = number
+  default     = 1
 }
 
 variable "extended_arms" {

--- a/coverage/smsv2/verify.sh
+++ b/coverage/smsv2/verify.sh
@@ -57,6 +57,9 @@ declare -a expected=(
   'Value "300.1.1.1" is not a valid IPv4 address'
   'Value "2001:db8::1" is not a valid IPv4 address'
   'value must be one of: ["Control" "Worker"], got: "Bogus"'
+  # S3 interface-arm validated leaves
+  "list must contain at least 1 elements and at most 8 elements, got: 0"
+  'Value "2001:db8::gg/64" is not a valid CIDR range'
 )
 for msg in "${expected[@]}"; do
   case "${reject_norm}" in
@@ -67,4 +70,5 @@ done
 
 echo
 echo "PASS: SMSv2 validators accept valid input and reject all four numeric leaves plus the"
-echo "      mac / ip_address(CIDR) / default_gw(IP) / nameserver+vip(IPv4) / node-type string leaves."
+echo "      mac / ip_address(CIDR) / default_gw(IP) / nameserver+vip(IPv4) / node-type string leaves,"
+echo "      and the S3 interface-arm leaves (bond devices SizeBetween(1, 8) / static_ipv6 CIDR)."


### PR DESCRIPTION
## Summary
Exhaustive coverage of all 13 `securemesh_site_v2` interface oneof arms, modeled as enum selectors (one member per oneof — no `ConflictsWith`).

- **Live-verified (9)** apply→0-change→import→destroy on the disposable probe: `ethernet_interface`, `dhcp_client`, `static_ip`, `no_ipv4_address`, `no_ipv6_address`, `monitor`, `monitor_disabled`, s2s-iface `disabled`, s2s-iface `enabled` (the last accepted by the single-node probe despite recon predicting 400 — reclassified live with evidence).
- **Plan-only (4)**, confirmed `[BAD_REQUEST] 400` live on a single-node azure probe → mock/plan coverage: `bond_interface`, `vlan_interface`, `ipv6_auto_config`, `static_ipv6_address`.
- 2 new reject-tests (`bond` empty-devices → `SizeBetween(1,8)`; `static_ipv6` bad prefix → `CIDRValidator`); `verify.sh` = 9 positive asserts + 12 exact reject diagnostics, exits 0.
- `string_arms` reconciled to gate only `mac`; address oneof driven by `address_arm`. Matrix updated (no overclaiming); `is_management`/`is_primary` deferred to api-specs-enriched #1049.

## Verification
verify.sh green; live cycle per applyable arm (only the known #1244 `labels {}` import drift); demo sites untouched; fmt/tflint/shellcheck clean.

Closes #584. Part of epic f5-sales-demo/terraform-provider-xcsh#1207.
