### PR TITLE
feat(xc-site): authorize SSH on the CE appliances for execcli access

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,6 +111,9 @@ module "xc_site" {
   sw_version           = var.ce_sw_version
   enable_bgp           = var.enable_bgp
   approve_registration = var.approve_registration
+  # Same operator key the Azure VMs get, so CE SSH needs no extra input. Set
+  # ce_ssh_enabled = false to leave the appliance with no SSH listener.
+  ssh_public_key = var.ce_ssh_enabled ? local.ssh_public_key : ""
 }
 
 # The Azure side of each eBGP session (Route Server -> CE eth0/SLO IP).

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -97,6 +97,18 @@ resource "xcsh_securemesh_site_v2" "this" {
       volterra_software_version = var.sw_version == "" ? null : var.sw_version
     }
   }
+
+  # SSH access to the CE appliance, for `execcli` and on-box diagnostics.
+  # The CE image manages its own OS authentication, so the Azure VM's
+  # admin_ssh_key (modules/ce-node) does NOT grant CE login — this block is what
+  # authorizes a key on the appliance itself. An empty var renders no block,
+  # leaving the appliance default (no SSH listener), so this is opt-in.
+  dynamic "admin_user_credentials" {
+    for_each = var.ssh_public_key == "" ? [] : [1]
+    content {
+      ssh_key = var.ssh_public_key
+    }
+  }
 }
 
 # The approve API takes the runtime registration name ("r-<uuid>"), NOT the site

--- a/terraform/modules/xc-site/variables.tf
+++ b/terraform/modules/xc-site/variables.tf
@@ -76,3 +76,14 @@ variable "sw_version" {
   type        = string
   default     = ""
 }
+
+variable "ssh_public_key" {
+  description = <<-EOT
+    Public key authorized for SSH login to the CE appliance (admin_user_credentials.ssh_key),
+    used to reach `execcli` and on-box diagnostics. The CE manages its own OS authentication,
+    so the Azure VM's admin_ssh_key does not grant CE login — this is the only thing that does.
+    Empty (default) renders no block, leaving the appliance default of no SSH listener.
+  EOT
+  type        = string
+  default     = ""
+}

--- a/terraform/tests/xc_site.tftest.hcl
+++ b/terraform/tests/xc_site.tftest.hcl
@@ -65,3 +65,59 @@ run "site_and_interface_binding" {
     error_message = "perf_mode_l7_enhanced must NOT select jumbo_enabled: jumbo_disabled is the arm F5 materialises, and switching arms changes the CE data path."
   }
 }
+
+# CE SSH (admin_user_credentials.ssh_key) is opt-in and must be genuinely absent when
+# no key is supplied — a rendered-but-empty block would authorize nothing yet still
+# claim the appliance is configured. Two runs, because the discriminating evidence is
+# the difference between them: unlike the jumbo arms above, ssh_key carries a real
+# value rather than an empty marker, so the mocked provider does distinguish these.
+run "ce_ssh_key_authorized_when_supplied" {
+  command = plan
+
+  module {
+    source = "./modules/xc-site"
+  }
+
+  variables {
+    site_name      = "ar-bgp-eastus01"
+    hostname       = "f5-xc-ce-vm-01"
+    interface_name = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac   = "7c:1e:52:18:c1:77"
+    rs_peer_ips    = ["10.0.4.4", "10.0.4.5"]
+    ce_asn         = 64512
+    rs_asn         = 65515
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAATESTKEYONLY test@example"
+  }
+
+  assert {
+    condition = (
+      xcsh_securemesh_site_v2.this.admin_user_credentials.ssh_key ==
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAATESTKEYONLY test@example"
+    )
+    error_message = "admin_user_credentials.ssh_key must carry the supplied key verbatim: the CE manages its own OS auth, so this block is the only thing that authorizes SSH login for execcli."
+  }
+}
+
+run "ce_ssh_block_absent_when_no_key" {
+  command = plan
+
+  module {
+    source = "./modules/xc-site"
+  }
+
+  variables {
+    site_name      = "ar-bgp-eastus01"
+    hostname       = "f5-xc-ce-vm-01"
+    interface_name = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac   = "7c:1e:52:18:c1:77"
+    rs_peer_ips    = ["10.0.4.4", "10.0.4.5"]
+    ce_asn         = 64512
+    rs_asn         = 65515
+    ssh_public_key = ""
+  }
+
+  assert {
+    condition     = xcsh_securemesh_site_v2.this.admin_user_credentials == null
+    error_message = "An empty ssh_public_key must render NO admin_user_credentials block, leaving the appliance default of no SSH listener."
+  }
+}

