### PR TITLE
fix(docs): the access tier still lost its title and routing hint

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,4 +1,3 @@
 {
-  "promote": ["**/customer-edge/access"],
   "demote": ["**/customer-edge/commands/**"]
 }


### PR DESCRIPTION
Closes #649

## Problem

#640 fixed the access tier only partially. Verified against the **deployed** site:

```
/_llms-txt/en/customer-edge/access.txt   200   (was 404 — that part worked)
```

but its content is:

```
# Access

## Contents
- [Debug API](...)
- [Serial console](...)
```

versus a healthy tier:

```
# Command reference

> Every Site CLI command reachable through the debug API, with its category, privilege
> tier and transport. Read a specific command page for syntax and captured output.
```

The heading is the `titleCase` fallback rather than the page title, there is **no
description**, and the tier's own index page is missing from Contents. The routing hint
is the reason a tier exists, so this was still broken — just less visibly.

## Cause: the same clobber, one level up

Promoting `**/customer-edge/access` gives that entry the sort key
`__en/customer-edge/access`, which sorts ahead of its own **ancestor**
`_en/customer-edge`:

```
promoted: processing order
   "__en/customer-edge/access"          <- descendant, first
   "_en/customer-edge"                  <- its ancestor, second
   "_en/customer-edge/access/debug-api"
```

Processing the access index first creates a directory node for `customer-edge`. The
ancestor then arrives as a two-segment leaf and `current.children.set(seg, leaf)` writes
over that directory, taking the access entry with it. A later child recreates `access`
from scratch — hence `titleCase` and no description.

So promoting a descendant above its own ancestor is destructive in exactly the way
promoting children above their parent was. My first fix moved the damage from the whole
subtree to just the index page instead of removing it.

## Fix

No promote is needed at all.

```diff
-  "promote": ["**/customer-edge/access"],
   "demote": ["**/customer-edge/commands/**"]
```

`access` already precedes `commands` and `workflows` alphabetically, and demoting the
commands children keeps the reference last. The ordering is unchanged.

## Verification

Against the plugin's own `buildTierTree`, with real Astro ids:

| Config | access title | description | order |
| --- | --- | --- | --- |
| #640 (deployed) | `"Access"` | `undefined` | index, access, workflows, commands |
| this PR | `"Reaching a Customer Edge"` | present | index, access, workflows, commands |

The first row reproduces the deployed symptom, which is what confirms the model.

I will re-check the deployed tier after this merges rather than calling it done here —
that is what caught this one.

## Upstream

`docs-control#810` updated with this second manifestation: the defect is not specifically
"parent after children", it is that **any** ordering placing a descendant before an
ancestor silently destroys data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
