### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,22 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
+  # Locale lint — hardcoded locale lists should import from @f5-sales-demo/i18n-core.
+  # The script no-ops in repositories that do not carry it.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: locale-lint
+        name: Locale lint
+        entry: >-
+          bash -c
+          'if [ -f scripts/locale-lint.sh ];
+          then bash scripts/locale-lint.sh; fi'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+  # ===========================================================================
   # File size guard
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -236,6 +252,7 @@ ci:
   skip:
     - local-hooks
     - check-repo-hygiene
+    - locale-lint
     - yamllint
     - markdownlint
     - shellcheck

--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -41,6 +41,15 @@ check_pattern() {
   return 0
 }
 
+# The package that owns these definitions cannot import them from itself. The
+# exclusion below matches "i18n-core/src/", which only appears when i18n-core is a
+# dependency; inside its own repository the path is "./src/...", so the check used
+# to flag its own source of truth and could never pass there.
+if [ -f package.json ] && grep -qE '"name"[[:space:]]*:[[:space:]]*"@f5-sales-demo/i18n-core"' package.json; then
+  echo "Locale lint: this is the i18n-core package itself — its locale definitions are canonical."
+  exit 0
+fi
+
 echo "Locale lint: checking for hardcoded locale lists..."
 echo ""
 


### PR DESCRIPTION
Closes #612

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .pre-commit-config.yaml
- scripts/locale-lint.sh