### PR TITLE
fix(xc): read the app namespace instead of owning it

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -140,22 +140,30 @@ module "client_vm" {
 # F5 XC data-plane (app tier)
 # ---------------------------------------------------------
 
-# The deployment owns its application namespace (origin pool + VIP load balancer
-# live here). Referencing xcsh_namespace.mcn.name from the pool/LB creates the
-# apply-time ordering so the namespace exists before its members. (XC sites/bgp
-# live in the fixed `system` namespace and are unaffected.)
-resource "xcsh_namespace" "mcn" {
-  name        = var.xc_app_namespace
-  description = "MCN CE-HA (BGP/ECMP) demo: origin pool + VIP-advertising load balancer."
+# The application namespace (origin pool + VIP load balancer live here) is an
+# input, never an owned object. This deployment CANNOT create a namespace:
+# POST /api/web/namespaces is 403 for every name with the deploying credential,
+# because namespace creation is tenant-scoped in this shared enterprise tenant
+# (issue #634). A `resource` block therefore expresses semantics the API does not
+# permit, and the only way to make an apply succeed was to import a namespace
+# somebody else owns — which put a personal namespace, and the unrelated demos
+# living in it, on the destroy list (issue #637).
+#
+# Reading it instead means Terraform never creates, updates or destroys it. The
+# read still gives the pool and the load balancer their apply-time ordering: they
+# take their namespace from this data source, so a missing namespace fails the
+# plan loudly rather than half-applying. `namespace` is empty because a namespace
+# object is not itself contained in a namespace (the API returns
+# `metadata.namespace: ""` for one).
+data "xcsh_namespace" "mcn" {
+  name      = var.xc_app_namespace
+  namespace = ""
 }
 
 resource "xcsh_origin_pool" "this" {
   name        = var.origin_pool_name
-  namespace   = var.xc_app_namespace
+  namespace   = data.xcsh_namespace.mcn.name
   description = "MCN reference origin pool -> ${var.origin_ip}:${var.origin_port}"
-
-  # xcsh_namespace.mcn owns var.xc_app_namespace; depend on it so it exists first.
-  depends_on = [xcsh_namespace.mcn]
 
   port = var.origin_port
 
@@ -173,10 +181,8 @@ resource "xcsh_origin_pool" "this" {
 
 resource "xcsh_http_loadbalancer" "this" {
   name        = var.lb_name
-  namespace   = var.xc_app_namespace
+  namespace   = data.xcsh_namespace.mcn.name
   description = "BGP/ECMP HA: custom VIP ${var.vip} advertised from every CE site."
-
-  depends_on = [xcsh_namespace.mcn]
 
   domains = [var.lb_domain]
 
@@ -205,7 +211,7 @@ resource "xcsh_http_loadbalancer" "this" {
 
   default_route_pools {
     pool {
-      namespace = var.xc_app_namespace
+      namespace = data.xcsh_namespace.mcn.name
       name      = xcsh_origin_pool.this.name
     }
     weight   = 1

--- a/terraform/tests/http_lb.tftest.hcl
+++ b/terraform/tests/http_lb.tftest.hcl
@@ -6,24 +6,31 @@ mock_provider "azurerm" {}
 mock_provider "azuread" {}
 mock_provider "xcsh" {}
 
+variables {
+  deployer = "tester"
+  # enable_bgp=false: work around the provider 63-char object-ref name cap (see
+  # main.tf). The LB/advertise/origin-pool under test are independent of bgp.
+  enable_bgp     = false
+  ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+  # Pinned rather than inherited: `terraform test` also reads the gitignored
+  # terraform.tfvars, so an assertion against a hard-coded namespace literal would
+  # pass in CI and fail for any engineer whose app namespace differs.
+  xc_app_namespace = "multi-cloud-networking"
+}
+
 run "loadbalancer_advertise_and_pool" {
   command = plan
 
   variables {
     ce_count = 3
-    deployer = "tester"
-    # enable_bgp=false: work around the provider 63-char object-ref name cap (see
-    # main.tf). The LB/advertise/origin-pool under test are independent of bgp.
-    enable_bgp     = false
-    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
   }
 
   # The dynamic advertise_where block (one entry per CE site) is exercised by
   # this run planning cleanly at N=3 — an expansion error would fail the run.
 
   assert {
-    condition     = xcsh_http_loadbalancer.this.namespace == "multi-cloud-networking"
-    error_message = "LB must live in the app namespace multi-cloud-networking."
+    condition     = xcsh_http_loadbalancer.this.namespace == var.xc_app_namespace
+    error_message = "LB must live in the app namespace named by xc_app_namespace."
   }
 
   assert {
@@ -32,12 +39,57 @@ run "loadbalancer_advertise_and_pool" {
   }
 
   assert {
-    condition     = xcsh_origin_pool.this.namespace == "multi-cloud-networking"
-    error_message = "Origin pool must live in the app namespace multi-cloud-networking."
+    condition     = xcsh_origin_pool.this.namespace == var.xc_app_namespace
+    error_message = "Origin pool must live in the app namespace named by xc_app_namespace."
   }
 
   assert {
     condition     = xcsh_origin_pool.this.port == 80
     error_message = "Origin pool port should be 80."
+  }
+}
+
+# The app namespace is read, never owned (#634, #637): a managed xcsh_namespace
+# resource would put a namespace this stack cannot recreate — and every unrelated
+# object living in it — on the destroy list. Sourcing the pool/LB namespace from
+# the data source is what keeps it off that list, so assert the wiring: these
+# references stop resolving the moment anyone reintroduces the resource.
+run "app_namespace_is_read_not_owned" {
+  command = plan
+
+  variables {
+    ce_count = 1
+  }
+
+  assert {
+    condition     = data.xcsh_namespace.mcn.name == var.xc_app_namespace
+    error_message = "The app namespace must be looked up by the xc_app_namespace input."
+  }
+
+  # A namespace object is not itself contained in a namespace; the API reports
+  # metadata.namespace as "" for one, so the lookup must ask for exactly that.
+  assert {
+    condition     = data.xcsh_namespace.mcn.namespace == ""
+    error_message = "The namespace lookup must use an empty containing namespace."
+  }
+
+  assert {
+    condition     = xcsh_origin_pool.this.namespace == data.xcsh_namespace.mcn.name
+    error_message = "The origin pool must take its namespace from the data source, not a bare variable."
+  }
+
+  assert {
+    condition     = xcsh_http_loadbalancer.this.namespace == data.xcsh_namespace.mcn.name
+    error_message = "The LB must take its namespace from the data source, not a bare variable."
+  }
+
+  # Written as a for-expression because `terraform test` accepts only attribute
+  # traversals in a reference, never an index step.
+  assert {
+    condition = alltrue([
+      for route_pool in xcsh_http_loadbalancer.this.default_route_pools :
+      route_pool.pool.namespace == data.xcsh_namespace.mcn.name
+    ])
+    error_message = "The default route pool reference must resolve through the data source."
   }
 }

--- a/terraform/variables_xc.tf
+++ b/terraform/variables_xc.tf
@@ -3,9 +3,14 @@
 # ---------------------------------------------------------
 
 variable "xc_app_namespace" {
-  description = "F5 XC namespace for the app-tier objects (origin pool + HTTP load balancer)."
+  description = "Name of a PRE-EXISTING F5 XC namespace to place the app-tier objects (origin pool + HTTP load balancer) in. This deployment reads the namespace, it never creates or deletes it: namespace creation is tenant-scoped and 403s for the deploying credential (issue #634)."
   type        = string
   default     = "multi-cloud-networking"
+
+  validation {
+    condition     = length(var.xc_app_namespace) > 0
+    error_message = "xc_app_namespace must name an existing namespace; it is looked up, not created."
+  }
 }
 
 variable "origin_pool_name" {


### PR DESCRIPTION
Closes #637

## Problem

`xcsh_namespace.mcn` declared **create-and-own** semantics that the API does not
grant. `POST /api/web/namespaces` returns 403 for *any* name with the deploying
credential (#634), so the only way an apply could ever succeed was to import a
namespace somebody else owns. It did: `r-mordasiewicz`, a personal namespace that
also holds the unrelated `acme-bankexample-lb` and `acme-bankexample-pool`.

A destroy would therefore have taken the Acme demo with it. Destroy plan on `main`:

```text
  # xcsh_namespace.mcn will be destroyed
Plan: 0 to add, 0 to change, 47 to destroy.
```

## Fix

Reference the namespace instead of owning it.

- `resource "xcsh_namespace" "mcn"` → `data "xcsh_namespace" "mcn"`. The data source
  exists in provider v3.80.0 (the pinned floor is `>= 3.77.5`, already satisfied).
- The origin pool, the load balancer, and the default route pool reference all take
  their namespace from `data.xcsh_namespace.mcn.name`. That keeps the apply-time
  ordering the two `depends_on` lines used to provide — a missing namespace now
  fails the plan loudly instead of half-applying — so both `depends_on` lines go.
- The lookup passes `namespace = ""` because a namespace object is not itself
  contained in a namespace; `GET /api/web/namespaces/<name>` returns
  `metadata.namespace: ""`, and a non-empty value would fail the data source
  consistency check.
- `xc_app_namespace` is documented as a pre-existing input and gets a non-empty
  validation.

## Migration (non-destructive — no object deleted)

State backup taken first, then:

```console
$ terraform state pull > /tmp/mcn-state-backup-20260726T104020Z.json   # serial 56, 52 resources
$ terraform state rm xcsh_namespace.mcn
Removed xcsh_namespace.mcn
Successfully removed 1 resource instance(s).
```

Already performed against the shared remote state; no `terraform destroy` was run at
any point.

## Verification

**AC1 — no `xcsh_namespace` resource remains.** `grep -rn 'resource "xcsh_namespace"' terraform/`
returns nothing; the only occurrence is the data source.

**AC2 — plan is 0-change against the live demo.**

```text
No changes. Your infrastructure matches the configuration.
```

**AC3 — destroy plan proposes no namespace deletion.** Inspection only, never applied:

```console
$ terraform plan -destroy -refresh=false -lock=false   # NOT applied
Plan: 0 to add, 0 to change, 46 to destroy.
```

Diff against the `main` destroy plan is exactly one line — `xcsh_namespace.mcn will be
destroyed` is gone, 47 → 46. No `acme-bankexample-*` object appears in either plan
(they were never in state). The XC objects still on the destroy list are the ones this
stack really does create:

```text
  # xcsh_http_loadbalancer.this will be destroyed
  # xcsh_origin_pool.this will be destroyed
  # xcsh_token.ce will be destroyed
  # module.xc_site["eastus0N"].xcsh_bgp.this[0] will be destroyed
  # module.xc_site["eastus0N"].xcsh_registration_approval.this[0] will be destroyed
  # module.xc_site["eastus0N"].xcsh_securemesh_site_v2.this will be destroyed
```

**AC4 — apply no longer touches any namespace field.** There is no managed namespace
object, so no create, update, or destroy of one can be planned.

**AC5 — tests.** `terraform test`: 14 passed, 0 failed. `terraform fmt -check -recursive`,
`terraform validate`, `tflint --recursive`, `codespell`, and the repo hygiene gate are clean.

## Tests

`tests/http_lb.tftest.hcl` gains `app_namespace_is_read_not_owned`, which asserts the
pool, the load balancer, and the default route pool reference all resolve through the
data source. It fails on the pre-fix config (`Reference to undeclared resource`), so
reintroducing the resource cannot pass the gate.

The existing assertions were also fixed at the source: they compared against the
hard-coded literal `multi-cloud-networking`, which passed in CI (no `terraform.tfvars`)
but failed for any engineer whose app namespace differs — a pre-existing local failure
on `main`. They now compare against `var.xc_app_namespace`, pinned in a file-level
`variables` block that also de-duplicates the shared run inputs.

## Demo health after the migration

Unchanged and healthy — nothing was destroyed or modified:

- Sites `ar-bgp-eastus01/02/03`: all `ONLINE`.
- 3-way ECMP: Azure Route Server learns `10.250.0.10/32` from `10.0.1.4`, `10.0.1.5`
  and `10.0.1.6` (AS 64512) on both Route Server instances.
- VIP: 10/10 HTTP 200 from `ar-ecmp-client`.
- `acme-bankexample-lb` and `acme-bankexample-pool` still present and untouched.

## Note for a human

The earlier apply overwrote the namespace's description to
`"MCN CE-HA (BGP/ECMP) demo: origin pool + VIP-advertising load balancer."`. The
original value is unknown, so it is deliberately **not** restored here — set it back
by hand if it mattered. Terraform no longer manages that field.

The `xc_app_namespace` default is still `multi-cloud-networking`, a namespace that was
deleted out of band and cannot be recreated (#634). Left alone deliberately: the honest
alternatives are a personal namespace (worse) or no default at all (a wider change to
every root plan test). Supply your own namespace in `terraform.tfvars`, as
`terraform.tfvars.example` already shows.
