### PR TITLE
chore(deps): floor the provider at >= 3.81.1 so approvals can succeed

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -17,7 +17,15 @@ terraform {
       # workaround in modules/xc-site: import-marker suppression for the nested
       # interface_list `labels {}` block (#1244) and preservation of a
       # config-declared empty top-level metadata `labels` map (#1286).
-      version = ">= 3.77.5"
+      # >= 3.81.1 is where xcsh_registration_approval first WORKS. Below it every
+      # approve omitted the required `passport` and the API returned 500
+      # "Validation approval: Passport is required" (xcsh#1355), so
+      # approve_registration = true — the default, and the whole point of the
+      # hands-off two-phase deploy — could never complete; approvals had to be
+      # POSTed out of band and imported. The provider now derives `passport`
+      # server-side (reads the sibling registration and echoes it verbatim), so
+      # it is not a Terraform attribute and modules/xc-site needs no change.
+      version = ">= 3.81.1"
     }
     # Azure providers deploy the hub VNet, Azure Route Server, the CE VMs and the
     # test client. azuread is read-only (resolves the deployer identity for naming/tags).


### PR DESCRIPTION
## What

Raises the `xcsh` provider floor from `>= 3.77.5` to `>= 3.81.1`, and records why in the existing rationale comment.

## Why

`>= 3.81.1` is the first version where `xcsh_registration_approval` actually works. Below it, every approve request omitted the required `passport` and the API returned:

```
500  "Validation approval: Passport is required"
```

So a deployment that merely satisfied the old floor could never complete `approve_registration = true` — the default, and the entire point of the hands-off two-phase deploy. During the recent demo restore all three approvals had to be POSTed out of band and then `terraform import`ed.

Root cause was in the provider's action codegen (terraform-provider-xcsh#1355): `tools/pkg/schema/extract.go` kept an action request property only when `prop.Type == "string"`, so the object-typed `passport` was silently discarded and the generated resource had no way to send it.

**No HCL change is needed in `modules/xc-site`.** `passport` did not become an attribute — the provider derives it server-side, reading the sibling registration and echoing the value back verbatim, so the resource's surface is unchanged.

## Verification

Run locally against the live N=3 demo:

- `terraform init` → `Installed f5-sales-demo/xcsh v3.81.1`
- `terraform validate` → `Success! The configuration is valid.`
- `terraform test` → `Success! 14 passed, 0 failed.`
- `terraform plan` → `No changes. Your infrastructure matches the configuration.`
- `terraform fmt -check -recursive`, `tflint --recursive`, `codespell` → clean

Note these were run with `TF_CLI_CONFIG_FILE` pointing at a `direct {}`-only provider config: `~/.terraformrc` carries a `dev_overrides` entry for a stale local build, which otherwise masks the registry release and fails with `Blocks of type "jumbo_disabled" are not expected here`.

The upstream fix is live-proven on a genuinely fresh CE (disposable RG/site/token; the `ar-bgp-eastus0N` demo untouched and all three still ONLINE): control request 500s on the missing passport, the fixed provider's capture shows `POST .../approve body_keys=name,namespace,passport,state`, the registration walks `PENDING → ADMITTED → ONLINE`, and import + re-plan is `No changes.`

## Scope

Existing state is unaffected — the demo's approvals are already in state and its registrations are ONLINE. This floor matters for the next **fresh** CE, where it restores hands-off approval and retires the out-of-band-passport + `terraform import` workaround described in #636. Re-approving an already-ONLINE registration remains a separate known condition (terraform-provider-xcsh#1278).

Closes #641
