### PR TITLE
fix(tests): remove live API tokens used as scrub-test fixtures

### DIFF
--- a/tests/test-sitecli-scrub.sh
+++ b/tests/test-sitecli-scrub.sh
@@ -56,10 +56,15 @@ assert_removed() {
 }
 
 # --- secrets: the whole point of the filter ------------------------------------
+# Fixtures below are DELIBERATELY fake and obviously so. An earlier version of this
+# file used real tenant API tokens because they made "realistic" fixtures, and
+# committed them to a public repository — in the very test that asserts tokens are
+# redacted. gitleaks did not catch them: the format matches none of its rules. Keep
+# these values self-evidently synthetic.
 assert_removed "API token in an Authorization header" \
-  'Authorization: APIToken lwEqhg+Oqbq5fsHMc0m/gxeysrA=' 'lwEqhg+Oqbq5fsHMc0m/gxeysrA='
+  'Authorization: APIToken EXAMPLEtoken0000NotARealValue=' 'EXAMPLEtoken0000NotARealValue='
 assert_removed "bare APIToken value" \
-  'curl -H "Authorization: APIToken OULzp2FaqP1FTmgygm1dn5BDfYA=" https://x' 'OULzp2FaqP1FTmgygm1dn5BDfYA='
+  'curl -H "Authorization: APIToken EXAMPLEsecond0000NotARealValue=" https://x' 'EXAMPLEsecond0000NotARealValue='
 assert_removed "Bearer token" \
   'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def' 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
 assert_removed "private key body" \


### PR DESCRIPTION
Closes #655

## Urgent

`tests/test-sitecli-scrub.sh` on `main` contains **two real tenant API tokens**, in a
public repository. I put them there: they were pasted into the session, and I used them
as fixtures because they looked realistic.

They sat in the test that asserts API tokens are redacted.

## gitleaks passed them

Every gate on every PR was green. The values are short base64-with-padding strings and
match none of the gitleaks rules, so the secret scanner had nothing to fire on. Worth
knowing, because it means "gitleaks is clean" is not evidence that a credential is absent
— it is only evidence that no *recognised* credential shape is present.

## Fix

Replaced with obviously synthetic values, and the reason is recorded in the file so the
fixtures are not later "improved" back into realistic-looking ones.

Verified: 82 assertions still pass, `shellcheck` and `shfmt` clean, zero occurrences of
either token remaining in the working tree.

## This does not undo it

Both tokens remain in the git history of a public repo and **must be rotated**. That is
now the third item riding on the history-rewrite decision in #630, alongside the tenant
identifier and — separately — the Azure subscription ID in `docs-control#803`.

## How it was found

A sweep of temp files for the pasted credential strings, run after the work was otherwise
complete. Nothing in the normal pipeline would have surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