--- a/terraform/variables_ce.tf
+++ b/terraform/variables_ce.tf
@@ -67,3 +67,21 @@ variable "ce_sw_version" {
   type        = string
   default     = ""
 }
+
+variable "ce_ssh_enabled" {
+  description = <<-EOT
+    Authorize the operator's SSH key on the CE appliances (admin_user_credentials.ssh_key),
+    so `execcli` and on-box diagnostics are reachable over SSH at each CE's management
+    public IP. Reuses the same key as the Azure VMs (local.ssh_public_key) — no extra input.
+
+    The CE manages its own OS authentication: the Azure VM's admin_ssh_key does NOT grant
+    CE login, so without this there is no SSH listener and port 22 is closed.
+
+    Defaults to false, and deliberately so: the CE subnets carry no NSG, so enabling
+    this exposes SSH to the internet (key-only auth). That is a decision an operator
+    should make consciously and auditably in their own tfvars, not inherit passively
+    from a module default. Set true to authorize the key.
+  EOT
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## What

Authorizes an SSH key on the CE appliances via `admin_user_credentials.ssh_key`, so `execcli` and on-box diagnostics are reachable over SSH — the access path the CE documentation needs.

## Why it did not work before

`modules/xc-site` set **no** `admin_user_credentials` at all, so the appliance never provisioned SSH access:

```
f5-xc-ce-vm-01  pip=20.124.35.231   port22=closed/filtered
f5-xc-ce-vm-02  pip=168.62.59.17    port22=closed/filtered
f5-xc-ce-vm-03  pip=20.120.96.34    port22=closed/filtered
```

The Azure-level `admin_ssh_key` already set in `modules/ce-node/main.tf:83` does **not** help: the CE is an appliance image that manages its own OS authentication, independent of the Azure VM's `osProfile`.

**Nothing was filtering at the network layer.** Verified: no NSG is associated with any CE subnet (`snet-hub-management`, `snet-hub-internal`, `snet-hub-external`, `RouteServerSubnet` all `None`) nor with any CE mgmt NIC. Port 22 was closed because the appliance was not listening — so this change needs no firewall or NSG work.

## Design

- `ssh_key` is fed from the existing `local.ssh_public_key` — the same operator key the Azure VMs already receive — so there is **no new input to manage**.
- An empty key renders **no block**, preserving the appliance default of no listener.
- **`ce_ssh_enabled` defaults to `false`.** Because the CE subnets carry no NSG, enabling the listener exposes SSH to the internet under key-only auth. That is a decision an operator should make consciously and auditably in their own tfvars, not inherit passively from a module default. Tightening it further would mean an NSG on `snet-hub-management` restricting source — worth doing if this outlives the documentation work.

## Verification

- `terraform plan`: **3 sites updated in-place, 0 to add, 0 to destroy** — no CE VM replacement.
- `terraform apply` succeeded; the key is present on the live site object:
  `spec.admin_user_credentials.ssh_key = "ssh-ed25519 AAAA… r.mordasiewicz@…"`
- Re-plan with the opt-in set: **No changes** (idempotent).
- Re-plan with `ce_ssh_enabled=false`: proposes in-place updates removing the key — so the flag genuinely controls the arm and the safe default is real, not decorative.
- `terraform test`: **16 passed, 0 failed**. `fmt -check -recursive`, `validate`, `tflint --recursive`, `codespell` all clean.

### The two new tests are proven load-bearing

Each mutation kills exactly its own assertion, so neither test can pass vacuously:

| Mutation to `modules/xc-site` | Result |
| --- | --- |
| drop the empty-key guard (`for_each = [1]`) | `ce_ssh_block_absent_when_no_key` **fails** |
| never render the block (`for_each = []`) | `ce_ssh_key_authorized_when_supplied` **fails** |
| unmutated | 3 passed |

## Not in scope

The CE documentation pages themselves. `docs/en/customer-edge/access/` is a translated tree behind a Translation Audit gate, and an SSH page is already in progress on another branch — this PR only supplies the access path it documents.

## Serial console context

This was requested because the Azure Serial Console is awkward for authoring documentation. Per Microsoft's docs it is **one session per VM** — a second connection *disconnects the first without logging it out* — and it caps pasted input at **2,048 characters**. Neither is rate limiting: Compute throttling (HTTP 429) applies to ARM API calls, not the console data channel. A dropped websocket also needs `*.serialconsole.azure.com` on the network allow list.

Closes #658
