### PR TITLE
fix(docs): restore the access tier missing from the deployed llms.txt hierarchy

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,4 +1,4 @@
 {
-  "promote": ["**/index", "**/customer-edge/access/**"],
+  "promote": ["**/customer-edge/access"],
   "demote": ["**/customer-edge/commands/**"]
 }


### PR DESCRIPTION
Closes #649

## Problem

The entire `access` subtree was missing from the deployed llms.txt hierarchy.
`/_llms-txt/en/customer-edge/access.txt` and its children returned **404**, while every
HTML page built fine (200). The `customer-edge` tier listed only index, workflows and
commands — with `access`, the tier that explains how to reach a node at all, absent.

Found by checking the deployed site rather than trusting a local simulation.

## Root cause

Two things combined.

**Astro collapses an index file to the directory path.**
`docs/en/customer-edge/access/index.mdx` has the id `en/customer-edge/access`, not
`en/customer-edge/access/index`. So the previous promote pattern
`**/customer-edge/access/**` matched the two leaf pages and **not their own parent**.

**A parent that sorts after its children silently destroys the subtree.**
`buildTierTree` walks entries in sort order. The promoted leaves came first and created
the `access` directory node. The parent then arrived as a two-segment leaf and

```ts
current.children.set(leafSegment, leaf);
```

**overwrote the DirectoryNode**, discarding both children with it.

`commands` and `workflows` escaped only by accident of ordering: demoting the children of
`commands` leaves its parent ahead of them, and `workflows` matches no pattern at all.

## Fix

Promote the parent index itself, so it stays ahead of its children and the existing
leaf-to-directory branch converts it rather than a later write clobbering it.

```diff
-  "promote": ["**/index", "**/customer-edge/access/**"],
+  "promote": ["**/customer-edge/access"],
```

`**/index` is also dropped: with index collapsing, no id ends in `/index`, so it matched
nothing.

## Verification

Against the plugin's own `buildTierTree`, with **real** Astro id semantics:

| Config | access children | order under `customer-edge` |
| --- | --- | --- |
| previous (deployed) | **0** | index, workflows, commands |
| this PR | **3** | index, access, workflows, commands |

The previous row reproduces the deployed failure exactly, which is what confirms the
model is now right.

## What I got wrong

My earlier verification of this file modelled ids as `.../access/index`, which do not
exist. It confirmed a hierarchy the build could never produce, and it passed. Simulating
a build is only as good as the model of its inputs; the deployed output is what settles
it. Reported separately as a plugin defect, because a config that promotes children above
their parent should not be able to silently delete a subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

