### PR TITLE
feat(ce-node): enable boot diagnostics so Azure Serial Console can attach

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+# Gitignored local inputs copied into a new git worktree, so the worktree can run
+# `terraform plan` instead of being born broken.
+#
+# Without these, a fresh worktree fails at `terraform init` (no backend config)
+# and then at plan time (no variable values), which looks like a problem with the
+# branch rather than a missing local file.
+#
+# Neither file is committed: backend.hcl names the shared state container, and
+# terraform.tfvars carries per-engineer values. XC provider credentials are NOT
+# listed here — they come from the environment or the xcsh context file and must
+# never be written into the repository.
+terraform/backend.hcl
+terraform/terraform.tfvars

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,33 @@
+# Local Terraform inputs and artifacts that must never be committed.
+#
+# The repository root .gitignore is governance-managed and covers neither *.tfvars
+# nor backend.hcl, so both sat untracked-but-committable: a single `git add -A`
+# would have published the shared state container name and per-engineer values.
+# The sibling webapp-api-protection/terraform/.gitignore already guards these;
+# mcn had no equivalent. Mirrors that file.
+#
+# The matching entries in ../.worktreeinclude copy these into a new worktree, so
+# ignoring them here does not leave a fresh worktree unable to plan.
+
+# Variable files carry environment-specific values
+*.tfvars
+!*.tfvars.example
+
+# Partial backend config; the example is committed
+backend.hcl
+!backend.hcl.example
+
+# Saved plan artifacts (terraform plan -out)
+tfplan
+*.tfplan
+
+# CLI config and credential material
+.terraformrc
+terraform.rc
+*.tfrc
+*.pem
+*.p12
+
+# Local overrides for iteration; the authoritative backend is azurerm
+*_override.tf
+*_override.tf.json

--- a/terraform/modules/ce-node/main.tf
+++ b/terraform/modules/ce-node/main.tf
@@ -119,5 +119,12 @@ resource "azurerm_linux_virtual_machine" "this" {
 
   custom_data = var.custom_data
 
+  # Required for Azure Serial Console, which is the only way into a CE that has
+  # not registered: the vpm/debug API used for every other diagnostic is reached
+  # through the XC control plane, so it answers only once the node is ONLINE, and
+  # the node refuses SSH as shipped. Empty block = Azure-managed storage, so there
+  # is no diagnostics storage account or access key to own.
+  boot_diagnostics {}
+
   tags = var.tags
 }

--- a/terraform/tests/ce_node.tftest.hcl
+++ b/terraform/tests/ce_node.tftest.hcl
@@ -61,4 +61,21 @@ run "ce_vm_and_nics" {
     condition     = azurerm_linux_virtual_machine.this.os_disk[0].storage_account_type == "StandardSSD_LRS"
     error_message = "CE OS disk must be StandardSSD_LRS."
   }
+
+  # Azure Serial Console requires boot diagnostics. It is the only way into a CE
+  # that has not registered: the vpm/debug API used for every other diagnostic is
+  # reached through the XC control plane, so it answers only once the node is
+  # ONLINE, and the node refuses SSH as shipped. Losing this block would silently
+  # remove the break-glass path for the exact failure it exists to debug.
+  assert {
+    condition     = length(azurerm_linux_virtual_machine.this.boot_diagnostics) == 1
+    error_message = "CE VM must enable boot diagnostics, or Azure Serial Console cannot attach."
+  }
+
+  # An empty block means Azure-managed storage, so there is no diagnostics storage
+  # account, lifecycle policy or access key for us to own.
+  assert {
+    condition     = azurerm_linux_virtual_machine.this.boot_diagnostics[0].storage_account_uri == null
+    error_message = "CE boot diagnostics must use Azure-managed storage (no storage_account_uri)."
+  }
 }


### PR DESCRIPTION
Closes #618

## Why

Serial Console is the **only** way into a CE that has not registered. Every other
diagnostic goes through the `vpm/debug` API, which is reached via the XC control
plane and therefore answers only once the node is `ONLINE` — precisely not the
case when registration is what failed. The node also refuses SSH as shipped:

```console
$ ssh -o ConnectTimeout=10 admin@<ce-public-ip>
ssh: connect to host <ce-public-ip> port 22: Connection refused
```

Confirmed from inside the VNet as well (`nc -z -w3 10.0.1.4 22` from the
`ar-ecmp-client` jump host), so this is the node and not an NSG rule.

Azure requires boot diagnostics for Serial Console, and all three CE VMs reported
`bootDiagnostics.enabled: False`.

## Change

```hcl
boot_diagnostics {}
```

An empty block selects Azure-managed storage, so there is no diagnostics storage
account, lifecycle policy or access key for us to own and secure.

## TDD

Two assertions added to `tests/ce_node.tftest.hcl` **first** and observed to fail:

```
CE VM must enable boot diagnostics, or Azure Serial Console cannot attach.
Error: Invalid index
  azurerm_linux_virtual_machine.this.boot_diagnostics is empty list of object
```

The second assertion pins managed storage, so a later change cannot quietly
introduce a storage account that would then need securing.

After: `Success! 13 passed, 0 failed.`

## Live plan: in place, and side-effect free

Run on this workstation (CI holds no Azure credential — see the header comment in
`.github/workflows/terraform.yml`). From `terraform show -json`:

| Address | Action |
| --- | --- |
| `module.ce_node["eastus01"].azurerm_linux_virtual_machine.this` | update |
| `module.ce_node["eastus02"].azurerm_linux_virtual_machine.this` | update |
| `module.ce_node["eastus03"].azurerm_linux_virtual_machine.this` | update |

```
boot_diagnostics: [] -> [{'storage_account_uri': None}]
other changed keys: NONE
```

No replacement, and `boot_diagnostics` is the only key that moves on any of them.

**Pre-existing drift, attributed:** the full plan reads `3 to add, 6 to change,
0 to destroy`. A baseline plan on pristine `main` already reads
`3 to add, 3 to change, 0 to destroy` — three `xcsh_registration_approval`
creations and three `xcsh_securemesh_site_v2` `labels {} -> null` updates that
this branch does not cause. This branch adds exactly the three CE VM updates.

**Not applied yet.** Apply mutates shared live demo infrastructure and would also
converge that unrelated drift, so it needs a decision rather than a default. The
remaining acceptance criteria — `bootDiagnostics.enabled: true` and an
`az serial-console connect` transcript — are gated on it.

## Two local-config hazards fixed on the way

Both were found by this work and both made a fresh worktree either broken or
dangerous:

- **`terraform/.gitignore` was missing entirely.** `*.tfvars` and `backend.hcl`
  were untracked but committable, so one `git add -A` would have published the
  shared state container name and per-engineer values. It nearly did in this
  branch; I caught it staged and reverted before committing. The sibling
  `webapp-api-protection/terraform/.gitignore` already guards these and this
  mirrors it. The root `.gitignore` is governance-managed and covers neither.
- **`.worktreeinclude` added** for those same two files. Without them a new
  worktree cannot `terraform init` a backend or plan at all, and it fails in a way
  that reads as a problem with the branch rather than a missing local file.

`git check-ignore` now confirms both rules fire, and the two files are absent from
this commit.

## Verification

- `terraform test` → 13 passed, 0 failed
- `terraform fmt -check -recursive` → clean
- `tflint --recursive` → exit 0
- `pre-commit run --all-files` → all hooks pass except the pre-existing
  `README.md:23 MD012`, which fails on pristine `main` in a governance-managed
  generated file (reported on `docs-control#795`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
