### PR TITLE
S8: audit the SMSv2 coverage matrix against provider v3.81.1 and classify every remaining gap

### DIFF
--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -90,7 +90,7 @@ Columns:
 | dc_cluster_group_sli{} (ref, s2s_sli_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_sli_arm=dc_cluster_group_sli`; plan-only — ObjectRefType, ref-dependent; plans clean |
 | dc_cluster_group_slo{} (ref, s2s_slo_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_slo_arm=dc_cluster_group_slo`; plan-only — ObjectRefType, ref-dependent; plans clean |
 | site_mesh_group_on_slo{site_mesh_group ref} (s2s_slo_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_slo_arm=site_mesh_group_ref`; plan-only — `site_mesh_group` ObjectRefType, ref-dependent; plans clean |
-| segment_vrf.segment_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4 `segment_vrf_arm=inline`; plan-only — needs a Segment object ref the provider cannot yet inject (specs #1053); validator `IPv4Validator()` (reject `"300.2.2.2"`, reject-segment-nameserver) proven at plan |
+| segment_vrf.segment_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4 `segment_vrf_arm=inline`; plan-only — needs a Segment object ref the provider cannot yet inject (api-specs-enriched #1053); validator `IPv4Validator()` (reject `"300.2.2.2"`, reject-segment-nameserver) proven at plan |
 <!-- S5: site-mode oneof arms (perf / os / sw / offline / re_select / upgrade / admin; enum selectors; live cycle uses -var extended_arms=false) -->
 | performance_enhancement_mode.perf_mode_l3_enhanced{} | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `perf_arm=perf_mode_l3_enhanced`; carries its own jumbo sub-oneof, spelled DIFFERENTLY from the l7 pair (`jumbo`/`no_jumbo`, not `jumbo_enabled`/`jumbo_disabled`) — rows below; live apply→idempotent→import (0-change)→destroy |
 | perf_mode_l3_enhanced.no_jumbo{} (jumbo sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | S8 `l3_jumbo_arm=no_jumbo` (default). S5 rendered this marker unconditionally; S8 made it a selector and re-verified live on v3.81.1: read-back `{"perf_mode_l3_enhanced":{"no_jumbo":{}}}`, apply→0-change re-plan→`state rm`→import→0-change plan→destroy |
@@ -207,7 +207,7 @@ Columns:
 - **S4c plan-only (single-node 400)** — `enable_ha` and `enable_management_network` 400 on the
   single-node `azure` probe; proven at PLAN.
 - **`segment_vrf` plan-only** — a live `segment_vrf` needs a Segment object reference the provider
-  cannot yet inject (specs #1053); proven at PLAN, and its `segment_config.nameserver`
+  cannot yet inject (api-specs-enriched #1053); proven at PLAN, and its `segment_config.nameserver`
   `IPv4Validator()` reject at plan (reject-segment-nameserver, `"300.2.2.2"`).
 - **Stale `log_receiver` avoided** — logs are driven via `log_receiver_with_net`, never the stale
   top-level `log_receiver` field (provider #1256).
@@ -382,7 +382,7 @@ hits). That matches the S3 note's deferral to api-specs-enriched #1049: it needs
 a regeneration, so it is a provider gap, not a probe gap.
 
 Likewise `segment_vrf` has **no `segment` ObjectRef attribute at all** — the exclusion recorded in
-the S4 notes ("needs a Segment object ref the provider cannot yet inject", specs #1053) is
+the S4 notes ("needs a Segment object ref the provider cannot yet inject", api-specs-enriched #1053) is
 structurally accurate, not an excuse: there is nowhere to put the reference.
 
 ### Caveats this audit will not sign off

--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -355,6 +355,14 @@ to "excluded" to make the table look finished.
 Totals: 1 n/a, 8 excluded with a reason, 5 partially covered, **155 still open**. Every open row
 above is a candidate slice, not a defect — but the table is no longer silent about them.
 
+All 155 open arms are tracked, so closing epic terraform-provider-xcsh#1207 does not drop them:
+
+| Tracking issue | Families | Arms |
+|---|---|---|
+| mcn #646 | J, L, M, N — `local_vrf` oneofs + the six `SiteStaticRoutesListType` subtrees | 96 |
+| mcn #647 | K, O, P, Q — SLI `network_option`, `ipv6_auto_config.router`, `cluster_static_ip`, bond remainder | 33 |
+| mcn #648 | B, C, D, E, F, H, I — `advanced_delivery`/`log_anonymization` oneofs, `tunnel_*`, `annotations`/`disable`, `custom_proxy` remainder, ref `tenant` | 26 |
+
 Two details that would not fit in a table cell:
 
 - **Family J's shape.** Each of the six `SiteStaticRoutesListType` instances carries `attrs`,

--- a/coverage/smsv2-coverage-matrix.md
+++ b/coverage/smsv2-coverage-matrix.md
@@ -11,6 +11,13 @@ Columns:
 - **Import-clean** — `terraform import` of the object re-plans with 0 changes.
 - **Notes** — slice that covers the arm and any caveats.
 
+> **Read the S8 completeness audit before quoting this table as "exhaustive."** The rows below are
+> the arms the slices *worked*; they are not the resource. A mechanical enumeration of the
+> `xcsh_securemesh_site_v2` schema finds **997 arms**, of which **312** are in scope for this probe
+> and **143** are rendered by it. The other **169** are classified — covered elsewhere, excluded
+> with a reason, or **still open** — in [S8 completeness audit](#s8-completeness-audit-provider-v3811)
+> at the bottom of this file. Nothing here is evidence about an arm that has no row.
+
 | Branch / leaf | Structural | Validated | Applied | Idempotent | Import-clean | Notes |
 |---|---|---|---|---|---|---|
 | azure.not_managed.node_list[].interface_list[] | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1 (live N=3) |
@@ -21,20 +28,20 @@ Columns:
 | ethernet_interface.mac | ✅ | ✅ | ✅ | ✅ | ✅ | S2: validator `MACValidator()` (reject `"not-a-mac"`); live-applied on the base eth0 with a valid MAC (`7C-1E-52-7F-F8-12`), idempotent; whole-object import re-plans 0-change (S7); gated by `string_arms` |
 | static_ip.ip_address (CIDR) | ✅ | ✅ | ✅ | ✅ | ✅ | S2: validator `CIDRValidator()` (reject `"999.999.0.0/8"`); static_ip is the `dhcp_client` address-oneof sibling, live-applied+idempotent (`10.0.1.5/24`), gated by `string_arms`; whole-object import re-plans 0-change (S7) |
 | static_ip.default_gw (IP) | ✅ | ✅ | ✅ | ✅ | ✅ | S2: validator `IPValidator()` (reject `"10.0.0.256"`); applied live with ip_address (`10.0.1.1`); whole-object import re-plans 0-change (S7) |
-| local_vrf.sli_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject `"300.1.1.1"`) proven at plan; NOT live-applied — `sli_config` is a distinct `local_vrf` oneof arm from the base `default_sli_config`; gated behind `vrf_string_arms` (default false), plan-validated only (live is an S3 oneof concern) |
-| local_vrf.sli_config.vip (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject the IPv6 literal `"2001:db8::1"`, proving IPv4-specificity); plan-validated only, gated behind `vrf_string_arms` (S3 oneof, as nameserver) |
+| local_vrf.sli_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: `IPv4Validator()` (reject `"300.1.1.1"`) proven at plan; NOT live — `sli_config` is a distinct `local_vrf` oneof arm from `default_sli_config`, gated behind `vrf_string_arms`. **S8: its "live is an S3 concern" deferral was never honoured** — S3 did only the *interface* oneofs, so the `local_vrf` oneof stays open (S8 gaps L/M) |
+| local_vrf.sli_config.vip (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S2: validator `IPv4Validator()` (reject the IPv6 literal `"2001:db8::1"`, proving IPv4-specificity); plan-validated only, gated behind `vrf_string_arms`. **S8: same never-honoured deferral as `nameserver` above** |
 <!-- remaining toggle/interface/services arms seeded ⬜ for S3–S5 -->
 | block_all_services{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
 | disable_ha{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 (S0 probe) |
-| dns_ntp_config.f5_dns_default{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: custom_dns S3 |
-| dns_ntp_config.f5_ntp_default{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: custom_ntp S3 |
-| local_vrf.default_config{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
-| local_vrf.default_sli_config{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
-| logs_streaming_disabled{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: log_receiver S4 |
-| no_forward_proxy{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: custom/active fwd proxy S4 |
-| no_network_policy{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe; oneof: active_network_policies S4 |
-| no_s2s_connectivity_sli{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
-| no_s2s_connectivity_slo{} | ✅ | ➖ | ✅ | ✅ | ⬜ | S0 probe |
+| dns_ntp_config.f5_dns_default{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alt `custom_dns` covered in S4 (row below). Import-clean flipped in S8: this default arm was in the object on both S8 `perf_mode_l3_enhanced` probes, each of which imported and re-planned 0-change |
+| dns_ntp_config.f5_ntp_default{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alt `custom_ntp` covered in S4 (row below). Import-clean flipped in S8, same evidence as `f5_dns_default` |
+| local_vrf.default_config{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; the `slo_config` oneof sibling is still open (S8 gap L). Import-clean flipped in S8 (both l3 probes imported 0-change with this arm present) |
+| local_vrf.default_sli_config{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; the `sli_config` oneof sibling is plan-only (rows above). Import-clean flipped in S8, same evidence |
+| logs_streaming_disabled{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alt `log_receiver_with_net` is plan-only S4b. Import-clean flipped in S8, same evidence |
+| no_forward_proxy{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alt `active_forward_proxy_policies` is plan-only S4b. Import-clean flipped in S8, same evidence |
+| no_network_policy{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alt `active_enhanced_firewall_policies` is plan-only S4b. Import-clean flipped in S8, same evidence |
+| no_s2s_connectivity_sli{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alt `dc_cluster_group_sli` is plan-only S4b. Import-clean flipped in S8, same evidence |
+| no_s2s_connectivity_slo{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 probe; oneof alts `dc_cluster_group_slo` / `site_mesh_group_on_slo` covered in S4. Import-clean flipped in S8, same evidence |
 | offline_survivability_mode.no_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `offline_arm=no_offline_survivability_mode` (default); defaults cycle apply→idempotent→import (0-change)→destroy; oneof alt: enable S5 |
 | performance_enhancement_mode.perf_mode_l7_enhanced{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `perf_arm=perf_mode_l7_enhanced` (default); defaults cycle round-trip (0-change); carries its own jumbo sub-oneof since v3.80.0 (rows below); oneof alt: perf_mode_l3_enhanced S5 |
 | re_select.geo_proximity{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `re_select_arm=geo_proximity` (default); defaults cycle round-trip (0-change); oneof alt: specific_re S5 |
@@ -42,9 +49,9 @@ Columns:
 | software_settings.sw.default_sw_version{} | ✅ | ➖ | ✅ | ✅ | ✅ | S0 base arm; S5 `sw_arm=default_sw_version` (default); defaults cycle round-trip (0-change); oneof alt: volterra_software_version S5 |
 | node_list[].type (Control/Worker) | ✅ | ✅ | ✅ | ✅ | ✅ | iter-1 live; S2: validator `OneOf("Control", "Worker")` (reject `"Bogus"`); the valid `Worker` arm plans clean and `Control` applied live |
 | interface_list.ethernet_interface{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; block arm (its `mac` leaf → Validated ✅, row above); oneof vs vlan/dedicated S3 |
-| interface_list.network_option.site_local_network{} | ✅ | ⬜ | ✅ | ✅ | ✅ | iter-1; oneof: SLI/inside S3 |
+| interface_list.network_option.site_local_network{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1; empty marker, nothing to validate. **S8: the "oneof: SLI/inside S3" deferral was never honoured** — the `site_local_inside_network{}` sibling is still open (S8 gap P); S3 selected only `site_local_network`, so this oneof has one of two members covered |
 | interface_list.dhcp_client{} | ✅ | ➖ | ✅ | ✅ | ✅ | iter-1 + S3 `address_arm=dhcp_client`; block arm; the `static_ip` address-oneof sibling → Validated ✅ + Applied ✅ (rows above); live-applied+idempotent, whole-object import re-plans 0-change (S7) |
-| labels (top-level metadata map) | ✅ | ➖ | ✅ | ✅ | ✅ | S7: `ignore_changes` removed; xcsh #1286 preserves a config-declared `labels = {}` on post-apply read-back (verified live: apply→plan "No changes"). Import still cannot see config, so the module sends `null` when the map is empty (verified: a literal `{}` re-plans `+ labels = {}` post-import) |
+| labels (top-level metadata map) | ✅ | ➖ | ✅ | ✅ | ✅ | S7: `ignore_changes` removed; xcsh #1103 **and** #1244 are both fixed and released — neither is still an open blocker. #1286 preserves a config-declared `labels = {}` on read-back. **`length(var.labels) > 0 ? var.labels : null` is LOAD-BEARING — never reduce it to a bare `var.labels`** (see the S7 note). |
 <!-- S3: interface / addressing oneof arms (enum selectors; live cycle uses -var extended_arms=false) -->
 | interface_list.static_ip{} (address_choice) | ✅ | ✅ | ✅ | ✅ | ✅ | S3 `address_arm=static_ip` (default); ip_address/default_gw validated (rows above); live-applied+idempotent, whole-object import re-plans 0-change (S7) |
 | interface_list.no_ipv4_address{} (address_choice) | ✅ | ➖ | ✅ | ✅ | ✅ | S3 `address_arm=no_ipv4_address`; empty marker; live apply→idempotent→import (0-change)→destroy |
@@ -85,14 +92,16 @@ Columns:
 | site_mesh_group_on_slo{site_mesh_group ref} (s2s_slo_choice) | ✅ | ➖ | ⬜ | ➖ | ➖ | S4 `s2s_slo_arm=site_mesh_group_ref`; plan-only — `site_mesh_group` ObjectRefType, ref-dependent; plans clean |
 | segment_vrf.segment_config.nameserver (IPv4) | ✅ | ✅ | ⬜ | ➖ | ➖ | S4 `segment_vrf_arm=inline`; plan-only — needs a Segment object ref the provider cannot yet inject (specs #1053); validator `IPv4Validator()` (reject `"300.2.2.2"`, reject-segment-nameserver) proven at plan |
 <!-- S5: site-mode oneof arms (perf / os / sw / offline / re_select / upgrade / admin; enum selectors; live cycle uses -var extended_arms=false) -->
-| performance_enhancement_mode.perf_mode_l3_enhanced{no_jumbo{}} | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `perf_arm=perf_mode_l3_enhanced`; renders the `no_jumbo{}` sub-oneof member; live apply→idempotent→import (0-change)→destroy |
+| performance_enhancement_mode.perf_mode_l3_enhanced{} | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `perf_arm=perf_mode_l3_enhanced`; carries its own jumbo sub-oneof, spelled DIFFERENTLY from the l7 pair (`jumbo`/`no_jumbo`, not `jumbo_enabled`/`jumbo_disabled`) — rows below; live apply→idempotent→import (0-change)→destroy |
+| perf_mode_l3_enhanced.no_jumbo{} (jumbo sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | S8 `l3_jumbo_arm=no_jumbo` (default). S5 rendered this marker unconditionally; S8 made it a selector and re-verified live on v3.81.1: read-back `{"perf_mode_l3_enhanced":{"no_jumbo":{}}}`, apply→0-change re-plan→`state rm`→import→0-change plan→destroy |
+| perf_mode_l3_enhanced.jumbo{} (jumbo sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | **S8, new** `l3_jumbo_arm=jumbo`; empty marker. Was the one unselected member of a covered oneof at the end of S7. Live on v3.81.1: read-back `{"perf_mode_l3_enhanced":{"jumbo":{}}}` (genuinely persisted, not defaulted), apply→0-change re-plan→`state rm`→import→0-change plan→destroy |
 | perf_mode_l7_enhanced.jumbo_disabled{} (jumbo sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | S7 `l7_jumbo_arm=jumbo_disabled` (default); sub-oneof new in provider v3.80.0; the server materializes this marker, so declaring it is what keeps the object import-clean; live apply→idempotent→import (0-change)→destroy |
 | perf_mode_l7_enhanced.jumbo_enabled{} (jumbo sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | S7 `l7_jumbo_arm=jumbo_enabled`; empty marker; live apply→idempotent→import (0-change)→destroy; read-back returns `jumbo_enabled` |
 | software_settings.os.operating_system_version | ✅ | ✅ | ✅ | ✅ | ✅ | S5 `os_arm=operating_system_version` (`9.2024.6`); validator `LengthAtMost(20)` (reject 21-char, reject-os-version); create-only leaf — live apply→idempotent→import round-trips 0-change (0-change)→destroy |
 | software_settings.sw.volterra_software_version | ✅ | ✅ | ✅ | ✅ | ✅ | S5 `sw_arm=volterra_software_version` (`crt-20250613-3382`); validator `LengthAtMost(20)` (reject 21-char, reject-sw-version); create-only leaf — live round-trips 0-change (0-change) |
 | offline_survivability_mode.enable_offline_survivability_mode{} | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `offline_arm=enable_offline_survivability_mode`; empty marker; live apply→idempotent→import (0-change)→destroy |
 | upgrade_settings...enable_upgrade_drain{} (kubernetes_upgrade_drain) | ✅ | ✅ | ✅ | ✅ | ✅ | S5 `upgrade_drain_arm=enable_upgrade_drain`; recon expected 400 (k8s worker-drain on non-k8s node) but the single-node `azure` probe ACCEPTS it — reclassified live; renders drain leaves + `disable_vega_upgrade_mode{}`; apply→idempotent→import (0-change)→destroy |
-| enable_upgrade_drain.drain_max_unavailable_node_count (1-5000) | ✅ | ✅ | ✅ | ✅ | ✅ | S5: validator `Between(1, 5000)` (reject 5001, reject-drain-count); applied live via enable_upgrade_drain (default 1) |
+| enable_upgrade_drain.drain_max_unavailable_node_count (1-5000) | ✅ | ✅ | ✅ | ✅ | ✅ | S5: `Between(1, 5000)`, upper reject 5001 (reject-drain-count); applied live via enable_upgrade_drain (default 1). **S8 closed the LOWER bound**: reject-drain-count-min pushes 0, so both bounds are asserted — a regression dropping the minimum used to pass |
 | enable_upgrade_drain.drain_node_timeout (0-900) | ✅ | ✅ | ✅ | ✅ | ✅ | S5: validator `Between(0, 900)` (reject 901, reject-drain-timeout); applied live via enable_upgrade_drain (default 300) |
 | enable_upgrade_drain.disable_vega_upgrade_mode{} (vega sub-oneof) | ✅ | ➖ | ✅ | ✅ | ✅ | S5 `vega_arm=disable_vega_upgrade_mode` (default); empty marker; applied live via enable_upgrade_drain; alt `enable_vega_upgrade_mode` plans clean |
 | admin_user_credentials{ssh_key, admin_password clear_secret_info} | ✅ | ✅ | ⬜ | ➖ | ➖ | S5 `admin_creds=true`; plan-only — `[BAD_REQUEST]` 400 live on the single-node `azure` probe (recon expected live, reclassified); `ssh_key` `LengthAtMost(8192)` reject-proven at plan; dummy `string:///<base64>` secret (no real secret committed) |
@@ -101,17 +110,23 @@ Columns:
 **S1 notes (numeric-leaf input validation):**
 
 - **How "Validated" is proven** — `coverage/smsv2/verify.sh` drives `terraform test` with a
-  mocked `xcsh` provider (credential-free; the real v3.75.0 schema validators still fire at
-  plan). `validation.tftest.hcl` asserts valid bounds plan clean; `reject-tests/*.tftest.hcl`
+  mocked `xcsh` provider (credential-free; the real schema validators still fire at plan — the
+  version is whatever `terraform init` resolved against the floor in `coverage/smsv2/versions.tf`,
+  the only tracked pin, and S8 removed the drifted per-file copies of that number).
+  `validation.tftest.hcl` asserts valid bounds plan clean; `reject-tests/*.tftest.hcl`
   each push one leaf out of range and are *designed to fail* — `expect_failures` cannot capture
   provider schema validators (only user custom conditions), so verify.sh asserts the exact
-  validator diagnostic per leaf instead.
+  validator diagnostic per leaf instead. As of S8: 23 reject cases, 23 asserted diagnostics,
+  counted by the script rather than restated in prose.
 - **mtu is `AtMost(16384)` only** — the API's discontinuous rule {0} ∪ [512,16384] has no single
   minimum, so the failing test uses `mtu = 20000` (a small value like 200 is *not* rejected).
 - **import caveat CLEARED (S7)** — the whole-object `terraform import` used to re-plan one
   in-place change, `- labels {}` on the interface. That is fixed in provider v3.77.5 (xcsh
   #1244 emits the import guards for the nested `interface_list.labels {}` marker). Re-verified
-  live on v3.77.5: apply → plan "No changes" → `state rm` → `import` → plan **0 changes**.
+  live on v3.77.5: apply → plan "No changes" → `state rm` → `import` → plan **0 changes**, and
+  again on v3.81.1 in S8. S8 confirmed the guard is load-bearing rather than defensive: the API
+  read-back of a probe that never declares it returns `interface_list[0].labels: {}`, i.e. the
+  server really does materialize the marker.
 - **vlan_id / proxy_port not live-applied** — `vlan_interface` and top-level `custom_proxy` both
   return `[BAD_REQUEST] Invalid request parameters (400)` on the `azure` not_managed single Control
   node. They are gated behind `var.extended_arms` (default true) so their validators are reached
@@ -279,6 +294,134 @@ Columns:
   `cov-probe-s7-nettype-inside-01`, `cov-probe-s7-jumbo-enabled-01` and `cov-probe-s7-defaults-01` each
   ran the full cycle and were destroyed. The live demo sites were never in state and never touched.
 
+## S8 completeness audit (provider v3.81.1)
+
+Every slice before this one grew the table row by row and never asked what was *missing*. S8 asks.
+
+### Method (reproducible)
+
+```bash
+cd coverage/smsv2
+printf 'provider_installation {\n  direct {}\n}\n' > /tmp/tfrc
+TF_CLI_CONFIG_FILE=/tmp/tfrc terraform init -upgrade      # log must name the version you expect
+TF_CLI_CONFIG_FILE=/tmp/tfrc terraform providers schema -json > /tmp/schema.json
+# then walk resource_schemas["xcsh_securemesh_site_v2"].block recursively over
+# .attributes and .block_types, emitting one dotted path per arm.
+```
+
+### Headline
+
+| Measure | Count |
+|---|---|
+| Arms in the `xcsh_securemesh_site_v2` schema at v3.81.1 (415 attributes + 582 blocks) | 997 |
+| Out of scope: the 10 non-`azure` site-provider subtrees, 68 arms each | 680 |
+| Out of scope: the Terraform `timeouts` meta-block | 5 |
+| **In scope for this probe** | **312** |
+| Rendered by `coverage/smsv2/main.tf` | 143 |
+| **Not rendered — classified below** | **169** |
+
+The 11 site-provider subtrees (`aws`, `azure`, `baremetal`, `equinix`, `gcp`, `kvm`, `nutanix`,
+`oci`, `openshift_virtualization`, `openstack`, `vmware`) were verified **byte-identical** modulo
+the top-level key: dumping each subtree with its prefix rewritten to `SITE` and `diff`-ing against
+`azure` gives no differences for all ten. They come from one generated code path, so the `azure`
+rows describe their structure too — but only `azure` is live-verified, and nothing here claims a
+CE was ever booted on AWS or vSphere.
+
+### Gap classification
+
+Not covered, and why. "Still open" means exactly that: no arm below has been quietly downgraded
+to "excluded" to make the table look finished.
+
+| # | Family | Arms | Class | Reason / evidence |
+|---|---|---|---|---|
+| A | `id` | 1 | ➖ n/a | Computed Terraform identifier, not an API arm. |
+| B | `annotations`, `description`, `disable` | 3 | ⚠️ partial | `description` **is** applied live by the production module (`terraform/modules/xc-site/main.tf`), just not by this probe, and has no validator anywhere. `annotations`/`disable` are **still open**: S8 saw the server materialize `metadata.annotations: {}` unprompted, so a literal `{}` is an untested drift source. |
+| C | `tunnel_type`, `tunnel_dead_timeout` | 2 | ⬜ still open | Both `Optional + Computed`; S8 saw the server materialize them (`SITE_TO_SITE_TUNNEL_IPSEC_OR_SSL` / `0`) on a probe declaring neither. Computed absorbs the default — which is exactly why 8 slices missed them: undeclared, they cannot drift. Never *set* from config, so no round-trip evidence. |
+| D | `enable_advanced_delivery{}` / `disable_advanced_delivery{}` | 2 | ⬜ still open | A whole top-level oneof with no row in any slice. S8 evidence: neither key appears in the read-back of a live site, so unlike C the server does **not** default it — it is genuinely unexercised, not merely invisible. |
+| E | `enable_log_anonymization{}` / `disable_log_anonymization{}` | 2 | ⬜ still open | Same as D: a whole top-level oneof, absent from the read-back, never rendered. |
+| F | `.tenant` on every ObjectRefType | 12 | ⬜ still open | Not excluded, just untested. Every arm carrying one is itself plan-only (ref-dependent), so a `tenant` round-trip could not have been observed even incidentally. A cross-tenant ref is the only thing that would exercise it. |
+| G | `SecretType.blindfold_secret_info{...}` (×2 sites) | 8 | ➖ excluded | Needs an offline Blindfold seal plus a real decryption/store provider. Sealing is non-deterministic, so an inline seal drifts on every plan; the seal must be done once and pinned. The probe deliberately uses `clear_secret_info`, the only dependency-free backend — `vault`/`wingman` 400 for the same reason. |
+| H | `clear_secret_info.provider_ref` (×2 sites) | 2 | ⬜ still open | The `url` sibling is covered; `provider_ref` names a secret-management provider object that must pre-exist. Same class as F. |
+| I | `custom_proxy.username`, `.password{...}`, `{enable,disable}_re_tunnel{}` | 6 | ⬜ still open at plan | `custom_proxy` itself returns `[BAD_REQUEST] 400` on the single-node `azure` probe, so nothing under it can be live. But its `proxy_ip_address`/`proxy_port` leaves *are* plan-asserted and these are not — there is no reason they could not be. |
+| J | `static_routes` / `static_v6_routes` under `local_vrf.{sli,slo}_config` and `segment_vrf.segment_config` | 84 | ⬜ still open | **Largest single gap: 27% of the in-scope surface.** Six instances of one identical `SiteStaticRoutesListType`. Even the `no_static_routes{}` empty siblings are unrendered. One selector on one instance covers all six. |
+| K | `interface_list.ipv6_auto_config.router{...}` | 21 | ⬜ still open | The probe renders only the `host{}` member of `autoconfig_choice`. The `router` member carries `network_prefix`, a `dns_config` oneof, and a `stateful` DHCPv6 subtree with pools. `ipv6_auto_config` as a whole is already plan-only (400 on a single-node IPv4 probe), so this is a plan-level gap. |
+| L | `local_vrf.slo_config{...}` | 7 | ⬜ still open | The SLO counterpart of `sli_config`. The probe always selects the `default_config{}` empty marker, so this member of the oneof has never been rendered — not even at plan. |
+| M | `local_vrf.sli_config` unwired leaves (`secondary_nameserver`, `labels{}`, `no_static_routes{}`, `no_v6_static_routes{}`) | 4 | ⬜ still open | `sli_config` renders only `nameserver` + `vip`, for their IPv4 validators. |
+| N | `segment_vrf.segment_config.secondary_nameserver` | 1 | ⬜ still open | Sibling of the covered `nameserver`; `segment_vrf` is plan-only regardless. |
+| O | `bond_interface.{name, link_polling_interval, link_up_delay}`, `.active_backup{}` | 4 | ⬜ still open | `active_backup{}` is the unselected member of the bond mode oneof (`lacp` is covered). `bond_interface` is plan-only (400), so this is a plan-level gap. |
+| P | Unselected members of covered oneofs: `site_local_inside_network{}`, `use_management_network{}`, `sm_connection_pvt_ip{}`, `cluster_static_ip{}` (+ `interface_ip_map{}`) | 6 | ⬜ still open | The most misleading class: every *sibling* is ✅. SLI `site_local_inside_network` is the notable one — its row promised it as "S3" and S3 never did it. `perf_mode_l3_enhanced.jumbo{}` sat here until S8. |
+| Q | `interface_list.description_spec`, `interface_list.labels{}`, `node_static_ip.default_gw`, `node_list.public_ip` | 4 | ⚠️ mixed | `public_ip` **is** applied live by the production module (`public_ip = ""`). `interface_list.labels{}` is covered indirectly but load-bearingly — see the note below. `description_spec` and `node_static_ip.default_gw` are **still open**. |
+
+Totals: 1 n/a, 8 excluded with a reason, 5 partially covered, **155 still open**. Every open row
+above is a candidate slice, not a defect — but the table is no longer silent about them.
+
+Two details that would not fit in a table cell:
+
+- **Family J's shape.** Each of the six `SiteStaticRoutesListType` instances carries `attrs`,
+  `ip_address`, `ip_prefixes`, a `default_gateway{}` marker, and a `node_interface.list[].interface`
+  ObjectRef (with `kind`/`name`/`namespace`/`tenant`/`uid`). Because all six are identical, one
+  selector on one instance would establish the shape for the whole 84.
+- **Family Q's `interface_list.labels{}`.** Nobody declares it, yet S8's read-back shows the server
+  materializing it (`interface_list[0].labels: {}`). Suppressing exactly that marker is what xcsh
+  #1244's import guards do, so the resource's whole import-clean story rests on an arm with no row.
+  It is covered in effect, not by declaration — which is why it is listed here rather than as ✅.
+
+### Also confirmed absent from the provider schema
+
+`interface_list.is_management` and `interface_list.is_primary` appear in the API read-back but have
+**no attribute in the provider schema at v3.81.1** (a grep of the 997-arm enumeration finds zero
+hits). That matches the S3 note's deferral to api-specs-enriched #1049: it needs spec injection and
+a regeneration, so it is a provider gap, not a probe gap.
+
+Likewise `segment_vrf` has **no `segment` ObjectRef attribute at all** — the exclusion recorded in
+the S4 notes ("needs a Segment object ref the provider cannot yet inject", specs #1053) is
+structurally accurate, not an excuse: there is nowhere to put the reference.
+
+### Caveats this audit will not sign off
+
+Read these before treating the ✅ column as proof.
+
+- **A create path verified only by `terraform import` is NOT verified.** This is not hypothetical.
+  S6's `xcsh_registration_approval` passed review on an import of an *already-approved* registration
+  plus a 0-change plan; the approve `POST` was never exercised, and it could never have worked —
+  the provider discarded the required object-typed `passport`, so every real approve returned
+  `500 "Validation approval: Passport is required"` (xcsh #1355, fixed in v3.81.1 and only then
+  live-proven on a fresh CE). Applied to this matrix: every `Applied ✅` cell here **was** reached
+  by a real `apply` (HTTP 200) — that failure was in a different resource. But the **Import-clean
+  column is different**, and the S7 note says so: most cells were flipped to ✅ by *reasoning* that
+  xcsh #1244's fix is resource-wide (39 of 39 nested `labels` closures guarded), not by re-running
+  an import per arm. Only the base/defaults probe, the `blocked_service` members, the
+  `network_type` non-default, the l7 `jumbo_enabled` arm and (in S8) both l3 jumbo arms have a
+  per-arm import actually observed.
+- **`api-specs-enriched#1108`: the contract-diff gate diffs a release against ITSELF, never N-1 → N,
+  so it cannot see upstream removals.** F5 dropped **307 schemas and 74 properties** during a
+  16-day window and the gate reported none of it — which is how the `apm*` family removal silently
+  broke the provider build (xcsh #1351). So a green Contract-diff gate is **not** evidence that
+  upstream is stable, and no completeness claim in this file leans on it. The enumeration above is
+  a point-in-time snapshot of v3.81.1: arms can vanish under it without any gate going red. Re-run
+  the Method above after every provider bump rather than trusting the counts.
+- **Every plan-only arm names its reason** — single-node 400, a missing ref object, or an
+  entitlement — and the reasons are recorded per row above and in the S3/S4/S5 notes. Where a
+  slice *expected* live and got a 400, the row says "reclassified" rather than being quietly
+  restated as excluded (`s2s_..._enabled` and `enable_upgrade_drain` went the other way: expected
+  plan-only, accepted live, reclassified up).
+- **No arm in this file is entitlement-blocked.** That reason appears in other coverage efforts in
+  this org (Bot Defense, WAAP); it does not apply to `xcsh_securemesh_site_v2`.
+
+### S8 live evidence
+
+Registry v3.81.1 (`TF_CLI_CONFIG_FILE` pointing at `provider_installation { direct {} }`, never
+`~/.terraformrc` `dev_overrides`), disposable probes only:
+
+- `cov-probe-s8-l3jumbo-01` — `perf_arm=perf_mode_l3_enhanced l3_jumbo_arm=jumbo`: apply (1 added)
+  → read-back `{"perf_mode_l3_enhanced":{"jumbo":{}}}` → re-plan "no changes" → `state rm` →
+  `import system/cov-probe-s8-l3jumbo-01` → post-import plan "no changes" → destroy.
+- `cov-probe-s8-l3nojumbo-01` — same arm at its `no_jumbo` default (regression check on making the
+  marker a selector): apply → read-back `{"perf_mode_l3_enhanced":{"no_jumbo":{}}}` → re-plan
+  "no changes" → import → post-import plan "no changes" → destroy.
+- Both destroyed. The live demo sites `ar-bgp-eastus01/02/03` were read over the API only
+  (`GET .../securemesh_site_v2s/<site>`, HTTP 200 each) and were never in any Terraform state.
+
 <!--
 Slice roadmap:
 - S0: probe workspace + this matrix (done).
@@ -290,4 +433,11 @@ Slice roadmap:
 - S7: labels workaround retired (provider v3.77.5) + blocked_services promoted plan-only -> live once the
   x-f5xc-wire-name contract shipped (provider v3.80.0), including the blocked_service service_choice
   members and the new perf_mode_l7_enhanced jumbo sub-oneof — DONE (verify.sh + live matrix).
+- S8: completeness audit against provider v3.81.1 — DONE. Mechanical 997-arm schema enumeration;
+  every stale annotation reconciled; perf_mode_l3_enhanced jumbo sub-oneof closed (live, both members);
+  drain_max_unavailable_node_count lower bound closed; per-file provider-version claims collapsed onto
+  versions.tf + the lock file; the stale "object-ref name capped at 63" blocker retired in all six sites
+  (mcn #592) and every root plan test now runs with enable_bgp at its true default. Remaining gaps are
+  classified above rather than closed — 155 arms still open, tracked as follow-up slices.
+  Closes epic terraform-provider-xcsh#1207.
 -->

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -5,32 +5,52 @@ to exercise schema arms. The object creates/reads/deletes with **no backing Azur
 VM** (each an HTTP 200). Never targets the live demo sites
 (`ar-bgp-eastus01/02/03`).
 
-## Local runs (dev_overrides — no `terraform init`)
+## Runs — always against a registry release
 
-`~/.terraformrc` `dev_overrides` points `f5-sales-demo/xcsh` at the local provider
-build. dev_overrides forbids `terraform init` (it errors), so run `plan`/`apply`/
-`destroy` directly.
+Drive this probe with an explicit `TF_CLI_CONFIG_FILE`, never with the ambient
+`~/.terraformrc`:
 
 ```bash
 cd coverage/smsv2
+printf 'provider_installation {\n  direct {}\n}\n' > /tmp/tfrc-registry-only.hcl
+export TF_CLI_CONFIG_FILE=/tmp/tfrc-registry-only.hcl
+terraform init -upgrade    # confirm the log names the version you expect
 set -a; source /tmp/mcn-xcsh.env; set +a   # live XC creds (env-only, never commit)
 terraform apply -auto-approve -var probe_name=cov-probe-s0-01
 terraform plan  -var probe_name=cov-probe-s0-01   # expect: No changes (idempotent)
 terraform destroy -auto-approve -var probe_name=cov-probe-s0-01
 ```
 
+A `dev_overrides` entry in `~/.terraformrc` silently substitutes a local working-tree build for
+the released provider, and the resulting failure does not look like a version problem: against a
+pre-v3.80.0 build this probe errors with `Blocks of type "jumbo_disabled" are not expected here`,
+which reads as a config bug. `dev_overrides` also forbids `terraform init`, so the lock file
+cannot be refreshed while it is active. `TF_CLI_CONFIG_FILE` overrides `~/.terraformrc` outright,
+so it is the only supported way in.
+
+`versions.tf` is the only **tracked** place a provider version is pinned. `.terraform.lock.hcl`
+pins the resolved version at runtime but is gitignored, so `terraform init -upgrade` is what tells
+you which release you are actually testing — read its log. See the comment in `versions.tf` for why
+nothing else may restate a version.
+
 Use a **fresh `-var probe_name=` per run** — a stale name collides with the tenant's
 existing StatusObject and 500s on create. XC site names reject underscores, so keep them
 hyphenated.
 
-To run against the **pinned registry release** instead of the local build (what the S7 live proof
-used), point Terraform at an empty CLI config so `dev_overrides` is out of the way, then `init`:
+## Adding a file here needs `git add -f`
+
+`.gitignore` ignores `coverage/` wholesale (a rule aimed at test-coverage output, which this
+directory is not). Every tracked file here was force-added, so `git add -A` **silently skips** any
+new one — `git status` will not even list it, because it is ignored rather than untracked:
 
 ```bash
-: > /tmp/tfrc-registry-only.hcl
-export TF_CLI_CONFIG_FILE=/tmp/tfrc-registry-only.hcl
-terraform init -upgrade   # installs the version versions.tf pins (>= 3.80.0)
+git add -f coverage/smsv2/reject-tests/reject-my-new-leaf.tftest.hcl
 ```
+
+S8 lost `reject-drain-count-min.tftest.hcl` this way. `verify.sh` caught it in CI — the assertion
+was present but its reject case was not in the commit, so the diagnostic never appeared — which is
+exactly why the assertion list lives in `verify.sh` rather than being inferred from the files on
+disk. `.gitignore` is managed by docs-control, so the rule cannot be fixed from this repo.
 
 ## Variables
 
@@ -49,6 +69,7 @@ terraform init -upgrade   # installs the version versions.tf pins (>= 3.80.0)
 | `s2s_iface_arm` | `disabled` | eth0 site_to_site_connectivity_interface_choice oneof: `disabled` \| `enabled`. Both live-appliable. |
 | `blocked_service_arm` | `ssh` | blocked_service service_choice oneof: `dns` \| `ssh` \| `web_user_interface`. All three live-appliable; F5 keeps exactly one member. |
 | `l7_jumbo_arm` | `jumbo_disabled` | perf_mode_l7_enhanced jumbo sub-oneof: `jumbo_disabled` \| `jumbo_enabled`. Both live-appliable; `jumbo_disabled` is the server default. |
+| `l3_jumbo_arm` | `no_jumbo` | perf_mode_l3_enhanced jumbo sub-oneof: `no_jumbo` \| `jumbo`. Different member names from the l7 pair. Rendered only when `perf_arm=perf_mode_l3_enhanced`; both live-appliable. |
 
 ## S3 interface / addressing oneof arms
 
@@ -203,7 +224,7 @@ import.
 
 ```bash
 cd coverage/smsv2
-./verify.sh   # credential-free: mocks the xcsh provider; the real v3.80.0 schema validators fire at plan
+./verify.sh   # credential-free: mocks the xcsh provider; the real schema validators fire at plan
 ```
 
 `verify.sh` proves the SMSv2 numeric validators both accept valid bounds and reject

--- a/coverage/smsv2/README.md
+++ b/coverage/smsv2/README.md
@@ -129,7 +129,7 @@ live):
 - `active_forward_proxy_policies`, `active_enhanced_firewall_policies`, `log_receiver_with_net`,
   `dc_cluster_group_sli`, `dc_cluster_group_slo`, `site_mesh_group_on_slo` (ref variant) — ObjectRefType
   arms whose referents must pre-exist.
-- `segment_vrf` — needs a Segment object ref the provider cannot yet inject (specs #1053).
+- `segment_vrf` — needs a Segment object ref the provider cannot yet inject (api-specs-enriched #1053).
 
 Logs are driven via `log_receiver_with_net`, never the stale top-level `log_receiver` field
 (provider #1256).

--- a/coverage/smsv2/main.tf
+++ b/coverage/smsv2/main.tf
@@ -281,7 +281,7 @@ resource "xcsh_securemesh_site_v2" "probe" {
   }
 
   # S4 segment_vrf (plan-only — a live segment_vrf needs a Segment object ref the provider cannot yet
-  # inject, specs #1053). Renders one entry exposing the segment_config.nameserver IPv4Validator leaf.
+  # inject, api-specs-enriched #1053). Renders one entry exposing the segment_config.nameserver IPv4Validator leaf.
   dynamic "segment_vrf" {
     for_each = var.segment_vrf_arm == "inline" ? [1] : []
     content {

--- a/coverage/smsv2/main.tf
+++ b/coverage/smsv2/main.tf
@@ -438,8 +438,8 @@ resource "xcsh_securemesh_site_v2" "probe" {
   # var.perf_arm. perf_mode_l7_enhanced (default) carries its own jumbo sub-oneof
   # {jumbo_disabled | jumbo_enabled}, new in provider v3.80.0 (specs v2.1.194) and keyed on
   # var.l7_jumbo_arm; the server materializes jumbo_disabled, so the default declares it and the
-  # object stays import-clean. perf_mode_l3_enhanced renders its no_jumbo{} sub-oneof member
-  # (jumbo|no_jumbo). Both are S5a live.
+  # object stays import-clean. perf_mode_l3_enhanced carries its OWN, differently spelled jumbo
+  # sub-oneof {jumbo | no_jumbo}, keyed on var.l3_jumbo_arm. Both are S5a live.
   performance_enhancement_mode {
     dynamic "perf_mode_l7_enhanced" {
       for_each = var.perf_arm == "perf_mode_l7_enhanced" ? [1] : []
@@ -459,7 +459,15 @@ resource "xcsh_securemesh_site_v2" "probe" {
     dynamic "perf_mode_l3_enhanced" {
       for_each = var.perf_arm == "perf_mode_l3_enhanced" ? [1] : []
       content {
-        no_jumbo {}
+        dynamic "no_jumbo" {
+          for_each = var.l3_jumbo_arm == "no_jumbo" ? [1] : []
+          content {}
+        }
+
+        dynamic "jumbo" {
+          for_each = var.l3_jumbo_arm == "jumbo" ? [1] : []
+          content {}
+        }
       }
     }
   }

--- a/coverage/smsv2/reject-tests/reject-bond-devices.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-bond-devices.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves bond_interface.devices validator SizeBetween(1, 8) rejects an empty
 # list (size 0 < 1). Run via verify.sh (not plain terraform test). mock_provider => no credentials;
-# validator fires from the real v3.76.0 schema at plan. interface_arm=bond renders the bond arm.
+# validator fires from the real provider schema at plan. interface_arm=bond renders the bond arm.
 mock_provider "xcsh" {}
 
 run "reject_bond_devices_empty" {

--- a/coverage/smsv2/reject-tests/reject-drain-count-min.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-drain-count-min.tftest.hcl
@@ -1,0 +1,17 @@
+# DESIGNED TO FAIL — proves upgrade_settings...enable_upgrade_drain.drain_max_unavailable_node_count
+# validator Between(1, 5000) rejects 0 (< min). Run via verify.sh (not plain terraform test).
+# mock_provider => no credentials; the real schema validator (see versions.tf for the pinned floor)
+# fires at plan. reject-drain-count covers the UPPER bound; this file covers the lower one, so a
+# regression that dropped the minimum from the validator cannot pass unnoticed.
+mock_provider "xcsh" {}
+
+run "reject_drain_count_under_min" {
+  command = plan
+
+  variables {
+    probe_name            = "cov-probe-s8-drain-count-min"
+    upgrade_drain_arm     = "enable_upgrade_drain"
+    drain_max_unavailable = 0
+    drain_node_timeout    = 300
+  }
+}

--- a/coverage/smsv2/reject-tests/reject-drain-count.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-drain-count.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves upgrade_settings...enable_upgrade_drain.drain_max_unavailable_node_count
 # validator Between(1, 5000) rejects 5001 (> max). Run via verify.sh (not plain terraform test).
-# mock_provider => no credentials; validator fires from the real v3.76.0 schema at plan.
+# mock_provider => no credentials; validator fires from the real provider schema at plan.
 # upgrade_drain_arm=enable_upgrade_drain renders the drain leaves; drain_node_timeout stays valid so
 # only drain_max_unavailable_node_count fails.
 mock_provider "xcsh" {}

--- a/coverage/smsv2/reject-tests/reject-drain-timeout.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-drain-timeout.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves upgrade_settings...enable_upgrade_drain.drain_node_timeout validator
 # Between(0, 900) rejects 901 (> max). Run via verify.sh (not plain terraform test). mock_provider =>
-# no credentials; validator fires from the real v3.76.0 schema at plan. upgrade_drain_arm=
+# no credentials; validator fires from the real provider schema at plan. upgrade_drain_arm=
 # enable_upgrade_drain renders the drain leaves; drain_max_unavailable stays valid so only
 # drain_node_timeout fails.
 mock_provider "xcsh" {}

--- a/coverage/smsv2/reject-tests/reject-mac.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-mac.tftest.hcl
@@ -1,7 +1,7 @@
 # DESIGNED TO FAIL — proves ethernet_interface.mac validator MACValidator() rejects a malformed MAC.
 # One reject run per file: a failing run halts the rest of its own file, so each leaf gets
 # its own file to guarantee its validator fires. Run via verify.sh (not plain terraform test).
-# mock_provider => no credentials; validator fires from the real v3.75.1 schema at plan.
+# mock_provider => no credentials; validator fires from the real provider schema at plan.
 # string_arms defaults true, so the mac leaf is wired on the eth0 ethernet_interface.
 mock_provider "xcsh" {}
 

--- a/coverage/smsv2/reject-tests/reject-mtu.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-mtu.tftest.hcl
@@ -1,7 +1,7 @@
 # DESIGNED TO FAIL — proves interface_list.mtu validator AtMost(16384) rejects >16384.
 # One reject run per file: a failing run halts the rest of its own file, so each leaf gets
 # its own file to guarantee its validator fires. Run via verify.sh (not plain terraform test).
-# mock_provider => no credentials; validator fires from the real v3.75.0 schema at plan.
+# mock_provider => no credentials; validator fires from the real provider schema at plan.
 mock_provider "xcsh" {}
 
 run "reject_mtu_over_max" {

--- a/coverage/smsv2/reject-tests/reject-network-type.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-network-type.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves blocked_services.blocked_service.network_type validator
 # OneOf(VIRTUAL_NETWORK_*) rejects an out-of-enum value. Run via verify.sh (not plain terraform
-# test). mock_provider => no credentials; validator fires from the real v3.80.0 schema at plan.
+# test). mock_provider => no credentials; validator fires from the real provider schema at plan.
 # services_arm=blocked_services renders the blocked_service so the network_type leaf is reachable.
 # blocked_network_type has no terraform validation so the provider OneOf validator fires.
 mock_provider "xcsh" {}

--- a/coverage/smsv2/reject-tests/reject-os-version.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-os-version.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves software_settings.os.operating_system_version validator
 # LengthAtMost(20) rejects a 21-char string. Run via verify.sh (not plain terraform test).
-# mock_provider => no credentials; validator fires from the real v3.76.0 schema at plan.
+# mock_provider => no credentials; validator fires from the real provider schema at plan.
 # os_arm=operating_system_version renders the pinned-version leaf so it is reachable.
 mock_provider "xcsh" {}
 

--- a/coverage/smsv2/reject-tests/reject-primary-re.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-primary-re.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves re_select.specific_re.primary_re validator LengthBetween(1, 64) rejects a
 # 65-char string (> max). Run via verify.sh (not plain terraform test). mock_provider => no
-# credentials; validator fires from the real v3.76.0 schema at plan. re_select_arm=specific_re renders
+# credentials; validator fires from the real provider schema at plan. re_select_arm=specific_re renders
 # the specific_re leaves so primary_re is reachable.
 mock_provider "xcsh" {}
 

--- a/coverage/smsv2/reject-tests/reject-proxy-ip.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-proxy-ip.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves custom_proxy.proxy_ip_address validator IPv4Validator() rejects a
 # malformed IPv4. Run via verify.sh (not plain terraform test). mock_provider => no credentials;
-# validator fires from the real v3.76.0 schema at plan. proxy_arm=custom_proxy (default) + the
+# validator fires from the real provider schema at plan. proxy_arm=custom_proxy (default) + the
 # default extended_arms=true render custom_proxy so the proxy_ip_address leaf is reachable. The
 # malformed value differs from the S2 static_ip reject ("999.999.0.0/8") so its diagnostic is
 # unambiguous. proxy_ip_address has no terraform validation so the provider IPv4 validator fires.

--- a/coverage/smsv2/reject-tests/reject-segment-nameserver.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-segment-nameserver.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves segment_vrf.segment_config.nameserver validator IPv4Validator() rejects
 # a malformed IPv4. Run via verify.sh (not plain terraform test). mock_provider => no credentials;
-# validator fires from the real v3.76.0 schema at plan. segment_vrf_arm=inline renders the
+# validator fires from the real provider schema at plan. segment_vrf_arm=inline renders the
 # segment_config so the nameserver leaf is reachable. The malformed value ("300.2.2.2") differs from
 # the S2 local_vrf nameserver reject ("300.1.1.1") so its diagnostic is unambiguous. segment_nameserver
 # has no terraform validation so the provider IPv4 validator fires.

--- a/coverage/smsv2/reject-tests/reject-ssh-key.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-ssh-key.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves admin_user_credentials.ssh_key validator LengthAtMost(8192) rejects a
 # >8192-char string. Run via verify.sh (not plain terraform test). mock_provider => no credentials;
-# validator fires from the real v3.76.0 schema at plan. admin_creds=true renders the block; the
+# validator fires from the real provider schema at plan. admin_creds=true renders the block; the
 # 8200-char key is generated in-HCL (join+range over 10-char chunks; `range` caps at 1024 elements) so
 # no oversized literal is committed.
 mock_provider "xcsh" {}

--- a/coverage/smsv2/reject-tests/reject-static-ipv6.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-static-ipv6.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves static_ipv6_address.node_static_ip.ip_address validator CIDRValidator()
 # rejects a malformed IPv6 CIDR. Run via verify.sh (not plain terraform test). mock_provider => no
-# credentials; validator fires from the real v3.76.0 schema at plan. ipv6_arm=static_ipv6_address
+# credentials; validator fires from the real provider schema at plan. ipv6_arm=static_ipv6_address
 # renders node_static_ip so the ip_address leaf is reachable. The malformed value differs from the
 # S2 static_ip reject ("999.999.0.0/8") so its exact diagnostic is unambiguous.
 mock_provider "xcsh" {}

--- a/coverage/smsv2/reject-tests/reject-sw-version.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-sw-version.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves software_settings.sw.volterra_software_version validator
 # LengthAtMost(20) rejects a 21-char string. Run via verify.sh (not plain terraform test).
-# mock_provider => no credentials; validator fires from the real v3.76.0 schema at plan.
+# mock_provider => no credentials; validator fires from the real provider schema at plan.
 # sw_arm=volterra_software_version renders the pinned-version leaf so it is reachable.
 mock_provider "xcsh" {}
 

--- a/coverage/smsv2/reject-tests/reject-vip-vrrp-mode.tftest.hcl
+++ b/coverage/smsv2/reject-tests/reject-vip-vrrp-mode.tftest.hcl
@@ -1,6 +1,6 @@
 # DESIGNED TO FAIL — proves load_balancing.vip_vrrp_mode validator OneOf(VIP_VRRP_INVALID,
 # VIP_VRRP_ENABLE, VIP_VRRP_DISABLE) rejects an out-of-enum value. Run via verify.sh (not plain
-# terraform test). mock_provider => no credentials; validator fires from the real v3.76.0 schema at
+# terraform test). mock_provider => no credentials; validator fires from the real provider schema at
 # plan. A non-empty vip_vrrp_mode renders load_balancing so the leaf is reachable. vip_vrrp_mode has
 # no terraform validation so the provider OneOf validator (not a variable check) fires.
 mock_provider "xcsh" {}

--- a/coverage/smsv2/validation.tftest.hcl
+++ b/coverage/smsv2/validation.tftest.hcl
@@ -399,7 +399,7 @@ run "plan_segment_vrf" {
   }
   assert {
     condition     = xcsh_securemesh_site_v2.probe.segment_vrf[0].segment_config.nameserver == "10.0.3.53"
-    error_message = "segment_vrf_arm=inline must render segment_config.nameserver plan-clean through IPv4Validator (plan-only; specs #1053)."
+    error_message = "segment_vrf_arm=inline must render segment_config.nameserver plan-clean through IPv4Validator (plan-only; api-specs-enriched #1053)."
   }
 }
 

--- a/coverage/smsv2/validation.tftest.hcl
+++ b/coverage/smsv2/validation.tftest.hcl
@@ -1,9 +1,11 @@
-# S1 numeric- + S2 string-leaf input validation for xcsh_securemesh_site_v2 (provider >= 3.80.0).
+# S1 numeric- + S2 string-leaf input validation for xcsh_securemesh_site_v2.
 #
 # POSITIVE case: valid bounds AND valid mac/ip/CIDR/node-type plan cleanly through the REAL
 # provider schema. mock_provider means no XC credentials are needed — the schema (and its
-# numeric + string validators) come from the dev_overrides build locally / the registry v3.80.0
-# in CI, and fire during plan regardless of whether the API is contacted.
+# numeric + string validators) come from whichever release `terraform init` resolved against the
+# floor in versions.tf, and fire during plan regardless of whether the API is contacted.
+# versions.tf is the only tracked pin: do not restate a version in prose here or in
+# reject-tests/, or the copies drift (they did, across four releases, until S8).
 #
 # The out-of-range REJECT cases live in ./reject-tests/reject.tftest.hcl. They cannot be
 # asserted with `expect_failures` because Terraform only captures user-defined custom
@@ -59,7 +61,7 @@ run "accept_valid_bounds" {
 
 # S3 positive plan asserts — each interface oneof arm PLANS cleanly through the real provider
 # schema (schema-valid) even where it would 400 live on a single-node `azure` probe. This proves the
-# HCL wiring + provider v3.76.0 schema accept every arm; the live/plan split is in the matrix.
+# HCL wiring + provider schema accept every arm; the live/plan split is in the matrix.
 
 run "plan_address_no_ipv4" {
   command = plan
@@ -163,7 +165,7 @@ run "plan_s2s_enabled" {
 
 # S4 positive plan asserts — each networking/services oneof arm PLANS cleanly through the real
 # provider schema (schema-valid) whether it is live (S4a) or ref-dependent / single-node-400
-# (S4b/S4c). This proves the HCL wiring + provider v3.76.0 schema accept every arm; the live/plan
+# (S4b/S4c). This proves the HCL wiring + provider schema accept every arm; the live/plan
 # split is recorded in the matrix.
 
 run "plan_blocked_services" {
@@ -402,7 +404,7 @@ run "plan_segment_vrf" {
 }
 
 # S5 positive plan asserts — each site-mode oneof alternative arm PLANS cleanly through the real
-# provider v3.76.0 schema (schema-valid) whether it is live (S5a) or single-node-400 (S5b). This proves
+# provider schema (schema-valid) whether it is live (S5a) or single-node-400 (S5b). This proves
 # the HCL wiring + schema accept every arm; the live/plan split is recorded in the matrix.
 
 run "plan_perf_l3_enhanced" {
@@ -412,8 +414,21 @@ run "plan_perf_l3_enhanced" {
     perf_arm   = "perf_mode_l3_enhanced"
   }
   assert {
-    condition     = xcsh_securemesh_site_v2.probe.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo != null
-    error_message = "perf_arm=perf_mode_l3_enhanced must render the no_jumbo sub-oneof member of perf_mode_l3_enhanced."
+    condition     = xcsh_securemesh_site_v2.probe.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo != null && xcsh_securemesh_site_v2.probe.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo == null
+    error_message = "perf_arm=perf_mode_l3_enhanced (l3_jumbo_arm default) must render only the no_jumbo member of the perf_mode_l3_enhanced jumbo sub-oneof."
+  }
+}
+
+run "plan_l3_jumbo_enabled" {
+  command = plan
+  variables {
+    probe_name   = "cov-probe-s8-l3-jumbo"
+    perf_arm     = "perf_mode_l3_enhanced"
+    l3_jumbo_arm = "jumbo"
+  }
+  assert {
+    condition     = xcsh_securemesh_site_v2.probe.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo != null && xcsh_securemesh_site_v2.probe.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo == null
+    error_message = "l3_jumbo_arm=jumbo must render only the jumbo member of the perf_mode_l3_enhanced jumbo sub-oneof."
   }
 }
 

--- a/coverage/smsv2/variables.tf
+++ b/coverage/smsv2/variables.tf
@@ -430,7 +430,7 @@ variable "segment_vrf_arm" {
   description = <<-EOT
     segment_vrf selector. `unset` (default) omits `segment_vrf` (pre-S4 base never set it). `inline`
     renders one `segment_vrf { segment_config { nameserver ... } }` entry. Plan-only: a live
-    `segment_vrf` needs a Segment object reference the provider cannot yet inject (specs #1053).
+    `segment_vrf` needs a Segment object reference the provider cannot yet inject (api-specs-enriched #1053).
   EOT
   type        = string
   default     = "unset"

--- a/coverage/smsv2/variables.tf
+++ b/coverage/smsv2/variables.tf
@@ -500,14 +500,28 @@ variable "ref_namespace" {
 variable "perf_arm" {
   description = <<-EOT
     performance_enhancement_mode oneof member. `perf_mode_l7_enhanced` (default, base) renders its own
-    jumbo sub-oneof via l7_jumbo_arm and is S5a live. `perf_mode_l3_enhanced` renders its `no_jumbo{}`
-    sub-oneof member (S5a live).
+    jumbo sub-oneof via l7_jumbo_arm and is S5a live. `perf_mode_l3_enhanced` renders its own
+    {jumbo | no_jumbo} sub-oneof via l3_jumbo_arm (S5a live).
   EOT
   type        = string
   default     = "perf_mode_l7_enhanced"
   validation {
     condition     = contains(["perf_mode_l7_enhanced", "perf_mode_l3_enhanced"], var.perf_arm)
     error_message = "perf_arm must be perf_mode_l7_enhanced | perf_mode_l3_enhanced."
+  }
+}
+
+variable "l3_jumbo_arm" {
+  description = <<-EOT
+    perf_mode_l3_enhanced jumbo sub-oneof member: `no_jumbo` (default) | `jumbo`. Distinct from the
+    l7 pair (`jumbo_disabled`/`jumbo_enabled`) — F5 spells the l3 members differently. Rendered only
+    when perf_arm=perf_mode_l3_enhanced.
+  EOT
+  type        = string
+  default     = "no_jumbo"
+  validation {
+    condition     = contains(["no_jumbo", "jumbo"], var.l3_jumbo_arm)
+    error_message = "l3_jumbo_arm must be no_jumbo | jumbo."
   }
 }
 

--- a/coverage/smsv2/verify.sh
+++ b/coverage/smsv2/verify.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # S1 numeric- + S2 string-validation gate for the SMSv2 coverage probe.
 #
-# Proves the provider v3.80.0 SMSv2 numeric AND string validators both ACCEPT valid input and
-# REJECT invalid input, entirely credential-free (mock_provider fires the real schema
-# validators at plan). This wraps `terraform test` because Terraform's `expect_failures`
-# only captures user-defined custom conditions, not provider schema attribute validators, so
-# a rejection cannot be asserted as a passing test run natively.
+# Proves the SMSv2 numeric AND string validators both ACCEPT valid input and REJECT invalid
+# input, entirely credential-free (mock_provider fires the real schema validators at plan).
+# The version under test is whatever `terraform init` resolved against the floor in versions.tf
+# (the lock file is gitignored) — deliberately NOT restated here, because the per-file copies of
+# it drifted across four releases before S8 removed them.
+#
+# This wraps `terraform test` because Terraform's `expect_failures` only captures user-defined
+# custom conditions, not provider schema attribute validators, so a rejection cannot be asserted
+# as a passing test run natively.
 #
 #   Phase 1 (accept): plain `terraform test` runs the root accept case -> must exit 0.
 #   Phase 2 (reject): `terraform test -test-directory=reject-tests` runs the DESIGNED-TO-FAIL
@@ -28,7 +32,8 @@ if ! terraform test; then
 fi
 
 echo
-echo "== Phase 2: reject out-of-range input (terraform test -test-directory=reject-tests) =="
+reject_files="$(find reject-tests -name '*.tftest.hcl' | wc -l | tr -d ' ')"
+echo "== Phase 2: reject out-of-range input (${reject_files} cases via terraform test -test-directory=reject-tests) =="
 reject_out="$(terraform test -test-directory=reject-tests 2>&1)"
 reject_rc=$?
 echo "${reject_out}"
@@ -71,6 +76,7 @@ declare -a expected=(
   "software_settings.os.operating_system_version string length must be at most 20, got: 21"
   "software_settings.sw.volterra_software_version string length must be at most 20, got: 21"
   "must be between 1 and 5000, got: 5001"
+  "must be between 1 and 5000, got: 0"
   "must be between 0 and 900, got: 901"
   "re_select.specific_re.primary_re string length must be between 1 and 64, got: 65"
   "admin_user_credentials.ssh_key string length must be at most 8192, got: 8200"
@@ -83,10 +89,8 @@ for msg in "${expected[@]}"; do
 done
 
 echo
-echo "PASS: SMSv2 validators accept valid input and reject all four numeric leaves plus the"
-echo "      mac / ip_address(CIDR) / default_gw(IP) / nameserver+vip(IPv4) / node-type string leaves,"
-echo "      the S3 interface-arm leaves (bond devices SizeBetween(1, 8) / static_ipv6 CIDR),"
-echo "      the S4 networking/services leaves (vip_vrrp_mode OneOf / blocked_services network_type"
-echo "      OneOf / custom_proxy proxy_ip_address IPv4 / segment_vrf nameserver IPv4), and the S5"
-echo "      site-mode leaves (os/sw version LengthAtMost(20) / drain count+timeout Between / specific_re"
-echo "      primary_re LengthBetween(1, 64) / ssh_key LengthAtMost(8192)."
+# Count-driven, NOT a hand-maintained prose list: the previous summary re-listed the leaves and
+# drifted out of step with `expected` (it still said "all four numeric leaves" and left a
+# parenthesis unclosed). The array above is the single source of truth for what is asserted.
+echo "PASS: the accept case plans clean and all ${#expected[@]} asserted validator diagnostics were emitted"
+echo "      by the ${reject_files} reject cases in reject-tests/ (see the 'expected' array for the exact list)."

--- a/coverage/smsv2/versions.tf
+++ b/coverage/smsv2/versions.tf
@@ -10,9 +10,25 @@ terraform {
 
 # 3.80.0 is the floor because it is the first release carrying the `x-f5xc-wire-name` contract
 # (specs v2.1.194): `blocked_services` cannot round-trip on anything older (provider #1257).
+# It stays 3.80.0 rather than tracking the newest release because that is the honest MINIMUM at
+# which every arm in this probe works — the root terraform/versions.tf floor is higher (>= 3.81.1)
+# because the deployment, unlike this probe, declares xcsh_registration_approval.
 #
-# Local runs use ~/.terraformrc dev_overrides → ../../terraform-provider-xcsh build,
-# which overrides the version constraint above (a warning is expected, not an error).
-# Do NOT run `terraform init` (dev_overrides forbids it); use plan/apply directly. To run against the
-# pinned registry release instead, set TF_CLI_CONFIG_FILE to an empty file and `init` (see README).
+# This floor is the ONLY TRACKED place a provider version is pinned (`.terraform.lock.hcl` also
+# pins one at runtime, but it is gitignored, so it cannot be a source of truth for a reader). Do
+# not restate a version in a comment in main.tf / verify.sh / *.tftest.hcl: those copies drifted
+# across four releases before S8 removed them.
+#
+# ALWAYS run against a REGISTRY release, never a local build:
+#
+#   printf 'provider_installation {\n  direct {}\n}\n' > /tmp/tfrc
+#   TF_CLI_CONFIG_FILE=/tmp/tfrc terraform init -upgrade   # confirm the log names the version
+#
+# A `dev_overrides` entry in ~/.terraformrc silently masks the registry release with a local
+# working-tree build. That build lags the released schema, and the failure is not obviously a
+# version problem — a pre-v3.80.0 build rejects this probe with
+# `Blocks of type "jumbo_disabled" are not expected here`, which reads like a config error.
+# dev_overrides also forbids `terraform init`, so the lock file cannot be refreshed while it is
+# active. TF_CLI_CONFIG_FILE overrides ~/.terraformrc entirely, which is why it is the only
+# supported way to drive this probe.
 provider "xcsh" {}

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -142,18 +142,18 @@ resource "xcsh_registration_approval" "this" {
 # Route Server (ASN var.rs_asn), one external peer per Route Server virtual
 # router IP, each bound to the explicit SLO interface.
 #
-# KNOWN BLOCKER (provider bug — tracked under epic xcsh #1207 alongside the
-# #1205/#1206 token/approval gaps): the provider caps EVERY object-ref name at
-# stringvalidator.LengthBetween(1, 63) (see terraform-provider-xcsh
-# internal/provider/bgp_resource.go). The interface object XC auto-generates for
-# the explicit SLO interface is 71 chars
-# (ves-io-securemesh-site-v2-<site>-network-<hostname>-eth0-0), which the API
-# accepts (see AS-BUILT.md §3.2 / the live bgp JSON) but the provider rejects at
-# plan/apply time. No naming choice inside the mandated scheme fits (even minimal
-# names land at ~65), so the pure-Terraform BGP binding cannot apply until the
-# provider validator is relaxed. enable_bgp defaults true (faithful intent); the
-# plan tests set it false to work around the provider bug, and a dedicated bgp
-# test verifies the HCL/schema wiring with a shortened interface name.
+# NOT BLOCKED — and nothing about this arm is gated any more. The object-ref name
+# length limit that used to block it is gone: the provider relaxed it to
+# stringvalidator.LengthBetween(1, 128) in v3.74.0, so the 71-char interface object
+# XC auto-generates for the explicit SLO interface
+# (ves-io-securemesh-site-v2-<site>-network-<hostname>-eth0-0) validates. The floor
+# that guarantees it is declared once, in versions.tf — do not restate the number.
+#
+# var.enable_bgp therefore defaults true and every test now runs with that default;
+# it survives only as an escape hatch for deploying the topology without BGP. It is
+# NOT an ordering gate: var.interface_name is derived statically from ce_topology, and
+# XC accepts a bgp object naming an interface that does not exist yet (it converges
+# once the CE is up — see the deploy ordering in the root main.tf).
 resource "xcsh_bgp" "this" {
   count = var.enable_bgp ? 1 : 0
 

--- a/terraform/modules/xc-site/variables.tf
+++ b/terraform/modules/xc-site/variables.tf
@@ -54,7 +54,7 @@ variable "labels" {
 }
 
 variable "enable_bgp" {
-  description = "Create the xcsh_bgp object. Defaults true (faithful intent). BLOCKED by a provider validator bug (object-ref name capped at 63 < the real 71-char XC interface name); set false to plan the rest of the graph until the provider is fixed. See main.tf."
+  description = "Create the xcsh_bgp object. Defaults true, and nothing gates it: the object-ref name length blocker that once forced it false was removed in provider v3.74.0. Retained only as an escape hatch for planning or deploying the graph without BGP. See main.tf."
   type        = bool
   default     = true
 }

--- a/terraform/tests/http_lb.tftest.hcl
+++ b/terraform/tests/http_lb.tftest.hcl
@@ -8,9 +8,9 @@ mock_provider "xcsh" {}
 
 variables {
   deployer = "tester"
-  # enable_bgp=false: work around the provider 63-char object-ref name cap (see
-  # main.tf). The LB/advertise/origin-pool under test are independent of bgp.
-  enable_bgp     = false
+  # enable_bgp left at its true default; the LB/advertise/origin-pool under test are
+  # independent of bgp either way. It used to be forced false only to dodge the provider's
+  # object-ref name length cap, relaxed in v3.74.0.
   ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
   # Pinned rather than inherited: `terraform test` also reads the gitignored
   # terraform.tfvars, so an assertion against a hard-coded namespace literal would

--- a/terraform/tests/plan.tftest.hcl
+++ b/terraform/tests/plan.tftest.hcl
@@ -13,10 +13,9 @@ run "root_plans_end_to_end" {
   variables {
     ce_count = 2
     deployer = "tester"
-    # enable_bgp=false works around the provider's 63-char object-ref name cap
-    # (the real 71-char XC interface name is rejected at plan; see main.tf /
-    # modules/xc-site). This verifies the rest of the graph plans clean.
-    enable_bgp     = false
+    # enable_bgp is left at its true default so the root integration test plans the WHOLE
+    # graph, bgp objects included. It used to be forced false only to dodge the provider's
+    # object-ref name length cap, relaxed in v3.74.0 (see modules/xc-site/main.tf).
     ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
   }
 

--- a/terraform/tests/xc_site.tftest.hcl
+++ b/terraform/tests/xc_site.tftest.hcl
@@ -18,11 +18,10 @@ run "site_and_interface_binding" {
     rs_peer_ips    = ["10.0.4.4", "10.0.4.5"]
     ce_asn         = 64512
     rs_asn         = 65515
-    # Site-focused run. bgp disabled here because the real 71-char interface name
-    # asserted below exceeds the provider's 63-char object-ref cap (blocker, see
-    # modules/xc-site/main.tf). Asserting the OUTPUT is fine — outputs are not
-    # length-validated — so this still proves the interface-name binding string.
-    enable_bgp = false
+    # enable_bgp left at its true default. It used to be forced false because the real
+    # 71-char interface name asserted below exceeded the provider's object-ref name cap;
+    # v3.74.0 relaxed that cap, so the real name now validates as an INPUT, not merely as
+    # an (unvalidated) output. See modules/xc-site/main.tf.
   }
 
   assert {

--- a/terraform/variables_ce.tf
+++ b/terraform/variables_ce.tf
@@ -32,7 +32,7 @@ variable "rs_asn" {
 }
 
 variable "enable_bgp" {
-  description = "Create the per-CE xcsh_bgp objects. Defaults true (this PR's whole point is BGP/ECMP). Currently BLOCKED at apply by a provider validator bug: object-ref names cap at 63 chars but the real XC SLO interface name is 71 (tracked under epic xcsh #1207). Set false to plan/deploy the rest of the topology until the provider validator is relaxed."
+  description = "Create the per-CE xcsh_bgp objects. Defaults true — BGP/ECMP is the point of this deployment — and nothing gates it: the object-ref name length blocker that once forced it false was removed in provider v3.74.0. Retained only as an escape hatch for planning or deploying the topology without BGP."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
Closes #644
Closes #592

## What this is

The final slice (S8) of the SMSv2 coverage effort: a mechanical completeness audit of
`coverage/smsv2-coverage-matrix.md` against provider **v3.81.1**, plus the gap closures and
stale-annotation reconciliation that came out of it. It is the gate for closing epic
`f5-sales-demo/terraform-provider-xcsh#1207`.

## The audit

Enumerated every arm of `xcsh_securemesh_site_v2` from `terraform providers schema -json`:

| Measure | Count |
|---|---|
| Arms in the schema at v3.81.1 (415 attributes + 582 blocks) | 997 |
| Out of scope — the 10 non-`azure` site-provider subtrees, 68 arms each | 680 |
| Out of scope — the Terraform `timeouts` meta-block | 5 |
| **In scope** | **312** |
| Rendered by `coverage/smsv2/main.tf` | 143 |
| **Not rendered — now classified** | **169** |

The 11 site-provider subtrees were verified **byte-identical** modulo their top-level key
(`diff` of each subtree with its prefix rewritten to `SITE`, against `azure`: no differences for
all ten), so the `azure` rows describe their structure — but only `azure` is live-verified and
nothing claims otherwise.

The 169 break down as 1 n/a, **8 legitimately excluded with a reason**, 5 partially covered, and
**155 still open**. The largest single gap is family J: 84 arms (27% of the in-scope surface) of
identical `SiteStaticRoutesListType` under `local_vrf.{sli,slo}_config` and
`segment_vrf.segment_config`, where not even the `no_static_routes{}` empty siblings are rendered.
Full table in the matrix.

Nothing was downgraded from open to excluded to make the table look finished.

## Gaps actually closed (not just documented)

- **`perf_mode_l3_enhanced.jumbo{}`** — the last unselected member of a covered oneof. Now an enum
  selector (`l3_jumbo_arm`, distinct from the l7 pair, which F5 spells differently) and
  live-verified on v3.81.1, both members, with API read-backs proving each is genuinely persisted
  rather than defaulted.
- **`drain_max_unavailable_node_count` lower bound** — only 5001 (upper) was reject-tested.
  `reject-drain-count-min` pushes 0. Proven **RED before the test file existed**
  (`FAIL: expected validator message not found -> must be between 1 and 5000, got: 0`), then GREEN.
  A regression dropping the validator's minimum can no longer pass.

## Stale annotations reconciled

| Annotation | How it was confirmed |
|---|---|
| `labels` rows implying xcsh #1103 / #1244 are open | Both are fixed and released; PR #605 retired the `ignore_changes` workaround. Rows now say so, and record that `length(var.labels) > 0 ? var.labels : null` is **load-bearing** (import exposes no Config, so a literal `{}` re-plans forever) — with the live reason: the server injects `{"ves.io/provider":"ves-io-AZURE"}` and the probe still imports 0-change against it. |
| `site_local_network` row promising the SLI sibling "in S3" | Schema enumeration shows `site_local_inside_network{}` is not rendered anywhere. Marked **still open** (gap P), not done. |
| `sli_config.nameserver`/`.vip` rows deferring live to "an S3 oneof concern" | S3 covered only the *interface* oneofs. The `local_vrf` SLI/SLO oneof is **still open** (gaps L/M). |
| S1 note claiming "the real v3.75.0 schema validators" | De-versioned; `versions.tf` is the only tracked pin. |
| 9 S0 rows with `Import-clean ⬜` | Flipped on this slice's own live evidence: both S8 probes carried those default arms and imported + re-planned 0-change. |
| `perf_mode_l3_enhanced{no_jumbo{}}` as one row | Split into parent + both sub-oneof members, each live-verified. |
| `secret_encoding_type` | Already retired repo-wide (`grep` finds zero references in `*.tf`/`*.hcl`/`*.sh`/`*.md`). Matrix correctly says the attribute no longer exists — no coverage is claimed for it. |
| `perf_mode_l7_enhanced` `{jumbo_disabled\|jumbo_enabled}` rows (PR #632) | Already present and correct. Confirmed live against a demo site read-back: `{"perf_mode_l7_enhanced":{"jumbo_disabled":{}}}` — the server really does materialize the marker. |
| `blocked_service` `service_choice` rows | Already present as `blocked_service_arm`, one row per mutually-exclusive member. Confirmed against the schema: exactly three members, all three have rows. |
| Stale `verify.sh` echo | The trailing summary re-listed the leaves and had drifted out of step with the `expected` array — still said "all four numeric leaves" and left a parenthesis unclosed. Replaced with a **count-driven** summary (`23 asserted diagnostics / 23 reject cases`) so it cannot drift again. |

### Version claims collapsed onto one source of truth

`verify.sh`, `validation.tftest.hcl` and 12 `reject-tests/*.tftest.hcl` each pinned a *different*
provider version in a comment (v3.75.0 / v3.75.1 / v3.76.0 / v3.80.0) while restating a
version-independent fact. `versions.tf` is the only tracked pin (`.terraform.lock.hcl` is
gitignored) and now says why nothing else may restate one.

### The documented run path was broken

`versions.tf` and `README.md` instructed the reader to use `~/.terraformrc` `dev_overrides`. That
masks the registry release with a stale local build and fails as
`Blocks of type "jumbo_disabled" are not expected here` — a version problem wearing a config
error's clothes. Both now mandate `TF_CLI_CONFIG_FILE` with
`provider_installation { direct {} }`, and explain the failure mode so the next reader recognises it.

## #592: the 63-char blocker, retired in six sites (not three)

#592 named three files. There were **six** — three more in `terraform/tests/`. The validator was
relaxed 63 → 128 in v3.74.0, so rather than re-justifying the workaround, this removes it:
`enable_bgp` is back at its `true` default in all three plan tests, **verified** to leave all 14
root tests passing. Every root plan test now actually exercises the `xcsh_bgp` objects, which none
of them did before.

#592 also asked whether `enable_bgp`'s gating is still warranted. It is not: I initially wrote that
it was a deploy-ordering gate, then found the repo's own `terraform/main.tf:16` says "the bgp/LB
objects can be applied before ONLINE; they converge once the CE is up", which falsifies that. The
descriptions now say what is true — it survives purely as an escape hatch — rather than inventing a
replacement blocker.

## Caveats this PR states rather than papering over

Recorded in the matrix, not just here:

- **A create path verified only by `terraform import` is not verified.** S6's
  `xcsh_registration_approval` passed review on an import of an already-approved registration plus a
  0-change plan; the approve `POST` was never exercised and could never have worked (xcsh #1355,
  fixed in v3.81.1). Applied to this matrix: every `Applied ✅` cell here *was* reached by a real
  apply — but the **Import-clean column is different.** Most cells were flipped by *reasoning* that
  xcsh #1244's fix is resource-wide (39/39 nested `labels` closures guarded), not by re-running an
  import per arm. The matrix now names the arms that do have a per-arm import observed.
- **`api-specs-enriched#1108`: the contract-diff gate diffs a release against itself, never
  N-1 → N, so it cannot see upstream removals.** F5 dropped 307 schemas and 74 properties in a
  16-day window and the gate reported none of it — which is how the `apm*` removal silently broke
  the provider build (xcsh #1351). **No completeness claim in this PR leans on that gate.** The
  997-arm count is a point-in-time snapshot; arms can vanish under it with no gate going red, so the
  matrix tells you to re-run the enumeration after every provider bump instead of trusting the
  numbers.
- **Every plan-only arm names its reason** — single-node 400, missing ref object, or entitlement.
  (No arm in this resource is entitlement-blocked; that reason belongs to other efforts in this org.)

## Verification

Live, registry **v3.81.1** (`TF_CLI_CONFIG_FILE` → `provider_installation { direct {} }`, init log
confirmed `Installed f5-sales-demo/xcsh v3.81.1`), disposable probes only:

- `cov-probe-s8-l3jumbo-01` (`l3_jumbo_arm=jumbo`): apply (1 added) → read-back
  `{"perf_mode_l3_enhanced":{"jumbo":{}}}` → re-plan "no changes" → `state rm` → import →
  post-import plan "no changes" → destroy.
- `cov-probe-s8-l3nojumbo-01` (`no_jumbo` default, regression check on making the marker a
  selector): apply → read-back `{"perf_mode_l3_enhanced":{"no_jumbo":{}}}` → re-plan "no changes" →
  import → post-import plan "no changes" → destroy.

Linters, all reproduced locally and green: `terraform fmt -check -recursive`, `tflint --recursive`,
`terraform validate` (probe + root), `terraform test` (14/14 root), `coverage/smsv2/verify.sh`
(23/23 asserted diagnostics), `shellcheck`, `shfmt -d`, `codespell`, `textlint` (repo `.textlintrc`,
terminology rule), `markdownlint` (**MD013 ≤ 400** — five of my table rows breached it and were
shortened, with the overflowing detail moved into prose below the table), and `pre-commit
--all-files`.

One pre-existing failure is **out of scope**: `pre-commit` reports
`README.md:23 MD012/no-multiple-blanks` on the repo-root `README.md`. Confirmed present on
`origin/main` and untouched by this branch, and `README.md` is in `.claude/governance.json`
`protected_files` — it belongs in a docs-control issue, not here.

## The live demo is untouched

`ar-bgp-eastus01/02/03` and RG `rg-mcn-ce-ha-rmordasiewicz` were never in any Terraform state and
no `apply`/`destroy` ran against them. The only contact was read-only
`GET /api/config/namespaces/system/securemesh_site_v2s/<site>` (HTTP 200 on all three), used to
confirm the server materializes `perf_mode_l7_enhanced.jumbo_disabled` and injects
`metadata.labels["ves.io/provider"]`. No file under `terraform/` changed except comments and two
variable descriptions; the three test-file edits only remove an override that restored a default.
