### PR TITLE
S5: SMSv2 perf/os/upgrade/offline/admin arm coverage

### DIFF
--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -35,11 +35,11 @@ Columns:
 | no_network_policy{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: active_network_policies S4 |
 | no_s2s_connectivity_sli{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
 | no_s2s_connectivity_slo{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
-| offline_survivability_mode.no_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: enable S5 |
-| performance_enhancement_mode.perf_mode_l7_enhanced{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: perf_mode_l3_enhanced S5 |
-| re_select.geo_proximity{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: from_site_list S5 |
-| software_settings.os.default_os_version{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: operating_system_version S5 |
-| software_settings.sw.default_sw_version{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: volterra_software_version S5 |
+| offline_survivability_mode.no_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `offline_arm=no_offline_survivability_mode` (default); defaults cycle apply→idempotent→import (labels{} #1244 drift only)→destroy; oneof alt: enable S5 |
+| performance_enhancement_mode.perf_mode_l7_enhanced{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `perf_arm=perf_mode_l7_enhanced` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: perf_mode_l3_enhanced S5 |
+| re_select.geo_proximity{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `re_select_arm=geo_proximity` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: specific_re S5 |
+| software_settings.os.default_os_version{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `os_arm=default_os_version` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: operating_system_version S5 |
+| software_settings.sw.default_sw_version{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `sw_arm=default_sw_version` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: volterra_software_version S5 |
 | node_list[].type (Control/Worker) | ✅ | ✅ | ✅ | ✅ | ✅ | iter-1 live; S2: validator `OneOf("Control", "Worker")` (reject `"Bogus"`); the valid `Worker` arm plans clean and `Control` applied live |
 | interface_list.ethernet_interface{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm (its `mac` leaf → Validated ✅, row above); oneof vs vlan/dedicated S3 |
 | interface_list.network_option.site_local_network{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: SLI/inside S3 |
@@ -81,6 +81,17 @@ Columns:
 | dc_cluster_group_slo{} (ref, s2s_slo_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_slo_arm=dc_cluster_group_slo`; plan-only — ObjectRefType, ref-dependent; plans clean |
 | site_mesh_group_on_slo{site_mesh_group ref} (s2s_slo_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_slo_arm=site_mesh_group_ref`; plan-only — `site_mesh_group` ObjectRefType, ref-dependent; plans clean |
 | segment_vrf.segment_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4 `segment_vrf_arm=inline`; plan-only — needs a Segment object ref the provider cannot yet inject (specs #1053); validator `IPv4Validator()` (reject `"300.2.2.2"`, reject-segment-nameserver) proven at plan |
+<!-- S5: site-mode oneof arms (perf / os / sw / offline / re_select / upgrade / admin; enum selectors; live cycle uses -var extended_arms=false) -->
+| performance_enhancement_mode.perf_mode_l3_enhanced{no_jumbo{}} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S5 `perf_arm=perf_mode_l3_enhanced`; renders the `no_jumbo{}` sub-oneof member; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| software_settings.os.operating_system_version | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5 `os_arm=operating_system_version` (`9.2024.6`); validator `LengthAtMost(20)` (reject 21-char, reject-os-version); create-only leaf — live apply→idempotent→import round-trips 0-change (labels{} #1244 drift only)→destroy |
+| software_settings.sw.volterra_software_version | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5 `sw_arm=volterra_software_version` (`crt-20250613-3382`); validator `LengthAtMost(20)` (reject 21-char, reject-sw-version); create-only leaf — live round-trips 0-change (labels{} #1244 drift only) |
+| offline_survivability_mode.enable_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S5 `offline_arm=enable_offline_survivability_mode`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| upgrade_settings...enable_upgrade_drain{} (kubernetes_upgrade_drain) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5 `upgrade_drain_arm=enable_upgrade_drain`; recon expected 400 (k8s worker-drain on non-k8s node) but the single-node `azure` probe ACCEPTS it — reclassified live; renders drain leaves + `disable_vega_upgrade_mode{}`; apply→idempotent→import (labels{} #1244 drift)→destroy |
+| enable_upgrade_drain.drain_max_unavailable_node_count (1-5000) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5: validator `Between(1, 5000)` (reject 5001, reject-drain-count); applied live via enable_upgrade_drain (default 1) |
+| enable_upgrade_drain.drain_node_timeout (0-900) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5: validator `Between(0, 900)` (reject 901, reject-drain-timeout); applied live via enable_upgrade_drain (default 300) |
+| enable_upgrade_drain.disable_vega_upgrade_mode{} (vega sub-oneof) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S5 `vega_arm=disable_vega_upgrade_mode` (default); empty marker; applied live via enable_upgrade_drain; alt `enable_vega_upgrade_mode` plans clean |
+| admin_user_credentials{ssh_key, admin_password clear_secret_info} | ✅ | ✅ | ⬜ | ➖ | ➖ | S5 `admin_creds=true`; plan-only — `[BAD_REQUEST]` 400 live on the single-node `azure` probe (recon expected live, reclassified); `ssh_key` `LengthAtMost(8192)` + `secret_encoding_type` `OneOf` reject-proven at plan; dummy `string:///<base64>` secret (no real secret committed) |
+| re_select.specific_re{primary_re, backup_re} | ✅ | ✅ | ⬜ | ➖ | ➖ | S5 `re_select_arm=specific_re`; plan-only — `[BAD_REQUEST] Invalid request parameters (status: 400)` live (primary_re must name a real RE geography); `primary_re` `LengthBetween(1, 64)` (reject 65-char, reject-primary-re) proven at plan |
 
 **S1 notes (numeric-leaf input validation):**
 
@@ -178,6 +189,39 @@ Columns:
 - **Stale `log_receiver` avoided** — logs are driven via `log_receiver_with_net`, never the stale
   top-level `log_receiver` field (provider #1256).
 
+**S5 notes (site-mode oneof arms, provider v3.76.0):**
+
+- **Enum selectors supersede the base literals** — each site-mode oneof is driven by an enum var
+  (`perf_arm`, `os_arm`/`os_version`, `sw_arm`/`sw_version`, `offline_arm`, `re_select_arm`,
+  `upgrade_drain_arm`/`drain_max_unavailable`/`drain_node_timeout`/`vega_arm`, `admin_creds`) that
+  replaces the pre-S5 hardcoded `performance_enhancement_mode`/`software_settings`/
+  `offline_survivability_mode`/`re_select` literals, and adds gated `upgrade_settings` +
+  `admin_user_credentials` blocks (both unset in the base). Every default renders the identical base
+  member, so a bare `terraform plan` (all defaults) shows NO diff — verified live: defaults
+  apply→0-change re-plan→import→destroy round-trips with only the known `labels {}` #1244 drift.
+- **S5a live-appliable** (HTTP 200, idempotent, import-clean modulo `labels {}` #1244):
+  `perf_mode_l3_enhanced{no_jumbo{}}`, `operating_system_version` (`9.2024.6`),
+  `volterra_software_version` (`crt-20250613-3382`), `enable_offline_survivability_mode`, and
+  `upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain` (drain count/timeout + vega). Each
+  ran apply→0-change re-plan→import→destroy on the single-node probe.
+- **`operating_system_version`/`volterra_software_version` are create-only** — the API forbids
+  changing them after create, but the pinned values still import/re-plan 0-change (verified).
+- **`enable_upgrade_drain` reclassified live** — recon expected a 400 (k8s worker-node drain on a
+  non-k8s single node), but the single-node `azure` probe ACCEPTS it and round-trips clean (same
+  surprise as S3 `s2s_..._enabled`). `disable_upgrade_drain` and `enable_vega_upgrade_mode` plan clean.
+- **S5b plan-only (single-node 400)** — `admin_user_credentials` and `re_select.specific_re` each
+  return `[BAD_REQUEST] Invalid request parameters (status: 400)` on the single-node probe (both were
+  expected live in recon; reclassified after verification). `admin_user_credentials` needs the node
+  local services / a multi-node CE; `re_select.specific_re.primary_re` must name a real RE geography
+  (a dummy name 400s). Their validators are reject-proven at plan.
+- **`admin_password` dummy secret** — the `admin_password` SecretType uses `clear_secret_info { url =
+  "string:///<base64>" }` (the only dependency-free backend; blindfold/vault/wingman need external
+  providers → 400) with a base64 of a throwaway placeholder. NO real secret is committed. The
+  `secret_encoding_type` is `EncodingBase64` (`OneOf(EncodingNone, EncodingBase64)`).
+- **Provider enrichment gap #1258** — filed for the `enable_upgrade_drain.drain_node_timeout`
+  required-ness (the arm inventory marks it required); the harness always supplies it (default 300).
+  Not blocking — S5 is pure-mcn coverage (no provider/specs change).
+
 <!--
 Slice roadmap:
 - S0: probe workspace + this matrix (done).
@@ -185,5 +229,5 @@ Slice roadmap:
 - S2: string-leaf input validation (mac/CIDR/IP/IPv4/node-type) — DONE (verify.sh; provider v3.75.1).
 - S3: interface/addressing oneof arms (interface_choice ethernet/bond/vlan; address_choice dhcp_client/static_ip/no_ipv4_address; ipv6_address_choice; monitoring_choice; s2s_iface_choice) — DONE (verify.sh + live matrix; provider v3.76.0).
 - S4: networking/services top-level oneof arms (blocked_services, dns/ntp, enterprise proxy, proxy bypass, url categorization, management network, load_balancing vip_vrrp_mode, s2s slo/sli, forward proxy, network policy, log streaming/receiver, site mesh group, segment_vrf) — DONE (verify.sh + live matrix; provider v3.76.0).
-- S5: site-mode oneof arms (offline survivability, performance mode, re_select, software_settings explicit versions).
+- S5: site-mode oneof arms (offline survivability, performance mode, re_select, software_settings versions, kubernetes_upgrade_drain, admin_user_credentials) — DONE (verify.sh + live matrix; provider v3.76.0). S5a live: perf_mode_l3_enhanced, os/sw versions (create-only), offline enable, enable_upgrade_drain (reclassified). S5b plan-only (400): admin_user_credentials, specific_re.
 -->

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -116,6 +116,48 @@ terraform plan                  -var probe_name=cov-probe-s4-x -var extended_arm
 terraform destroy -auto-approve -var probe_name=cov-probe-s4-x -var extended_arms=false -var vip_vrrp_mode=VIP_VRRP_ENABLE
 ```
 
+## S5 site-mode oneof arms
+
+Every site-mode oneof (performance mode, OS/SW version, offline survivability, RE selection, upgrade
+drain, admin credentials) is modeled as an **enum selector** (`perf_arm`, `os_arm`/`os_version`,
+`sw_arm`/`sw_version`, `offline_arm`, `re_select_arm`, `upgrade_drain_arm`, `vega_arm`, `admin_creds`)
+that supersedes the pre-S5 hardcoded literal, plus gated `upgrade_settings` + `admin_user_credentials`
+blocks (both unset in the base). Every default renders the identical base member, so a bare
+`terraform plan` (all defaults) is unchanged versus the pre-S5 base (verified: defaults
+apply→0-change→import→destroy round-trips with only the `labels {}` #1244 drift).
+
+**Live-appliable (S5a)** — apply→idempotent→import (labels{} #1244 drift only)→destroy on the
+single-node `azure` probe: `perf_mode_l3_enhanced{no_jumbo{}}`, `operating_system_version`
+(`9.2024.6`), `volterra_software_version` (`crt-20250613-3382`; both version leaves are **create-only**
+yet round-trip 0-change), `enable_offline_survivability_mode`, and
+`upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain` (drain count/timeout + vega
+sub-oneof). `enable_upgrade_drain` was expected plan-only (k8s worker drain on a non-k8s node) but the
+single-node probe accepts it — reclassified live after verification.
+
+**Plan-only (S5b)** — return `[BAD_REQUEST] Invalid request parameters (status: 400)` live on the
+single-node probe, so proven at plan via `validation.tftest.hcl` positive asserts:
+
+- `admin_user_credentials` — needs node local services / a multi-node CE. Its `admin_password`
+  SecretType uses `clear_secret_info { url = "string:///<base64>" }` — the only dependency-free
+  backend (blindfold/vault/wingman need external providers → 400) — with a base64 of a **dummy
+  throwaway placeholder**; NO real secret is committed. `ssh_key` `LengthAtMost(8192)` +
+  `secret_encoding_type` `OneOf(EncodingNone, EncodingBase64)` are reject-proven at plan.
+- `re_select.specific_re` — `primary_re` must name a real RE geography (a dummy name 400s);
+  `primary_re` `LengthBetween(1, 64)` reject-proven at plan.
+
+Live cycle per S5a arm (fresh `probe_name`, `extended_arms=false`):
+
+```bash
+cd coverage/smsv2
+set -a; source /tmp/mcn-xcsh.env; set +a
+terraform apply   -auto-approve -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version
+terraform plan                  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version  # No changes
+terraform state rm xcsh_securemesh_site_v2.probe
+terraform import  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version xcsh_securemesh_site_v2.probe system/cov-probe-s5-x
+terraform plan                  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version  # 0-change modulo labels {}
+terraform destroy -auto-approve -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version
+```
+
 ## S1 numeric-validation gate
 
 ```bash

--- a/coverage/smsv2/main.tf
+++ b/coverage/smsv2/main.tf
@@ -401,24 +401,127 @@ resource "xcsh_securemesh_site_v2" "probe" {
     }
   }
 
+  # S5 offline_survivability_mode oneof {no_offline_survivability_mode | enable_offline_survivability_mode},
+  # keyed on var.offline_arm. no_offline_survivability_mode (default) is the base arm; both are empty
+  # markers and both are S5a live.
   offline_survivability_mode {
-    no_offline_survivability_mode {}
+    dynamic "no_offline_survivability_mode" {
+      for_each = var.offline_arm == "no_offline_survivability_mode" ? [1] : []
+      content {}
+    }
+
+    dynamic "enable_offline_survivability_mode" {
+      for_each = var.offline_arm == "enable_offline_survivability_mode" ? [1] : []
+      content {}
+    }
   }
 
+  # S5 performance_enhancement_mode oneof {perf_mode_l7_enhanced | perf_mode_l3_enhanced}, keyed on
+  # var.perf_arm. perf_mode_l7_enhanced (default) is the base empty arm; perf_mode_l3_enhanced renders
+  # its no_jumbo{} sub-oneof member (jumbo|no_jumbo). Both are S5a live.
   performance_enhancement_mode {
-    perf_mode_l7_enhanced {}
+    dynamic "perf_mode_l7_enhanced" {
+      for_each = var.perf_arm == "perf_mode_l7_enhanced" ? [1] : []
+      content {}
+    }
+
+    dynamic "perf_mode_l3_enhanced" {
+      for_each = var.perf_arm == "perf_mode_l3_enhanced" ? [1] : []
+      content {
+        no_jumbo {}
+      }
+    }
   }
 
+  # S5 re_select oneof {geo_proximity | specific_re}, keyed on var.re_select_arm. geo_proximity
+  # (default) is the base empty arm and S5a live; specific_re renders primary_re (LengthBetween(1, 64))
+  # + backup_re and is plan-only S5b (primary_re must name a real RE geography).
   re_select {
-    geo_proximity {}
+    dynamic "geo_proximity" {
+      for_each = var.re_select_arm == "geo_proximity" ? [1] : []
+      content {}
+    }
+
+    dynamic "specific_re" {
+      for_each = var.re_select_arm == "specific_re" ? [1] : []
+      content {
+        primary_re = var.primary_re
+        backup_re  = var.backup_re
+      }
+    }
   }
 
+  # S5 software_settings.os / .sw oneofs. Each SingleNestedBlock carries either its default_*_version{}
+  # empty marker (default arm) OR the pinned version string attribute (operating_system_version /
+  # volterra_software_version, LengthAtMost(20)) — never both. The version leaves are create-only. All
+  # arms are S5a live; the pinned-version round-trip must still import/re-plan 0-change.
   software_settings {
     os {
-      default_os_version {}
+      dynamic "default_os_version" {
+        for_each = var.os_arm == "default_os_version" ? [1] : []
+        content {}
+      }
+      operating_system_version = var.os_arm == "operating_system_version" ? var.os_version : null
     }
     sw {
-      default_sw_version {}
+      dynamic "default_sw_version" {
+        for_each = var.sw_arm == "default_sw_version" ? [1] : []
+        content {}
+      }
+      volterra_software_version = var.sw_arm == "volterra_software_version" ? var.sw_version : null
+    }
+  }
+
+  # S5 upgrade_settings.kubernetes_upgrade_drain oneof {disable_upgrade_drain | enable_upgrade_drain},
+  # UNSET in the pre-S5 base — the whole block renders only when var.upgrade_drain_arm != "unset" so a
+  # bare plan omits it. enable_upgrade_drain exposes drain_max_unavailable_node_count (Between(1, 5000))
+  # + drain_node_timeout (Between(0, 900)) + a vega sub-oneof. Plan-only S5b: worker-node drain 400s on
+  # a non-k8s single-node probe.
+  dynamic "upgrade_settings" {
+    for_each = var.upgrade_drain_arm != "unset" ? [1] : []
+    content {
+      kubernetes_upgrade_drain {
+        dynamic "disable_upgrade_drain" {
+          for_each = var.upgrade_drain_arm == "disable_upgrade_drain" ? [1] : []
+          content {}
+        }
+
+        dynamic "enable_upgrade_drain" {
+          for_each = var.upgrade_drain_arm == "enable_upgrade_drain" ? [1] : []
+          content {
+            drain_max_unavailable_node_count = var.drain_max_unavailable
+            drain_node_timeout               = var.drain_node_timeout
+
+            dynamic "disable_vega_upgrade_mode" {
+              for_each = var.vega_arm == "disable_vega_upgrade_mode" ? [1] : []
+              content {}
+            }
+
+            dynamic "enable_vega_upgrade_mode" {
+              for_each = var.vega_arm == "enable_vega_upgrade_mode" ? [1] : []
+              content {}
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # S5 admin_user_credentials (UNSET in the pre-S5 base) — rendered only when var.admin_creds is true so
+  # a bare plan omits it. The admin_password SecretType uses clear_secret_info (the only dependency-free
+  # backend; blindfold/vault/wingman need external providers) with a DUMMY base64 password — never a
+  # real secret. ssh_key is LengthAtMost(8192); secret_encoding_type is OneOf(EncodingNone,
+  # EncodingBase64). Attempted S5a live.
+  dynamic "admin_user_credentials" {
+    for_each = var.admin_creds ? [1] : []
+    content {
+      ssh_key = var.ssh_key
+      admin_password {
+        clear_secret_info {
+          url = "string:///${base64encode(var.admin_password_b64_source)}"
+        }
+        secret_encoding_type = var.secret_encoding_type
+      }
     }
   }
 

--- a/coverage/smsv2/reject-tests/reject-drain-count.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-drain-count.tftest.hcl
@@ -1,0 +1,17 @@
+# DESIGNED TO FAIL — proves upgrade_settings...enable_upgrade_drain.drain_max_unavailable_node_count
+# validator Between(1, 5000) rejects 5001 (> max). Run via verify.sh (not plain terraform test).
+# mock_provider => no credentials; validator fires from the real v3.76.0 schema at plan.
+# upgrade_drain_arm=enable_upgrade_drain renders the drain leaves; drain_node_timeout stays valid so
+# only drain_max_unavailable_node_count fails.
+mock_provider "xcsh" {}
+
+run "reject_drain_count_over_max" {
+  command = plan
+
+  variables {
+    probe_name            = "cov-probe-s5-drain-count"
+    upgrade_drain_arm     = "enable_upgrade_drain"
+    drain_max_unavailable = 5001
+    drain_node_timeout    = 300
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-drain-timeout.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-drain-timeout.tftest.hcl
@@ -1,0 +1,17 @@
+# DESIGNED TO FAIL — proves upgrade_settings...enable_upgrade_drain.drain_node_timeout validator
+# Between(0, 900) rejects 901 (> max). Run via verify.sh (not plain terraform test). mock_provider =>
+# no credentials; validator fires from the real v3.76.0 schema at plan. upgrade_drain_arm=
+# enable_upgrade_drain renders the drain leaves; drain_max_unavailable stays valid so only
+# drain_node_timeout fails.
+mock_provider "xcsh" {}
+
+run "reject_drain_timeout_over_max" {
+  command = plan
+
+  variables {
+    probe_name            = "cov-probe-s5-drain-timeout"
+    upgrade_drain_arm     = "enable_upgrade_drain"
+    drain_max_unavailable = 1
+    drain_node_timeout    = 901
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-os-version.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-os-version.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves software_settings.os.operating_system_version validator
+# LengthAtMost(20) rejects a 21-char string. Run via verify.sh (not plain terraform test).
+# mock_provider => no credentials; validator fires from the real v3.76.0 schema at plan.
+# os_arm=operating_system_version renders the pinned-version leaf so it is reachable.
+mock_provider "xcsh" {}
+
+run "reject_os_version_too_long" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s5-os-bad"
+    os_arm     = "operating_system_version"
+    os_version = "123456789012345678901" # 21 chars > LengthAtMost(20)
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-primary-re.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-primary-re.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves re_select.specific_re.primary_re validator LengthBetween(1, 64) rejects a
+# 65-char string (> max). Run via verify.sh (not plain terraform test). mock_provider => no
+# credentials; validator fires from the real v3.76.0 schema at plan. re_select_arm=specific_re renders
+# the specific_re leaves so primary_re is reachable.
+mock_provider "xcsh" {}
+
+run "reject_primary_re_too_long" {
+  command = plan
+
+  variables {
+    probe_name    = "cov-probe-s5-primary-re-bad"
+    re_select_arm = "specific_re"
+    primary_re    = "12345678901234567890123456789012345678901234567890123456789012345" # 65 chars > LengthBetween(1, 64)
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-secret-encoding.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-secret-encoding.tftest.hcl
@@ -1,0 +1,16 @@
+# DESIGNED TO FAIL — proves admin_user_credentials.admin_password.secret_encoding_type validator
+# OneOf(EncodingNone, EncodingBase64) rejects an out-of-enum value. Run via verify.sh (not plain
+# terraform test). mock_provider => no credentials; validator fires from the real v3.76.0 schema at
+# plan. admin_creds=true renders the block; secret_encoding_type has no terraform validation so the
+# provider OneOf validator fires.
+mock_provider "xcsh" {}
+
+run "reject_secret_encoding_out_of_enum" {
+  command = plan
+
+  variables {
+    probe_name           = "cov-probe-s5-encoding-bad"
+    admin_creds          = true
+    secret_encoding_type = "BOGUS"
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-ssh-key.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-ssh-key.tftest.hcl
@@ -1,0 +1,16 @@
+# DESIGNED TO FAIL — proves admin_user_credentials.ssh_key validator LengthAtMost(8192) rejects a
+# >8192-char string. Run via verify.sh (not plain terraform test). mock_provider => no credentials;
+# validator fires from the real v3.76.0 schema at plan. admin_creds=true renders the block; the
+# 8200-char key is generated in-HCL (join+range over 10-char chunks; `range` caps at 1024 elements) so
+# no oversized literal is committed.
+mock_provider "xcsh" {}
+
+run "reject_ssh_key_too_long" {
+  command = plan
+
+  variables {
+    probe_name  = "cov-probe-s5-ssh-key-bad"
+    admin_creds = true
+    ssh_key     = join("", [for _ in range(820) : "0123456789"]) # 8200 chars > LengthAtMost(8192)
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-sw-version.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-sw-version.tftest.hcl
@@ -1,0 +1,15 @@
+# DESIGNED TO FAIL — proves software_settings.sw.volterra_software_version validator
+# LengthAtMost(20) rejects a 21-char string. Run via verify.sh (not plain terraform test).
+# mock_provider => no credentials; validator fires from the real v3.76.0 schema at plan.
+# sw_arm=volterra_software_version renders the pinned-version leaf so it is reachable.
+mock_provider "xcsh" {}
+
+run "reject_sw_version_too_long" {
+  command = plan
+
+  variables {
+    probe_name = "cov-probe-s5-sw-bad"
+    sw_arm     = "volterra_software_version"
+    sw_version = "123456789012345678901" # 21 chars > LengthAtMost(20)
+  }
+}

--- a/coverage/smsv2/validation.tftest.hcl
+++ b/coverage/smsv2/validation.tftest.hcl
@@ -366,3 +366,104 @@ run "plan_segment_vrf" {
     error_message = "segment_vrf_arm=inline must render segment_config.nameserver plan-clean through IPv4Validator (plan-only; specs #1053)."
   }
 }
+
+# S5 positive plan asserts — each site-mode oneof alternative arm PLANS cleanly through the real
+# provider v3.76.0 schema (schema-valid) whether it is live (S5a) or single-node-400 (S5b). This proves
+# the HCL wiring + schema accept every arm; the live/plan split is recorded in the matrix.
+
+run "plan_perf_l3_enhanced" {
+  command = plan
+  variables {
+    probe_name = "cov-probe-s5-perf-l3"
+    perf_arm   = "perf_mode_l3_enhanced"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo != null
+    error_message = "perf_arm=perf_mode_l3_enhanced must render the no_jumbo sub-oneof member of perf_mode_l3_enhanced."
+  }
+}
+
+run "plan_os_sw_pinned" {
+  command = plan
+  variables {
+    probe_name = "cov-probe-s5-os-sw"
+    os_arm     = "operating_system_version"
+    sw_arm     = "volterra_software_version"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.software_settings.os.operating_system_version == "9.2024.6"
+    error_message = "os_arm=operating_system_version must render the pinned OS version plan-clean through LengthAtMost(20)."
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.software_settings.sw.volterra_software_version == "crt-20250613-3382"
+    error_message = "sw_arm=volterra_software_version must render the pinned SW version plan-clean through LengthAtMost(20)."
+  }
+}
+
+run "plan_offline_enable" {
+  command = plan
+  variables {
+    probe_name  = "cov-probe-s5-offline"
+    offline_arm = "enable_offline_survivability_mode"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.offline_survivability_mode.enable_offline_survivability_mode != null
+    error_message = "offline_arm=enable_offline_survivability_mode must render the enable member of offline_survivability_mode."
+  }
+}
+
+run "plan_specific_re" {
+  command = plan
+  variables {
+    probe_name    = "cov-probe-s5-specific-re"
+    re_select_arm = "specific_re"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.re_select.specific_re.primary_re == "cov-primary-re"
+    error_message = "re_select_arm=specific_re must render primary_re plan-clean through LengthBetween(1, 64) (plan-only S5b)."
+  }
+}
+
+run "plan_upgrade_drain_enable" {
+  command = plan
+  variables {
+    probe_name        = "cov-probe-s5-drain"
+    upgrade_drain_arm = "enable_upgrade_drain"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain.drain_node_timeout == 300
+    error_message = "upgrade_drain_arm=enable_upgrade_drain must render drain_node_timeout plan-clean through Between(0, 900) (plan-only S5b)."
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain.disable_vega_upgrade_mode != null
+    error_message = "vega_arm default must render the disable_vega_upgrade_mode sub-oneof member."
+  }
+}
+
+run "plan_upgrade_drain_disable" {
+  command = plan
+  variables {
+    probe_name        = "cov-probe-s5-drain-disable"
+    upgrade_drain_arm = "disable_upgrade_drain"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.upgrade_settings.kubernetes_upgrade_drain.disable_upgrade_drain != null
+    error_message = "upgrade_drain_arm=disable_upgrade_drain must render the disable_upgrade_drain member of kubernetes_upgrade_drain."
+  }
+}
+
+run "plan_admin_user_credentials" {
+  command = plan
+  variables {
+    probe_name  = "cov-probe-s5-admin"
+    admin_creds = true
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.admin_user_credentials.admin_password.secret_encoding_type == "EncodingBase64"
+    error_message = "admin_creds=true must render admin_password.secret_encoding_type plan-clean through OneOf(EncodingNone, EncodingBase64)."
+  }
+  assert {
+    condition     = startswith(xcsh_securemesh_site_v2.probe.admin_user_credentials.admin_password.clear_secret_info.url, "string:///")
+    error_message = "admin_password.clear_secret_info.url must be a string:/// dummy-secret URL (dependency-free backend)."
+  }
+}

--- a/coverage/smsv2/variables.tf
+++ b/coverage/smsv2/variables.tf
@@ -476,3 +476,169 @@ variable "ref_namespace" {
   type        = string
   default     = "system"
 }
+
+# --- S5: site-mode oneof selectors (perf / os / sw / offline / re_select / upgrade / admin) --------
+# Each site-mode oneof is modeled as an enum selector superseding the pre-S5 base literal so exactly
+# ONE member of each oneof renders. Every default is the arm the base probe already applied, so a bare
+# `terraform plan` (all defaults) shows NO diff versus the pre-S5 base (defaults-supersession
+# invariant). S5a arms apply live on the single-node `azure` probe; S5b arms are plan-only.
+
+variable "perf_arm" {
+  description = <<-EOT
+    performance_enhancement_mode oneof member. `perf_mode_l7_enhanced` (default, base, empty) is S5a
+    live. `perf_mode_l3_enhanced` renders its `no_jumbo{}` sub-oneof member (S5a live).
+  EOT
+  type        = string
+  default     = "perf_mode_l7_enhanced"
+  validation {
+    condition     = contains(["perf_mode_l7_enhanced", "perf_mode_l3_enhanced"], var.perf_arm)
+    error_message = "perf_arm must be perf_mode_l7_enhanced | perf_mode_l3_enhanced."
+  }
+}
+
+variable "os_arm" {
+  description = <<-EOT
+    software_settings.os oneof member. `default_os_version` (default, base, empty) is S5a live.
+    `operating_system_version` renders the pinned OS-version string leaf (S5a live; create-only).
+  EOT
+  type        = string
+  default     = "default_os_version"
+  validation {
+    condition     = contains(["default_os_version", "operating_system_version"], var.os_arm)
+    error_message = "os_arm must be default_os_version | operating_system_version."
+  }
+}
+
+variable "os_version" {
+  description = "software_settings.os.operating_system_version. Provider validator: `LengthAtMost(20)`. Create-only. reject-os-version pushes a 21-char string. Rendered only when os_arm=operating_system_version."
+  type        = string
+  default     = "9.2024.6"
+}
+
+variable "sw_arm" {
+  description = <<-EOT
+    software_settings.sw oneof member. `default_sw_version` (default, base, empty) is S5a live.
+    `volterra_software_version` renders the pinned SW-version string leaf (S5a live; create-only).
+  EOT
+  type        = string
+  default     = "default_sw_version"
+  validation {
+    condition     = contains(["default_sw_version", "volterra_software_version"], var.sw_arm)
+    error_message = "sw_arm must be default_sw_version | volterra_software_version."
+  }
+}
+
+variable "sw_version" {
+  description = "software_settings.sw.volterra_software_version. Provider validator: `LengthAtMost(20)`. Create-only. Default is the live-proven version (iter-1). reject-sw-version pushes a 21-char string. Rendered only when sw_arm=volterra_software_version."
+  type        = string
+  default     = "crt-20250613-3382"
+}
+
+variable "offline_arm" {
+  description = <<-EOT
+    offline_survivability_mode oneof member. `no_offline_survivability_mode` (default, base, empty) is
+    S5a live. `enable_offline_survivability_mode` (empty marker) is S5a live.
+  EOT
+  type        = string
+  default     = "no_offline_survivability_mode"
+  validation {
+    condition     = contains(["no_offline_survivability_mode", "enable_offline_survivability_mode"], var.offline_arm)
+    error_message = "offline_arm must be no_offline_survivability_mode | enable_offline_survivability_mode."
+  }
+}
+
+variable "re_select_arm" {
+  description = <<-EOT
+    re_select oneof member. `geo_proximity` (default, base, empty) is S5a live. `specific_re` renders
+    `primary_re`/`backup_re` (plan-only S5b — `primary_re` must name a real RE geography).
+  EOT
+  type        = string
+  default     = "geo_proximity"
+  validation {
+    condition     = contains(["geo_proximity", "specific_re"], var.re_select_arm)
+    error_message = "re_select_arm must be geo_proximity | specific_re."
+  }
+}
+
+variable "primary_re" {
+  description = "re_select.specific_re.primary_re (Primary RE Geography). Provider validator: `LengthBetween(1, 64)`. reject-primary-re pushes a 65-char string. Rendered only when re_select_arm=specific_re."
+  type        = string
+  default     = "cov-primary-re"
+}
+
+variable "backup_re" {
+  description = "re_select.specific_re.backup_re (Backup RE Geography; no validator). Rendered only when re_select_arm=specific_re."
+  type        = string
+  default     = "cov-backup-re"
+}
+
+variable "upgrade_drain_arm" {
+  description = <<-EOT
+    upgrade_settings.kubernetes_upgrade_drain oneof selector. `unset` (default) omits the entire
+    `upgrade_settings` block (pre-S5 base never set it). `disable_upgrade_drain` (empty marker) and
+    `enable_upgrade_drain` (renders the drain leaves + vega sub-oneof) are plan-only S5b — worker-node
+    drain 400s on a non-k8s single-node probe.
+  EOT
+  type        = string
+  default     = "unset"
+  validation {
+    condition     = contains(["unset", "disable_upgrade_drain", "enable_upgrade_drain"], var.upgrade_drain_arm)
+    error_message = "upgrade_drain_arm must be unset | disable_upgrade_drain | enable_upgrade_drain."
+  }
+}
+
+variable "drain_max_unavailable" {
+  description = "enable_upgrade_drain.drain_max_unavailable_node_count (node batch size). Provider validator: `Between(1, 5000)`. reject-drain-count pushes 5001. Rendered only when upgrade_drain_arm=enable_upgrade_drain."
+  type        = number
+  default     = 1
+}
+
+variable "drain_node_timeout" {
+  description = "enable_upgrade_drain.drain_node_timeout (seconds). Provider validator: `Between(0, 900)`. reject-drain-timeout pushes 901. Rendered only when upgrade_drain_arm=enable_upgrade_drain."
+  type        = number
+  default     = 300
+}
+
+variable "vega_arm" {
+  description = <<-EOT
+    enable_upgrade_drain vega sub-oneof member. `disable_vega_upgrade_mode` (default, empty marker) |
+    `enable_vega_upgrade_mode` (empty marker). Rendered only when upgrade_drain_arm=enable_upgrade_drain.
+  EOT
+  type        = string
+  default     = "disable_vega_upgrade_mode"
+  validation {
+    condition     = contains(["disable_vega_upgrade_mode", "enable_vega_upgrade_mode"], var.vega_arm)
+    error_message = "vega_arm must be disable_vega_upgrade_mode | enable_vega_upgrade_mode."
+  }
+}
+
+variable "admin_creds" {
+  description = <<-EOT
+    When true, renders the `admin_user_credentials` block (unset in the pre-S5 base) with the `ssh_key`
+    leaf + an `admin_password` SecretType backed by `clear_secret_info`. Attempted S5a live. Default
+    false so a bare plan omits the block (defaults-supersession invariant).
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "ssh_key" {
+  description = "admin_user_credentials.ssh_key (public SSH key). Provider validator: `LengthAtMost(8192)`. reject-ssh-key pushes a >8192-char string. Rendered only when admin_creds=true. Dummy public key — never a real key."
+  type        = string
+  default     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDummyCoveragePublicKeyNotARealKey000000000000 cov-probe@example.com"
+}
+
+variable "admin_password_b64_source" {
+  description = <<-EOT
+    Cleartext DUMMY password whose base64 encoding feeds admin_password.clear_secret_info.url as
+    `string:///<base64>`. NEVER a real secret — a throwaway placeholder committed only for coverage.
+  EOT
+  type        = string
+  default     = "dummy-not-a-real-secret"
+}
+
+variable "secret_encoding_type" {
+  description = "admin_user_credentials.admin_password.secret_encoding_type. Provider validator: `OneOf(EncodingNone, EncodingBase64)`. reject-secret-encoding pushes \"BOGUS\". No terraform validation so the provider OneOf fires at plan."
+  type        = string
+  default     = "EncodingBase64"
+}

--- a/coverage/smsv2/verify.sh
+++ b/coverage/smsv2/verify.sh
@@ -65,6 +65,16 @@ declare -a expected=(
   'value must be one of: ["VIRTUAL_NETWORK_SITE_LOCAL"'
   'Value "999.1.1.1" is not a valid IPv4 address'
   'Value "300.2.2.2" is not a valid IPv4 address'
+  # S5 site-mode validated leaves (os/sw LengthAtMost(20), drain Between, primary_re LengthBetween,
+  # ssh_key LengthAtMost(8192), secret_encoding_type OneOf). The two LengthAtMost(20) messages are
+  # identical text, so each is qualified by its attribute path to prove BOTH leaves independently.
+  "software_settings.os.operating_system_version string length must be at most 20, got: 21"
+  "software_settings.sw.volterra_software_version string length must be at most 20, got: 21"
+  "must be between 1 and 5000, got: 5001"
+  "must be between 0 and 900, got: 901"
+  "re_select.specific_re.primary_re string length must be between 1 and 64, got: 65"
+  "admin_user_credentials.ssh_key string length must be at most 8192, got: 8200"
+  'value must be one of: ["EncodingNone" "EncodingBase64"], got: "BOGUS"'
 )
 for msg in "${expected[@]}"; do
   case "${reject_norm}" in
@@ -77,5 +87,7 @@ echo
 echo "PASS: SMSv2 validators accept valid input and reject all four numeric leaves plus the"
 echo "      mac / ip_address(CIDR) / default_gw(IP) / nameserver+vip(IPv4) / node-type string leaves,"
 echo "      the S3 interface-arm leaves (bond devices SizeBetween(1, 8) / static_ipv6 CIDR),"
-echo "      and the S4 networking/services leaves (vip_vrrp_mode OneOf / blocked_services network_type"
-echo "      OneOf / custom_proxy proxy_ip_address IPv4 / segment_vrf nameserver IPv4)."
+echo "      the S4 networking/services leaves (vip_vrrp_mode OneOf / blocked_services network_type"
+echo "      OneOf / custom_proxy proxy_ip_address IPv4 / segment_vrf nameserver IPv4), and the S5"
+echo "      site-mode leaves (os/sw version LengthAtMost(20) / drain count+timeout Between / specific_re"
+echo "      primary_re LengthBetween(1, 64) / ssh_key LengthAtMost(8192) / secret_encoding_type OneOf)."


### PR DESCRIPTION
## Summary
Coverage of the SMSv2 perf/os/upgrade/offline/re_select oneofs' alternative arms plus `admin_user_credentials`, via enum selectors (defaults-no-diff invariant).

- **Live-verified (S5a)**: `operating_system_version` + `volterra_software_version` pinned (create-only, import 0-change), `perf_mode_l3_enhanced{no_jumbo{}}`, `enable_offline_survivability_mode{}`, and `enable_upgrade_drain` (accepted live on the probe — reclassified from plan-only).
- **Plan-only (S5b)**: `admin_user_credentials` (400 on single-node; validators reject-proven at plan; dependency-free `clear_secret_info{url="string:///<base64>"}` with a DUMMY password — no real secret), `re_select.specific_re` (needs a real RE geography).
- 7 new reject-tests (os/sw version LengthAtMost(20), drain count Between(1,5000), drain timeout Between(0,900), primary_re LengthBetween(1,64), ssh_key LengthAtMost(8192), secret_encoding_type OneOf); `verify.sh` exits 0.

## Verification
Defaults plan = No changes; S5a live cycle clean (only #1244 `labels {}` drift); demo sites untouched; no real secret/private key; full lint reproduced (fmt/tflint/shellcheck/codespell/textlint; markdownlint MD013 — longest line 389). Provider gap #1258 (`drain_node_timeout` required) noted.

Closes #589. Part of epic f5-sales-demo/terraform-provider-xcsh#1207.
