### PR TITLE
fix(xc-site): declare perf_mode_l7_enhanced jumbo_disabled for provider v3.80.0

### DIFF
--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -65,7 +65,14 @@ resource "xcsh_securemesh_site_v2" "this" {
   }
 
   performance_enhancement_mode {
-    perf_mode_l7_enhanced {}
+    perf_mode_l7_enhanced {
+      # Provider v3.80.0 gave perf_mode_l7_enhanced a {jumbo_disabled | jumbo_enabled}
+      # sub-oneof. F5 materialises jumbo_disabled server-side, so leaving both members
+      # undeclared makes the site land and then re-plan the marker as a removal on
+      # every subsequent plan — it never reaches 0 changes. Declaring the server
+      # default explicitly is what settles it (same fix coverage/smsv2 took in #625).
+      jumbo_disabled {}
+    }
   }
 
   re_select {

--- a/terraform/tests/xc_site.tftest.hcl
+++ b/terraform/tests/xc_site.tftest.hcl
@@ -39,4 +39,30 @@ run "site_and_interface_binding" {
     condition     = xcsh_securemesh_site_v2.this.namespace == "system"
     error_message = "The site must be created in the system namespace."
   }
+
+  # Provider v3.80.0 gave perf_mode_l7_enhanced a {jumbo_disabled | jumbo_enabled}
+  # sub-oneof. F5 materialises jumbo_disabled server-side while a create stores null
+  # for it, so leaving both members undeclared makes the site re-plan the marker as a
+  # change on every plan after the create — it never reaches 0 changes.
+  #
+  # These two assertions pin WHICH member is declared; they cannot catch the member
+  # being dropped entirely, because the mocked provider resolves jumbo_disabled to {}
+  # and jumbo_enabled to null in the plan whether or not the config declares either.
+  # That was verified by running this file against the module with and without the
+  # declaration — both pass. The discriminating check is a live plan, recorded on the
+  # pull request; what is guarded here is a silent switch to the jumbo_enabled arm,
+  # which would change the data path.
+  assert {
+    condition = (
+      xcsh_securemesh_site_v2.this.performance_enhancement_mode.perf_mode_l7_enhanced.jumbo_disabled != null
+    )
+    error_message = "perf_mode_l7_enhanced must declare the jumbo_disabled arm."
+  }
+
+  assert {
+    condition = (
+      xcsh_securemesh_site_v2.this.performance_enhancement_mode.perf_mode_l7_enhanced.jumbo_enabled == null
+    )
+    error_message = "perf_mode_l7_enhanced must NOT select jumbo_enabled: jumbo_disabled is the arm F5 materialises, and switching arms changes the CE data path."
+  }
 }


### PR DESCRIPTION
## What

`terraform/modules/xc-site/main.tf` declared `perf_mode_l7_enhanced {}` with neither
member of the `{jumbo_disabled | jumbo_enabled}` sub-oneof that provider **v3.80.0**
added. A create stores `jumbo_disabled = null` while F5 materialises it server-side, so
every plan after the create proposed the marker again and the site never reached a
0-change plan.

This declares `jumbo_disabled {}` — the arm the sites are already running, so no
behaviour changes and no variable or Terraform-facing rename is needed.
`coverage/smsv2` absorbed the same schema delta in #625 (`l7_jumbo_arm`); the root
`terraform/` stack had not.

## Evidence

Live, registry release **v3.80.0**, `dev_overrides` off (`TF_CLI_CONFIG_FILE` pointed at
a config with only `direct {}`).

`ar-bgp-eastus03` was created **from scratch by this config**, so there is no import or
pre-existing-object explanation for the drift. Plan JSON immediately after its create:

```
BEFORE perf: {"perf_mode_l3_enhanced": null, "perf_mode_l7_enhanced": {"jumbo_disabled": null, "jumbo_enabled": null}}
AFTER  perf: {"perf_mode_l3_enhanced": null, "perf_mode_l7_enhanced": {"jumbo_disabled": {},   "jumbo_enabled": null}}
```

The API read-back confirms the server, not Terraform, set it:

```
GET /api/config/namespaces/system/securemesh_site_v2s/ar-bgp-eastus03
spec.performance_enhancement_mode = {"perf_mode_l7_enhanced": {"jumbo_disabled": {}}}
```

The v3.80.0 schema confirms the new arm exists:

```
$ terraform providers schema -json | ...
perf_mode_l7_enhanced blocks: ['jumbo_disabled', 'jumbo_enabled']
```

All three `ar-bgp-eastus01/02/03` sites showed the same `~ performance_enhancement_mode`
drift before this change.

## On the tests (please read — the failing-test-first is only partial)

Two assertions were added to `terraform/tests/xc_site.tftest.hcl`. Being straight about
what they do and do not cover:

- They pin **which** arm is declared. The `jumbo_enabled == null` assertion genuinely
  fails if someone switches arms, which would change the CE data path.
- Neither can fail when the member is **dropped entirely** — the regression this PR
  fixes. Under `mock_provider "xcsh" {}` the plan resolves `jumbo_disabled` to `{}` and
  `jumbo_enabled` to `null` whether or not the config declares either. That was checked
  by running the file against the module with and without the declaration: both pass.

So the standard failing-test-first could not be reproduced at plan level for this
marker. Rather than assert something that only looks like coverage, the limitation is
written into the test file next to the assertions, and the discriminating evidence is
the live plan above. A structural "every oneof declares exactly one arm" lint would be
the real guard; that is a bigger change than this fix and is not bundled here.

## Local gates

```
terraform fmt -recursive -check -diff   -> clean
terraform validate                      -> Success! The configuration is valid.
terraform test                          -> Success! 13 passed, 0 failed.
tflint --recursive                       -> exit 0
codespell (changed files)                -> clean
```

## Found while verifying, tracked separately — NOT in this PR

Two further blockers surfaced restoring the live demo, both outside this diff:

1. The app namespace `multi-cloud-networking` was deleted out of band and **cannot be
   recreated with the current credential**: `POST /api/web/namespaces` returns `403
   FORBIDDEN` for any name, including a throwaway probe. The token
   (`r.mordasiewicz@f5.com`, tenant `f5-amer-ent-qyyfhhfj`) holds
   `ves-io-power-developer-role` in `system`/`shared`/`default` and admin only in
   `r-mordasiewicz`, with no tenant-level namespace-create right. Without the namespace
   there is no origin pool and no load balancer, so no CE advertises the VIP.
2. `ce_os_version`/`ce_sw_version` cannot be applied to a site whose node has already
   auto-upgraded past the pin: the `PUT` is rejected `400 BAD_REQUEST`, while a `POST`
   with the same body succeeds. Honouring the pin on such a site requires recreating it.

Closes #629
