### PR TITLE
S7: retire the labels ignore_changes workaround (xcsh >= 3.77.5)

### DIFF
--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -235,6 +235,12 @@ Columns:
   (a) `cov-probe-s7d1-01` defaults → apply → plan "No changes" → `state rm` → `import system/...` → plan
   **0 changes**, with no `ignore_changes` anywhere; (b) `cov-probe-s7d1-02` with `labels = {}` in config →
   apply → plan **"No changes"**. Both probes destroyed; the live demo sites were never touched.
+- **Scope of the Import-clean flips.** The S7 import proof was re-run live on the base probe only. Every
+  other arm's Import-clean cell is now `✅` because the sole caveat it carried was this one shared marker,
+  and #1244's fix is resource-wide rather than arm-specific: regeneration guards **39 of 39** nested
+  `labels` closures in `securemesh_site_v2_resource.go`. Arms whose S3/S4/S5 cycle already recorded a live
+  `import (0-change)` are unchanged in meaning; the flip only removes the "modulo `labels {}`" caveat. No
+  arm was re-applied live in S7 to re-observe its own import.
 
 <!--
 Slice roadmap:

--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -14,13 +14,13 @@ Columns:
 | Branch / leaf | Structural | Validated | Applied | Idempotent | Import-clean | Notes |
 |---|---|---|---|---|---|---|
 | azure.not_managed.node_list[].interface_list[] | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1 (live N=3) |
-| interface_list.mtu (max 16384) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `AtMost(16384)` (reject 20000); base probe live-applied+idempotent; leaf does not drift on import but the object import carries the labels{} #1103 drift (see below) |
-| interface_list.priority (0-255) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S1: validator `Between(0, 255)` (reject 256); on the base eth0 interface, live-applied+idempotent; import caveat as mtu |
+| interface_list.mtu (max 16384) | ✅ | ✅ | ✅ | ✅ | ✅ | S1: validator `AtMost(16384)` (reject 20000); base probe live-applied+idempotent; the leaf does not drift and the whole-object import re-plans 0-change (S7) |
+| interface_list.priority (0-255) | ✅ | ✅ | ✅ | ✅ | ✅ | S1: validator `Between(0, 255)` (reject 256); on the base eth0 interface, live-applied+idempotent; whole-object import re-plans 0-change (S7) |
 | vlan_interface.vlan_id (1-4095) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(1, 4095)` (reject 4096) proven at plan; NOT live-applicable — vlan_interface on the `azure` not_managed single Control node 400s (BAD_REQUEST); gated behind `var.extended_arms`, plan-validated only |
 | custom_proxy.proxy_port (0-65535) | ✅ | ✅ | ⬜ | ➖ | ➖ | S1: validator `Between(0, 65535)` (reject 70000) proven at plan; NOT live-applicable — custom_proxy 400s on this probe; gated behind `var.extended_arms`, plan-validated only |
-| ethernet_interface.mac | ✅ | ✅ | ✅ | ✅ | ⚠️ | S2: validator `MACValidator()` (reject `"not-a-mac"`); live-applied on the base eth0 with a valid MAC (`7C-1E-52-7F-F8-12`), idempotent; whole-object import carries the labels{} #1103 drift (see S1 note); gated by `string_arms` |
-| static_ip.ip_address (CIDR) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S2: validator `CIDRValidator()` (reject `"999.999.0.0/8"`); static_ip is the `dhcp_client` address-oneof sibling, live-applied+idempotent (`10.0.1.5/24`), gated by `string_arms`; import labels{} #1103 drift |
-| static_ip.default_gw (IP) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S2: validator `IPValidator()` (reject `"10.0.0.256"`); applied live with ip_address (`10.0.1.1`); import labels{} #1103 drift |
+| ethernet_interface.mac | ✅ | ✅ | ✅ | ✅ | ✅ | S2: validator `MACValidator()` (reject `"not-a-mac"`); live-applied on the base eth0 with a valid MAC (`7C-1E-52-7F-F8-12`), idempotent; whole-object import re-plans 0-change (S7); gated by `string_arms` |
+| static_ip.ip_address (CIDR) | ✅ | ✅ | ✅ | ✅ | ✅ | S2: validator `CIDRValidator()` (reject `"999.999.0.0/8"`); static_ip is the `dhcp_client` address-oneof sibling, live-applied+idempotent (`10.0.1.5/24`), gated by `string_arms`; whole-object import re-plans 0-change (S7) |
+| static_ip.default_gw (IP) | ✅ | ✅ | ✅ | ✅ | ✅ | S2: validator `IPValidator()` (reject `"10.0.0.256"`); applied live with ip_address (`10.0.1.1`); whole-object import re-plans 0-change (S7) |
 | local_vrf.sli_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject `"300.1.1.1"`) proven at plan; NOT live-applied — `sli_config` is a distinct `local_vrf` oneof arm from the base `default_sli_config`; gated behind `vrf_string_arms` (default false), plan-validated only (live is an S3 oneof concern) |
 | local_vrf.sli_config.vip (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject the IPv6 literal `"2001:db8::1"`, proving IPv4-specificity); plan-validated only, gated behind `vrf_string_arms` (S3 oneof, as nameserver) |
 <!-- remaining toggle/interface/services arms seeded ⬜ for S3–S5 -->
@@ -35,25 +35,25 @@ Columns:
 | no_network_policy{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: active_network_policies S4 |
 | no_s2s_connectivity_sli{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
 | no_s2s_connectivity_slo{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
-| offline_survivability_mode.no_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `offline_arm=no_offline_survivability_mode` (default); defaults cycle apply→idempotent→import (labels{} #1244 drift only)→destroy; oneof alt: enable S5 |
-| performance_enhancement_mode.perf_mode_l7_enhanced{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `perf_arm=perf_mode_l7_enhanced` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: perf_mode_l3_enhanced S5 |
-| re_select.geo_proximity{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `re_select_arm=geo_proximity` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: specific_re S5 |
-| software_settings.os.default_os_version{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `os_arm=default_os_version` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: operating_system_version S5 |
-| software_settings.sw.default_sw_version{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S0 base arm; S5 `sw_arm=default_sw_version` (default); defaults cycle round-trip (labels{} #1244 drift only); oneof alt: volterra_software_version S5 |
+| offline_survivability_mode.no_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `offline_arm=no_offline_survivability_mode` (default); defaults cycle apply→idempotent→import (0-change)→destroy; oneof alt: enable S5 |
+| performance_enhancement_mode.perf_mode_l7_enhanced{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `perf_arm=perf_mode_l7_enhanced` (default); defaults cycle round-trip (0-change); oneof alt: perf_mode_l3_enhanced S5 |
+| re_select.geo_proximity{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `re_select_arm=geo_proximity` (default); defaults cycle round-trip (0-change); oneof alt: specific_re S5 |
+| software_settings.os.default_os_version{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `os_arm=default_os_version` (default); defaults cycle round-trip (0-change); oneof alt: operating_system_version S5 |
+| software_settings.sw.default_sw_version{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `sw_arm=default_sw_version` (default); defaults cycle round-trip (0-change); oneof alt: volterra_software_version S5 |
 | node_list[].type (Control/Worker) | ✅ | ✅ | ✅ | ✅ | ✅ | iter-1 live; S2: validator `OneOf("Control", "Worker")` (reject `"Bogus"`); the valid `Worker` arm plans clean and `Control` applied live |
 | interface_list.ethernet_interface{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm (its `mac` leaf → Validated ✅, row above); oneof vs vlan/dedicated S3 |
 | interface_list.network_option.site_local_network{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: SLI/inside S3 |
-| interface_list.dhcp_client{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | iter-1 + S3 `address_arm=dhcp_client`; block arm; the `static_ip` address-oneof sibling → Validated ✅ + Applied ✅ (rows above); live-applied+idempotent, labels{} #1244 import drift |
-| labels | ✅ | ➖ | ✅ | ➖ | ➖ | iter-1; ignore_changes (empty-map drift, xcsh #1103 class) |
+| interface_list.dhcp_client{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 + S3 `address_arm=dhcp_client`; block arm; the `static_ip` address-oneof sibling → Validated ✅ + Applied ✅ (rows above); live-applied+idempotent, whole-object import re-plans 0-change (S7) |
+| labels (top-level metadata map) | ✅ | ➖ | ✅ | ✅ | ✅ | S7: `ignore_changes` removed; xcsh #1286 preserves a config-declared `labels = {}` on post-apply read-back (verified live: apply→plan "No changes"). Import still cannot see config, so the module sends `null` when the map is empty (verified: a literal `{}` re-plans `+ labels = {}` post-import) |
 <!-- S3: interface / addressing oneof arms (enum selectors; live cycle uses -var extended_arms=false) -->
-| interface_list.static_ip{} (address_choice) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S3 `address_arm=static_ip` (default); ip_address/default_gw validated (rows above); live-applied+idempotent, labels{} #1244 import drift |
-| interface_list.no_ipv4_address{} (address_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `address_arm=no_ipv4_address`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| interface_list.no_ipv6_address{} (ipv6_address_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `ipv6_arm=no_ipv6_address` (default); empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| interface_list.monitor{} (monitoring_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `monitor_arm=monitor`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| interface_list.monitor_disabled{} (monitoring_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `monitor_arm=monitor_disabled` (default); empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| interface_list.site_to_site_connectivity_interface_disabled{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `s2s_iface_arm=disabled` (default); empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| interface_list.site_to_site_connectivity_interface_enabled{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S3 `s2s_iface_arm=enabled`; empty marker; recon expected 400 (s2s wiring) but the single-node `azure` probe ACCEPTS it — live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| interface_list.ethernet_interface{} (interface_choice) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S3 `interface_arm=ethernet` (default); mac leaf validated (row above); live-applied+idempotent, labels{} #1244 import drift |
+| interface_list.static_ip{} (address_choice) | ✅ | ✅ | ✅ | ✅ | ✅ | S3 `address_arm=static_ip` (default); ip_address/default_gw validated (rows above); live-applied+idempotent, whole-object import re-plans 0-change (S7) |
+| interface_list.no_ipv4_address{} (address_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `address_arm=no_ipv4_address`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| interface_list.no_ipv6_address{} (ipv6_address_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `ipv6_arm=no_ipv6_address` (default); empty marker; live apply→idempotent→import (0-change)→destroy |
+| interface_list.monitor{} (monitoring_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `monitor_arm=monitor`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| interface_list.monitor_disabled{} (monitoring_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `monitor_arm=monitor_disabled` (default); empty marker; live apply→idempotent→import (0-change)→destroy |
+| interface_list.site_to_site_connectivity_interface_disabled{} | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `s2s_iface_arm=disabled` (default); empty marker; live apply→idempotent→import (0-change)→destroy |
+| interface_list.site_to_site_connectivity_interface_enabled{} | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `s2s_iface_arm=enabled`; empty marker; recon expected 400 (s2s wiring) but the single-node `azure` probe ACCEPTS it — live apply→idempotent→import (0-change)→destroy |
+| interface_list.ethernet_interface{} (interface_choice) | ✅ | ✅ | ✅ | ✅ | ✅ | S3 `interface_arm=ethernet` (default); mac leaf validated (row above); live-applied+idempotent, whole-object import re-plans 0-change (S7) |
 | interface_list.bond_interface{} (interface_choice) | ✅ | ✅ | ⬜ | ➖ | ➖ | S3 `interface_arm=bond`; plan-only — 400 (BAD_REQUEST) on single-node `azure` probe (confirmed live); `devices` `SizeBetween(1, 8)` reject proven at plan (reject-bond-devices); `lacp.rate` `Between(1, 30)` + `devices` plan clean |
 | interface_list.vlan_interface{} (interface_choice) | ✅ | ✅ | ⬜ | ➖ | ➖ | S3 `interface_arm=vlan` (primary oneof); plan-only — 400 on single-node `azure` probe (confirmed live); `vlan_id` `Between(1, 4095)` validated (S1 reject-vlan-id via the extended_arms second interface) |
 | interface_list.ipv6_auto_config{} (ipv6_address_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S3 `ipv6_arm=ipv6_auto_config`; plan-only — 400 on single-node IPv4 `azure` probe (confirmed live); renders the `host {}` autoconfig_choice member; plans clean |
@@ -61,17 +61,17 @@ Columns:
 <!-- S4: networking / services top-level oneof arms (enum selectors; live cycle uses -var extended_arms=false) -->
 | blocked_services.blocked_service{} (services_choice) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4 `services_arm=blocked_services`; plan-only — provider read-back drops the block (inconsistent result after apply), tracked provider #1257. `network_type` `OneOf` reject proven at plan |
 | blocked_services.blocked_service.network_type (OneOf) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4: validator `OneOf(VIRTUAL_NETWORK_*)` (reject `"BOGUS"`) proven at plan (reject-network-type); not live (parent arm round-trip bug above) |
-| f5_proxy{} (enterprise_proxy_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `proxy_arm=f5_proxy`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| f5_proxy{} (enterprise_proxy_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `proxy_arm=f5_proxy`; empty marker; live apply→idempotent→import (0-change)→destroy |
 | custom_proxy.proxy_ip_address (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4: validator `IPv4Validator()` (reject `"999.1.1.1"`) proven at plan (reject-proxy-ip); custom_proxy 400s live (S1), gated behind `extended_arms`, plan-validated only |
-| dns_ntp_config.custom_dns.dns_servers | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `dns_arm=custom_dns`; renders `dns_servers`; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| dns_ntp_config.custom_ntp.ntp_servers | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `ntp_arm=custom_ntp`; renders `ntp_servers`; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| custom_proxy_bypass.proxy_bypass | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `proxy_bypass_arm=custom_proxy_bypass`; renders `proxy_bypass` domain list; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| no_proxy_bypass{} (proxy_bypass_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `proxy_bypass_arm=no_proxy_bypass`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| enable_url_categorization{} (url_categorization_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `url_cat_arm=enable_url_categorization`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| disable_url_categorization{} (url_categorization_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `url_cat_arm=disable_url_categorization`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| disable_management_network{} (management_network_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `mgmt_net_arm=disable_management_network`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| load_balancing.vip_vrrp_mode (OneOf) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S4 `vip_vrrp_mode=VIP_VRRP_ENABLE`/`VIP_VRRP_DISABLE`; validator `OneOf(VIP_VRRP_INVALID, VIP_VRRP_ENABLE, VIP_VRRP_DISABLE)` (reject `"BOGUS"`, reject-vip-vrrp-mode); both ENABLE and DISABLE live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| site_mesh_group_on_slo{no_site_mesh_group{} sm_connection_public_ip{}} (s2s_slo_choice) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S4 `s2s_slo_arm=site_mesh_group_empty`; renders both sub-oneofs (mesh_group_choice + connection_choice) all-empty; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
+| dns_ntp_config.custom_dns.dns_servers | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `dns_arm=custom_dns`; renders `dns_servers`; live apply→idempotent→import (0-change)→destroy |
+| dns_ntp_config.custom_ntp.ntp_servers | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `ntp_arm=custom_ntp`; renders `ntp_servers`; live apply→idempotent→import (0-change)→destroy |
+| custom_proxy_bypass.proxy_bypass | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `proxy_bypass_arm=custom_proxy_bypass`; renders `proxy_bypass` domain list; live apply→idempotent→import (0-change)→destroy |
+| no_proxy_bypass{} (proxy_bypass_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `proxy_bypass_arm=no_proxy_bypass`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| enable_url_categorization{} (url_categorization_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `url_cat_arm=enable_url_categorization`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| disable_url_categorization{} (url_categorization_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `url_cat_arm=disable_url_categorization`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| disable_management_network{} (management_network_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `mgmt_net_arm=disable_management_network`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| load_balancing.vip_vrrp_mode (OneOf) | ✅ | ✅ | ✅ | ✅ | ✅ | S4 `vip_vrrp_mode=VIP_VRRP_ENABLE`/`VIP_VRRP_DISABLE`; validator `OneOf(VIP_VRRP_INVALID, VIP_VRRP_ENABLE, VIP_VRRP_DISABLE)` (reject `"BOGUS"`, reject-vip-vrrp-mode); both ENABLE and DISABLE live apply→idempotent→import (0-change)→destroy |
+| site_mesh_group_on_slo{no_site_mesh_group{} sm_connection_public_ip{}} (s2s_slo_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S4 `s2s_slo_arm=site_mesh_group_empty`; renders both sub-oneofs (mesh_group_choice + connection_choice) all-empty; live apply→idempotent→import (0-change)→destroy |
 | enable_ha{} (node_ha_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `ha_arm=enable_ha`; plan-only — 400 on single-node `azure` probe (needs >=3 nodes); plans clean |
 | enable_management_network{} (management_network_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `mgmt_net_arm=enable_management_network`; plan-only — 400 on single-node `azure` probe; plans clean |
 | active_forward_proxy_policies.forward_proxy_policies[] (ref) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `forward_proxy_arm=active_forward_proxy_policies`; plan-only — ObjectRefType list, ref-dependent; plans clean |
@@ -82,14 +82,14 @@ Columns:
 | site_mesh_group_on_slo{site_mesh_group ref} (s2s_slo_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_slo_arm=site_mesh_group_ref`; plan-only — `site_mesh_group` ObjectRefType, ref-dependent; plans clean |
 | segment_vrf.segment_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4 `segment_vrf_arm=inline`; plan-only — needs a Segment object ref the provider cannot yet inject (specs #1053); validator `IPv4Validator()` (reject `"300.2.2.2"`, reject-segment-nameserver) proven at plan |
 <!-- S5: site-mode oneof arms (perf / os / sw / offline / re_select / upgrade / admin; enum selectors; live cycle uses -var extended_arms=false) -->
-| performance_enhancement_mode.perf_mode_l3_enhanced{no_jumbo{}} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S5 `perf_arm=perf_mode_l3_enhanced`; renders the `no_jumbo{}` sub-oneof member; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| software_settings.os.operating_system_version | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5 `os_arm=operating_system_version` (`9.2024.6`); validator `LengthAtMost(20)` (reject 21-char, reject-os-version); create-only leaf — live apply→idempotent→import round-trips 0-change (labels{} #1244 drift only)→destroy |
-| software_settings.sw.volterra_software_version | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5 `sw_arm=volterra_software_version` (`crt-20250613-3382`); validator `LengthAtMost(20)` (reject 21-char, reject-sw-version); create-only leaf — live round-trips 0-change (labels{} #1244 drift only) |
-| offline_survivability_mode.enable_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ⚠️ | S5 `offline_arm=enable_offline_survivability_mode`; empty marker; live apply→idempotent→import (labels{} #1244 drift only)→destroy |
-| upgrade_settings...enable_upgrade_drain{} (kubernetes_upgrade_drain) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5 `upgrade_drain_arm=enable_upgrade_drain`; recon expected 400 (k8s worker-drain on non-k8s node) but the single-node `azure` probe ACCEPTS it — reclassified live; renders drain leaves + `disable_vega_upgrade_mode{}`; apply→idempotent→import (labels{} #1244 drift)→destroy |
-| enable_upgrade_drain.drain_max_unavailable_node_count (1-5000) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5: validator `Between(1, 5000)` (reject 5001, reject-drain-count); applied live via enable_upgrade_drain (default 1) |
-| enable_upgrade_drain.drain_node_timeout (0-900) | ✅ | ✅ | ✅ | ✅ | ⚠️ | S5: validator `Between(0, 900)` (reject 901, reject-drain-timeout); applied live via enable_upgrade_drain (default 300) |
-| enable_upgrade_drain.disable_vega_upgrade_mode{} (vega sub-oneof) | ✅ | ➖ | ✅ | ✅ | ⚠️ | S5 `vega_arm=disable_vega_upgrade_mode` (default); empty marker; applied live via enable_upgrade_drain; alt `enable_vega_upgrade_mode` plans clean |
+| performance_enhancement_mode.perf_mode_l3_enhanced{no_jumbo{}} | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `perf_arm=perf_mode_l3_enhanced`; renders the `no_jumbo{}` sub-oneof member; live apply→idempotent→import (0-change)→destroy |
+| software_settings.os.operating_system_version | ✅ | ✅ | ✅ | ✅ | ✅ | S5 `os_arm=operating_system_version` (`9.2024.6`); validator `LengthAtMost(20)` (reject 21-char, reject-os-version); create-only leaf — live apply→idempotent→import round-trips 0-change (0-change)→destroy |
+| software_settings.sw.volterra_software_version | ✅ | ✅ | ✅ | ✅ | ✅ | S5 `sw_arm=volterra_software_version` (`crt-20250613-3382`); validator `LengthAtMost(20)` (reject 21-char, reject-sw-version); create-only leaf — live round-trips 0-change (0-change) |
+| offline_survivability_mode.enable_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `offline_arm=enable_offline_survivability_mode`; empty marker; live apply→idempotent→import (0-change)→destroy |
+| upgrade_settings...enable_upgrade_drain{} (kubernetes_upgrade_drain) | ✅ | ✅ | ✅ | ✅ | ✅ | S5 `upgrade_drain_arm=enable_upgrade_drain`; recon expected 400 (k8s worker-drain on non-k8s node) but the single-node `azure` probe ACCEPTS it — reclassified live; renders drain leaves + `disable_vega_upgrade_mode{}`; apply→idempotent→import (0-change)→destroy |
+| enable_upgrade_drain.drain_max_unavailable_node_count (1-5000) | ✅ | ✅ | ✅ | ✅ | ✅ | S5: validator `Between(1, 5000)` (reject 5001, reject-drain-count); applied live via enable_upgrade_drain (default 1) |
+| enable_upgrade_drain.drain_node_timeout (0-900) | ✅ | ✅ | ✅ | ✅ | ✅ | S5: validator `Between(0, 900)` (reject 901, reject-drain-timeout); applied live via enable_upgrade_drain (default 300) |
+| enable_upgrade_drain.disable_vega_upgrade_mode{} (vega sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `vega_arm=disable_vega_upgrade_mode` (default); empty marker; applied live via enable_upgrade_drain; alt `enable_vega_upgrade_mode` plans clean |
 | admin_user_credentials{ssh_key, admin_password clear_secret_info} | ✅ | ✅ | ⬜ | ➖ | ➖ | S5 `admin_creds=true`; plan-only — `[BAD_REQUEST]` 400 live on the single-node `azure` probe (recon expected live, reclassified); `ssh_key` `LengthAtMost(8192)` + `secret_encoding_type` `OneOf` reject-proven at plan; dummy `string:///<base64>` secret (no real secret committed) |
 | re_select.specific_re{primary_re, backup_re} | ✅ | ✅ | ⬜ | ➖ | ➖ | S5 `re_select_arm=specific_re`; plan-only — `[BAD_REQUEST] Invalid request parameters (status: 400)` live (primary_re must name a real RE geography); `primary_re` `LengthBetween(1, 64)` (reject 65-char, reject-primary-re) proven at plan |
 
@@ -103,10 +103,10 @@ Columns:
   validator diagnostic per leaf instead.
 - **mtu is `AtMost(16384)` only** — the API's discontinuous rule {0} ∪ [512,16384] has no single
   minimum, so the failing test uses `mtu = 20000` (a small value like 200 is *not* rejected).
-- **⚠️ import caveat (mtu, priority)** — a whole-object `terraform import` re-plans with one
-  in-place change: `- labels {}` on the interface (xcsh #1103 empty-marker class, still present
-  on v3.75.0 for `securemesh_site_v2` interface labels). The numeric leaves themselves do not
-  drift; the base probe is apply-clean and idempotent. Out of scope for S1 (numeric validators).
+- **import caveat CLEARED (S7)** — the whole-object `terraform import` used to re-plan one
+  in-place change, `- labels {}` on the interface. That is fixed in provider v3.77.5 (xcsh
+  #1244 emits the import guards for the nested `interface_list.labels {}` marker). Re-verified
+  live on v3.77.5: apply → plan "No changes" → `state rm` → `import` → plan **0 changes**.
 - **vlan_id / proxy_port not live-applied** — `vlan_interface` and top-level `custom_proxy` both
   return `[BAD_REQUEST] Invalid request parameters (400)` on the `azure` not_managed single Control
   node. They are gated behind `var.extended_arms` (default true) so their validators are reached
@@ -124,7 +124,8 @@ Columns:
   apply live (HTTP 200) on the `azure` not_managed single-node probe. The live cycle ran twice
   with a fresh `probe_name`: (a) the base arm `-var string_arms=false` (dhcp_client, no mac), and
   (b) the string arm `-var string_arms=true` (mac + static_ip) — both apply → 0-change re-plan →
-  import → destroy, with only the shared labels{} #1103 import drift and no string-leaf drift.
+  import → destroy 0-change on every step (the shared labels{} drift was cleared in S7) and no
+  string-leaf drift.
 - **nameserver / vip plan-only** — `IPv4Validator()` is proven at PLAN via `reject-nameserver`
   (bad IPv4 `300.1.1.1`) and `reject-vip` (the IPv6 literal `2001:db8::1`, proving IPv4-specificity).
   They live on `local_vrf.sli_config`, a distinct oneof arm from the base `default_sli_config`, so
@@ -144,8 +145,7 @@ Columns:
   `extended_arms=false` on the base probe (which still renders one member of every eth0 oneof).
 - **Live-appliable arms** — `ethernet_interface`, `dhcp_client`, `static_ip`, `no_ipv4_address`,
   `no_ipv6_address`, `monitor`, `monitor_disabled`, `s2s_..._disabled`, `s2s_..._enabled` all
-  apply (HTTP 200), re-plan clean, and import with only the known `labels {}` #1244 drift (already
-  handled by `ignore_changes`). `s2s_..._enabled` was expected plan-only in recon but the
+  apply (HTTP 200), re-plan clean, and import 0-change (the `labels {}` drift was cleared in S7). `s2s_..._enabled` was expected plan-only in recon but the
   single-node `azure` probe accepts it — reclassified live after verification.
 - **Plan-only arms** — `bond_interface`, `vlan_interface`, `ipv6_auto_config`,
   `static_ipv6_address` each return `[BAD_REQUEST] Invalid request parameters (status: 400)` on the
@@ -167,8 +167,7 @@ Columns:
   committed base, swapped in the S4 code, and a defaults plan reported "No changes."
 - **Live cycle uses `-var extended_arms=false`** — as in S1–S3, `custom_proxy` and the second vlan
   interface 400 live, so every S4a live apply/idempotent/import ran with `extended_arms=false`.
-- **S4a live-appliable arms** (HTTP 200, idempotent, import-clean modulo the known `labels {}` #1244
-  drift): `f5_proxy`, `custom_dns`, `custom_ntp`, `custom_proxy_bypass`, `no_proxy_bypass`,
+- **S4a live-appliable arms** (HTTP 200, idempotent, import-clean): `f5_proxy`, `custom_dns`, `custom_ntp`, `custom_proxy_bypass`, `no_proxy_bypass`,
   `enable_url_categorization`, `disable_url_categorization`, `disable_management_network`,
   `load_balancing.vip_vrrp_mode` (ENABLE + DISABLE), and `site_mesh_group_on_slo` all-empty
   (`no_site_mesh_group{} sm_connection_public_ip{}`). Each ran apply→0-change re-plan→import→destroy.
@@ -198,8 +197,8 @@ Columns:
   `offline_survivability_mode`/`re_select` literals, and adds gated `upgrade_settings` +
   `admin_user_credentials` blocks (both unset in the base). Every default renders the identical base
   member, so a bare `terraform plan` (all defaults) shows NO diff — verified live: defaults
-  apply→0-change re-plan→import→destroy round-trips with only the known `labels {}` #1244 drift.
-- **S5a live-appliable** (HTTP 200, idempotent, import-clean modulo `labels {}` #1244):
+  apply→0-change re-plan→import→destroy round-trips 0-change on every step.
+- **S5a live-appliable** (HTTP 200, idempotent, import-clean):
   `perf_mode_l3_enhanced{no_jumbo{}}`, `operating_system_version` (`9.2024.6`),
   `volterra_software_version` (`crt-20250613-3382`), `enable_offline_survivability_mode`, and
   `upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain` (drain count/timeout + vega). Each
@@ -221,6 +220,21 @@ Columns:
 - **Provider enrichment gap #1258** — filed for the `enable_upgrade_drain.drain_node_timeout`
   required-ness (the arm inventory marks it required); the harness always supplies it (default 300).
   Not blocking — S5 is pure-mcn coverage (no provider/specs change).
+
+**S7 notes (labels workaround retired, provider v3.77.5):**
+
+- **`ignore_changes = [labels]` deleted** from `terraform/modules/xc-site/main.tf`. Its comment blamed the
+  nested empty-marker class (#1103), but it targeted the **top-level metadata map** and was masking a
+  different bug. Both are now fixed: xcsh #1244 (import guards for the nested `interface_list.labels {}`
+  marker) and xcsh #1286 (a config-declared empty `labels = {}` survives the post-apply read-back).
+- **The module sends `null`, not `{}`, when `var.labels` is empty.** #1286 fixes the post-apply half only —
+  on import the state carries just id/name/namespace and `ReadRequest` exposes no config, so a literal `{}`
+  still re-plans `+ labels = {}` on the first post-import plan (verified live). `null` avoids asking the
+  provider to distinguish something it cannot observe.
+- **Live proof (v3.77.5 from the registry, dev_overrides off, disposable probes only):**
+  (a) `cov-probe-s7d1-01` defaults → apply → plan "No changes" → `state rm` → `import system/...` → plan
+  **0 changes**, with no `ignore_changes` anywhere; (b) `cov-probe-s7d1-02` with `labels = {}` in config →
+  apply → plan **"No changes"**. Both probes destroyed; the live demo sites were never touched.
 
 <!--
 Slice roadmap:

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -45,7 +45,7 @@ Every eth0 interface oneof is modeled as an **enum selector** (`interface_arm`, 
 siblings ever coexist (which would trip the provider's `ConflictsWith`). Defaults are the live-safe
 base arm, so a bare apply (with `extended_arms=false`) stays idempotent and import-clean.
 
-**Live-appliable** (HTTP 200, idempotent, import-clean modulo the known `labels {}` #1244 drift):
+**Live-appliable** (HTTP 200, idempotent, import-clean):
 `ethernet_interface`, `dhcp_client`, `static_ip`, `no_ipv4_address`, `no_ipv6_address`, `monitor`,
 `monitor_disabled`, `site_to_site_connectivity_interface_disabled`, and
 `site_to_site_connectivity_interface_enabled` (s2s `enabled` was expected to need s2s wiring but the
@@ -68,7 +68,7 @@ terraform apply   -auto-approve -var probe_name=cov-probe-s3-x -var extended_arm
 terraform plan                  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor  # No changes
 terraform state rm xcsh_securemesh_site_v2.probe
 terraform import  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor xcsh_securemesh_site_v2.probe system/cov-probe-s3-x
-terraform plan                  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor  # 0-change modulo labels {}
+terraform plan                  -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor  # No changes
 terraform destroy -auto-approve -var probe_name=cov-probe-s3-x -var extended_arms=false -var monitor_arm=monitor
 ```
 
@@ -82,7 +82,7 @@ renders. Every default is the base arm, so a bare `terraform plan` (all defaults
 the pre-S4 base (verified: applied the committed base, swapped in the S4 code, defaults plan =
 "No changes").
 
-**Live-appliable (S4a)** — apply→idempotent→import (labels{} #1244 drift only)→destroy on the
+**Live-appliable (S4a)** — apply→idempotent→import (0-change)→destroy on the
 single-node `azure` probe: `f5_proxy`, `custom_dns`, `custom_ntp`, `custom_proxy_bypass`,
 `no_proxy_bypass`, `enable_url_categorization`, `disable_url_categorization`,
 `disable_management_network`, `load_balancing.vip_vrrp_mode` (ENABLE + DISABLE), and
@@ -112,7 +112,7 @@ terraform apply   -auto-approve -var probe_name=cov-probe-s4-x -var extended_arm
 terraform plan                  -var probe_name=cov-probe-s4-x -var extended_arms=false -var vip_vrrp_mode=VIP_VRRP_ENABLE  # No changes
 terraform state rm xcsh_securemesh_site_v2.probe
 terraform import  -var probe_name=cov-probe-s4-x -var extended_arms=false -var vip_vrrp_mode=VIP_VRRP_ENABLE xcsh_securemesh_site_v2.probe system/cov-probe-s4-x
-terraform plan                  -var probe_name=cov-probe-s4-x -var extended_arms=false -var vip_vrrp_mode=VIP_VRRP_ENABLE  # 0-change modulo labels {}
+terraform plan                  -var probe_name=cov-probe-s4-x -var extended_arms=false -var vip_vrrp_mode=VIP_VRRP_ENABLE  # No changes
 terraform destroy -auto-approve -var probe_name=cov-probe-s4-x -var extended_arms=false -var vip_vrrp_mode=VIP_VRRP_ENABLE
 ```
 
@@ -124,9 +124,9 @@ drain, admin credentials) is modeled as an **enum selector** (`perf_arm`, `os_ar
 that supersedes the pre-S5 hardcoded literal, plus gated `upgrade_settings` + `admin_user_credentials`
 blocks (both unset in the base). Every default renders the identical base member, so a bare
 `terraform plan` (all defaults) is unchanged versus the pre-S5 base (verified: defaults
-apply→0-change→import→destroy round-trips with only the `labels {}` #1244 drift).
+apply→0-change→import→destroy round-trips 0-change).
 
-**Live-appliable (S5a)** — apply→idempotent→import (labels{} #1244 drift only)→destroy on the
+**Live-appliable (S5a)** — apply→idempotent→import (0-change)→destroy on the
 single-node `azure` probe: `perf_mode_l3_enhanced{no_jumbo{}}`, `operating_system_version`
 (`9.2024.6`), `volterra_software_version` (`crt-20250613-3382`; both version leaves are **create-only**
 yet round-trip 0-change), `enable_offline_survivability_mode`, and
@@ -154,7 +154,7 @@ terraform apply   -auto-approve -var probe_name=cov-probe-s5-x -var extended_arm
 terraform plan                  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version  # No changes
 terraform state rm xcsh_securemesh_site_v2.probe
 terraform import  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version xcsh_securemesh_site_v2.probe system/cov-probe-s5-x
-terraform plan                  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version  # 0-change modulo labels {}
+terraform plan                  -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version  # No changes
 terraform destroy -auto-approve -var probe_name=cov-probe-s5-x -var extended_arms=false -var os_arm=operating_system_version -var sw_arm=volterra_software_version
 ```
 

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -6,15 +6,14 @@ resource "xcsh_securemesh_site_v2" "this" {
   name        = var.site_name
   namespace   = "system"
   description = "MCN CE-HA (BGP/ECMP) single-node SMSv2 site ${var.site_name} — explicit eth0 SLO interface for BGP peer binding."
-  labels      = var.labels
-
-  # The provider reads empty labels back as absent, so an unset/empty labels map
-  # perpetually re-plans as `+ labels = {}` (empty-map round-trip drift, same class
-  # as xcsh #1103). Ignore label drift to keep the site idempotent — labels are not
-  # managed by this demo. Root-cause fix belongs in the provider (read-back suppression).
-  lifecycle {
-    ignore_changes = [labels]
-  }
+  # `null`, not `{}`, when no labels are set. xcsh #1286 makes the provider preserve a
+  # config-declared empty map on the POST-APPLY read-back, but import has no config to
+  # read: the state carries only id/name/namespace and `ReadRequest` exposes nothing
+  # else, so a literal `{}` would still re-plan as `+ labels = {}` on the first
+  # post-import plan. Sending `null` when the map is empty stops asking the provider to
+  # distinguish "declared empty" from "absent" — something it cannot observe on import.
+  # (The nested `interface_list.labels {}` marker is a separate class, fixed by xcsh #1244.)
+  labels = length(var.labels) > 0 ? var.labels : null
 
   azure {
     not_managed {

--- a/terraform/modules/xc-site/versions.tf
+++ b/terraform/modules/xc-site/versions.tf
@@ -10,8 +10,12 @@ terraform {
       # xcsh_registration_approval. It also includes >= 3.74.0's object-ref name
       # validator relaxed 63 -> 128 chars, so the real 71-char auto-derived SLO
       # interface name the BGP peer binds to validates (xcsh_bgp is not
-      # length-gated). Keep in lock-step with the root terraform/versions.tf.
-      version = ">= 3.77.3"
+      # length-gated). >= 3.77.5 raises the floor to the two labels fixes this
+      # module now relies on instead of `ignore_changes`: import-marker suppression
+      # for the nested interface_list `labels {}` block (#1244) and preservation of
+      # a config-declared empty top-level metadata `labels` map (#1286).
+      # Keep in lock-step with the root terraform/versions.tf.
+      version = ">= 3.77.5"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -13,7 +13,11 @@ terraform {
       # to validates), and the registration pair used by modules/xc-site — the
       # xcsh_site_registration data source (resolves a CE's r-<uuid> runtime
       # registration name from its site name) plus xcsh_registration_approval.
-      version = ">= 3.77.3"
+      # >= 3.77.5 additionally carries the two fixes that retire the labels
+      # workaround in modules/xc-site: import-marker suppression for the nested
+      # interface_list `labels {}` block (#1244) and preservation of a
+      # config-declared empty top-level metadata `labels` map (#1286).
+      version = ">= 3.77.5"
     }
     # Azure providers deploy the hub VNet, Azure Route Server, the CE VMs and the
     # test client. azuread is read-only (resolves the deployer identity for naming/tags).


### PR DESCRIPTION
## What
Retires the `labels` workaround now that both underlying provider bugs are fixed and released in **xcsh v3.77.5**.

```diff
-  labels      = var.labels
-  lifecycle {
-    ignore_changes = [labels]
-  }
+  labels = length(var.labels) > 0 ? var.labels : null
```

The deleted comment blamed the nested empty-marker class (#1103), but `ignore_changes = [labels]` targets the **top-level metadata map** — it was masking a different bug entirely. Both are now fixed: `terraform-provider-xcsh#1244` (import guards for the nested `interface_list.labels {}` marker) and `#1286` (a config-declared empty `labels = {}` survives the post-apply read-back).

## Why `null` and not `{}`
#1286 fixes the **post-apply** half only. On import, state carries just id/name/namespace and `ReadRequest` exposes no config, so a literal `{}` still re-plans `+ labels = {}` on the first post-import plan. Sending `null` when the map is empty stops asking the provider to distinguish "declared empty" from "absent" — something it cannot observe on import.

This was verified rather than assumed: with `labels = {}` left in config, `state rm` → `import` → `plan` yields `+ labels = {}` / `Plan: 0 to add, 1 to change, 0 to destroy`. The `null` is load-bearing.

## Live proof (provider v3.77.5 from the registry, dev_overrides **off**, disposable probes only)
**(a) whole-object import, no `ignore_changes` anywhere** — `cov-probe-s7d1-01`:
`apply` → `Apply complete! Resources: 1 added` → `plan` → `No changes.` → `state rm` → `import system/cov-probe-s7d1-01` → `Import successful!` → `plan` → **`No changes. Your infrastructure matches the configuration.`**
Previously this drifted `- labels {}`.

**(b) config-declared empty map** — `cov-probe-s7d1-02` with `labels = {}`:
`apply` → `plan` → **`No changes.`** Previously this drifted `+ labels = {}` on every plan, forever.

Both probes destroyed; a tenant sweep of 86 SMSv2 objects shows no `cov-probe` leftovers. The live demo sites, their resource group and the `multi-cloud-networking` namespace were never addressed.

## Also
- `xcsh` floor bumped to `>= 3.77.5` in **both** `terraform/versions.tf` and `terraform/modules/xc-site/versions.tf` (lock-step — the module is the one declaring these resources), with comments naming what the floor now carries.
- Stale caveats cleared from `coverage/smsv2-coverage-matrix.md` (37 Import-clean cells and their notes, the `labels` row restated, 6 prose bullets, plus an S7 notes section) and `coverage/smsv2/README.md`.
- The matrix explicitly records the **basis** for those flips: the import proof was re-run live on the base probe only; other arms went green because the one caveat they carried was this shared marker and #1244's fix is resource-wide (39 of 39 nested `labels` closures guarded), not because each arm was re-imported in S7.
- `blocked_services` rows and the #1257 bullet were deliberately left alone — see below.

## Verification
`terraform validate` Success and `terraform test` **13 passed / 0 failed** against the released provider with `TF_CLI_CONFIG_FILE=/dev/null` (so this proves v3.77.5 from the registry, not a local build). `coverage/smsv2/verify.sh` re-run → PASS. `terraform fmt -check -recursive`, `tflint --recursive`, `codespell`, `markdownlint-cli2` and textlint terminology all clean.

## Out of scope (follow-up)
Promoting the `blocked_services` arm to live and renaming `blocked_service` → `blocked_sevice` needs the provider's wire-key regeneration, which is currently blocked: the regenerated docs render the real-but-misspelled API field as `Blocked Sevice`, and codespell reports it ambiguously (`Sevice ==> Service, Device`) so `--write-changes` cannot resolve it. Tracked in docs-control#777 (add `sevice` to the managed `.codespellrc` ignore list, exactly as `checkin` already is) and api-specs-enriched#1063 (fix the ~90 genuine upstream prose typos at source).

Part of epic terraform-provider-xcsh#1207 (slice S7).

Closes #604
