### PR TITLE
feat(customer-edge): operator SSH to the CE admin account via cloud-init

### DIFF
--- a/terraform/cloud-init/ce-node.yaml
+++ b/terraform/cloud-init/ce-node.yaml
@@ -31,3 +31,14 @@ write_files:
         EtcdUseTLS: true
         Server: vip
         CloudProvider: disabled
+
+  # Operator SSH to the appliance `admin` account, whose login shell is the Site
+  # CLI (/opt/bin/vpmu). `admin` (uid 2202) is baked into the node image, so it
+  # exists before cloud-init runs and `owner: admin:admin` resolves. vpm's user
+  # pass logs "Won't do any change for user admin (internal skip)" and never
+  # rewrites this file. Reachable on the SLI address only.
+  - path: /var/home/admin/.ssh/authorized_keys
+    permissions: "0600"
+    owner: admin:admin
+    content: |
+      ${ssh_public_key}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -53,4 +53,19 @@ locals {
   # an explicit var.registration_token still wins when supplied (break-glass /
   # externally-minted token). Empty var (default) => the generated token.
   ce_registration_token = var.registration_token != "" ? var.registration_token : xcsh_token.ce.uid
+
+  # --- CE cloud-init, rendered once per node ---
+  # Rendered here rather than inline in the module block so the document is
+  # addressable as local.ce_cloud_init in `terraform test` — the rendered YAML is
+  # the whole contract with the appliance, and it is only worth asserting if it can
+  # be read. See tests/cloud_init.tftest.hcl.
+  ce_cloud_init = {
+    for key, node in module.ce_topology.ce_nodes : key => templatefile("${path.module}/cloud-init/ce-node.yaml", {
+      cluster_name = node.site_name
+      token        = local.ce_registration_token
+      # chomp: a key read from a .pub file ends in a newline, which would render a
+      # second, empty line into authorized_keys under `content: |`.
+      ssh_public_key = chomp(local.ssh_public_key)
+    })
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,10 +86,7 @@ module "ce_node" {
   admin_username      = var.admin_username
   ssh_public_key      = local.ssh_public_key
 
-  custom_data = base64encode(templatefile("${path.module}/cloud-init/ce-node.yaml", {
-    cluster_name = each.value.site_name
-    token        = local.ce_registration_token
-  }))
+  custom_data = base64encode(local.ce_cloud_init[each.key])
 
   tags = local.tags
 }

--- a/terraform/modules/ce-node/main.tf
+++ b/terraform/modules/ce-node/main.tf
@@ -119,11 +119,12 @@ resource "azurerm_linux_virtual_machine" "this" {
 
   custom_data = var.custom_data
 
-  # Required for Azure Serial Console, which is the only way into a CE that has
-  # not registered: the vpm/debug API used for every other diagnostic is reached
-  # through the XC control plane, so it answers only once the node is ONLINE, and
-  # the node refuses SSH as shipped. Empty block = Azure-managed storage, so there
-  # is no diagnostics storage account or access key to own.
+  # Required for Azure Serial Console, which is the only way into a CE that has not
+  # finished its first boot: the vpm/debug API used for every other diagnostic is
+  # reached through the XC control plane, so it answers only once the node is ONLINE,
+  # and operator SSH depends on cloud-init having written admin's authorized_keys and
+  # on the SLI interface being up. Empty block = Azure-managed storage, so there is
+  # no diagnostics storage account or access key to own.
   boot_diagnostics {}
 
   tags = var.tags

--- a/terraform/tests/ce_node.tftest.hcl
+++ b/terraform/tests/ce_node.tftest.hcl
@@ -62,11 +62,12 @@ run "ce_vm_and_nics" {
     error_message = "CE OS disk must be StandardSSD_LRS."
   }
 
-  # Azure Serial Console requires boot diagnostics. It is the only way into a CE
-  # that has not registered: the vpm/debug API used for every other diagnostic is
-  # reached through the XC control plane, so it answers only once the node is
-  # ONLINE, and the node refuses SSH as shipped. Losing this block would silently
-  # remove the break-glass path for the exact failure it exists to debug.
+  # Azure Serial Console requires boot diagnostics. It is the only way into a CE that
+  # has not finished its first boot: the vpm/debug API used for every other diagnostic
+  # is reached through the XC control plane, so it answers only once the node is
+  # ONLINE, and operator SSH only exists after cloud-init has written admin's
+  # authorized_keys. Losing this block would silently remove the break-glass path for
+  # the exact failure it exists to debug.
   assert {
     condition     = length(azurerm_linux_virtual_machine.this.boot_diagnostics) == 1
     error_message = "CE VM must enable boot diagnostics, or Azure Serial Console cannot attach."

--- a/terraform/tests/cloud_init.tftest.hcl
+++ b/terraform/tests/cloud_init.tftest.hcl
@@ -1,0 +1,120 @@
+# Plan-level tests for the rendered CE cloud-init document.
+#
+# The document is rendered into local.ce_cloud_init (locals.tf) specifically so that
+# its content is assertable here — a templatefile() call inlined in the module block
+# is not addressable from a test.
+#
+# registration_token is pinned to a literal so the rendered document is KNOWN at plan
+# time. Left at its default the token comes from xcsh_token.ce.uid, which stays unknown
+# until apply even under mock_provider, and every assertion below would fail with
+# "Unknown condition value" instead of on its own merits.
+
+mock_provider "azurerm" {}
+mock_provider "azuread" {}
+mock_provider "xcsh" {}
+
+variables {
+  ce_count           = 1
+  deployer           = "tester"
+  registration_token = "plan-test-token"
+}
+
+# The operator SSH grant. Asserted as one exact multi-line substring rather than as
+# four independent contains() checks, because path, mode, owner, key and the two-space
+# YAML indent only mean anything together: a correct mode on the wrong path, or the
+# right key under a mis-indented entry, would each pass a looser test and fail on the
+# node.
+#
+# owner: admin:admin resolves at write time because admin (uid 2202) is baked into the
+# node image and therefore exists before cloud-init runs — hence no runcmd/chown fixup.
+run "cloud_init_authorizes_operator_ssh_for_admin" {
+  command = plan
+
+  variables {
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+  }
+
+  assert {
+    condition = strcontains(
+      local.ce_cloud_init["eastus01"],
+      "  - path: /var/home/admin/.ssh/authorized_keys\n    permissions: \"0600\"\n    owner: admin:admin\n    content: |\n      ${var.ssh_public_key}\n"
+    )
+    error_message = "CE cloud-init must write the operator key to /var/home/admin/.ssh/authorized_keys as admin:admin mode 0600."
+  }
+}
+
+# Regression guard: the SSH entry is ADDITIVE. The vpm config is what makes the node
+# register at all, so a template edit that displaced or malformed it would cost three
+# CE rebuilds to discover.
+run "cloud_init_still_writes_the_vpm_config" {
+  command = plan
+
+  variables {
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+  }
+
+  assert {
+    condition     = strcontains(local.ce_cloud_init["eastus01"], "  - path: /etc/vpm/config.yaml\n    permissions: \"0600\"\n    owner: root\n")
+    error_message = "CE cloud-init must still write /etc/vpm/config.yaml root-only 0600."
+  }
+
+  assert {
+    condition     = strcontains(local.ce_cloud_init["eastus01"], "    Token: plan-test-token\n")
+    error_message = "CE cloud-init must still carry the registration token into the vpm config."
+  }
+
+  assert {
+    condition     = strcontains(local.ce_cloud_init["eastus01"], "    ClusterName: ar-bgp-eastus01\n")
+    error_message = "CE cloud-init must still carry the per-node XC site name as ClusterName."
+  }
+
+  assert {
+    condition     = startswith(local.ce_cloud_init["eastus01"], "#cloud-config\n")
+    error_message = "The rendered document must still begin with the #cloud-config header."
+  }
+}
+
+# A public key read from a .pub file carries a trailing newline. Interpolated raw under
+# `content: |` that newline renders a second, empty line into the key file, so the key
+# is chomped. Passing the key WITH a trailing newline here reproduces exactly what
+# file() yields on the real path (locals.tf falls back to file(var.ssh_public_key_path)).
+run "cloud_init_chomps_trailing_newline_on_the_key" {
+  command = plan
+
+  variables {
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l chomp-test\n"
+  }
+
+  assert {
+    condition     = !strcontains(local.ce_cloud_init["eastus01"], "chomp-test\n\n")
+    error_message = "A trailing newline on the public key must be chomped, or a blank line lands in authorized_keys."
+  }
+
+  assert {
+    condition     = strcontains(local.ce_cloud_init["eastus01"], "      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l chomp-test\n")
+    error_message = "The chomped key must still be written, indented under content:."
+  }
+}
+
+# Every node gets the key, not just the first. ce_count=3 is the demo shape.
+run "every_ce_node_gets_the_operator_key" {
+  command = plan
+
+  variables {
+    ce_count       = 3
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+  }
+
+  assert {
+    condition = alltrue([
+      for k, doc in local.ce_cloud_init :
+      strcontains(doc, "  - path: /var/home/admin/.ssh/authorized_keys\n") && strcontains(doc, "      ${var.ssh_public_key}\n")
+    ])
+    error_message = "Every CE node's cloud-init must authorize the operator key."
+  }
+
+  assert {
+    condition     = length(local.ce_cloud_init) == 3
+    error_message = "ce_count=3 must render three cloud-init documents."
+  }
+}


### PR DESCRIPTION
Closes #671

## What this changes

`terraform/cloud-init/ce-node.yaml` gains a second `write_files` entry that writes the
operator public key to `/var/home/admin/.ssh/authorized_keys` on the CE appliance,
`0600`, `owner: admin:admin`.

The rendered cloud-init document moves from an inline `templatefile()` in the `ce_node`
module block into `local.ce_cloud_init` (one document per node). That is not cosmetic: a
`templatefile()` inlined in a module block is not addressable from `terraform test`, and
the rendered YAML is the entire contract with the appliance. As a local it can be
asserted, which is what `terraform/tests/cloud_init.tftest.hcl` now does.

## Why the earlier attempts failed, and why this one does not

The node was never refusing SSH. It had no authorized key, and the one API field that
looked like it would install one is a no-op.

`vpm` explicitly skips the `admin` user:

```
vpm  users.go:165: Won't do any change for user admin (internal skip)
```

That is why `admin_user_credentials.ssh_key` (added in #659, reverted in #663) was inert —
stored on the site object, visible in the API read-back, never consumed — and why
`/var/home/admin/.ssh/authorized_keys` never exists. `sshd` itself is willing:
`pubkeyauthentication yes`.

So cloud-init writes the file directly. Three properties of the appliance make that
sufficient, each verified rather than assumed:

- `admin` (uid 2202, home `/var/home/admin`, shell `/opt/bin/vpmu`) is baked into the node
  image and exists **before** cloud-init runs, so `owner: admin:admin` resolves at write
  time. No `runcmd` and no `chown` fixup.
- `admin` is in `AllowUsers` in **both** sshd configs that ship on the node.
  `/etc/ssh/sshd_config` lists `admin vesadmin vesop xcuser centos core vagrant azureuser
  cloud-user`; `/etc/ssh/sshd_config_hardening` lists `admin vesadmin vesop vesbkp centos
  core`. The live file is swapped during registration, so `sshd_config` is never edited
  here — and note `azureuser` does not survive that swap, which is why the grant targets
  `admin`.
- vpm's user pass never rewrites the file, so the key persists past registration.

## Not gated behind a variable — reasoning

I did **not** put this behind a `ce_*_enabled` variable. The judgement, to be argued with
rather than assumed:

1. **A variable would not be an operational control.** `custom_data` is replace-only and
   cloud-init runs once, at first boot. Flipping such a flag does not grant or revoke
   access on a running fleet — it destroys and rebuilds all three CE VMs. Default-off
   would therefore mean "unavailable at precisely the moment you need it", since the
   break-glass scenario is exactly when you cannot afford to rebuild the node you are
   trying to inspect.
2. **The false branch would be untested surface** for no operational gain, against this
   repo's YAGNI standard.
3. **`ce_ssh_enabled` already exists as a discredited name** (#659, reverted in #663) where
   it gated the *inert API field*. Reusing that name for a mechanism that actually works
   would actively mislead.

**The honest security delta**, stated plainly rather than minimised: before this change
nobody can SSH to a registered CE — `azureuser` is dropped by the hardening config swap,
so the VM-level `admin_ssh_key` does not help. After it, the holder of the operator key
can log in as `admin`. That is a real new grant. What bounds it:

- **Reachability.** `sshd` binds `0.0.0.0:22` but only the internal/SLI address answers.
  eth0 is renamed `a-i-eth0` and carries no host IP because the datapath owns it, so the
  SLO/mgmt and external addresses have no listener at all. Probed from inside the VNet
  with positive and negative controls:

  ```
  CE internal/SLI   10.0.3.5:22   CONNECTED  SSH-2.0-OpenSSH_8.7
  CE mgmt/SLO       10.0.1.4:22   timed out
  CE external       10.0.2.4:22   timed out
  unused IP         10.0.3.99:22  TimeoutError
  ```

  So this is an RFC1918-only listener inside the hub VNet, not an internet-facing one.
- **Shell.** `admin`'s login shell is the Site CLI (`/opt/bin/vpmu`), not a
  general-purpose shell.
- **Principal.** The key authorized is `local.ssh_public_key` — the same operator key the
  deployment already puts on these VMs and the client VM. No new principal is introduced.

If you would rather have the flag anyway, say so and I will add it — but please read
point 1 first, because a default-off flag here is a rebuild, not a switch.

## Tests

`terraform/tests/cloud_init.tftest.hcl`, four `run` blocks, no credentials required:

- the `authorized_keys` entry, asserted as **one exact multi-line substring** covering
  path, mode, owner, key and the two-space YAML indent together — a correct mode on the
  wrong path, or the right key under a mis-indented entry, each passes a looser test and
  fails on the node;
- a regression guard that the vpm `config.yaml` entry, the token, the `ClusterName` and
  the `#cloud-config` header all survive (this is what makes the node register at all, so
  breaking it costs three CE rebuilds to discover);
- `chomp()` of a trailing newline on the key, exercised by passing a key that ends in one —
  which is exactly what `file(var.ssh_public_key_path)` yields on the real path;
- every node in a `ce_count = 3` deployment gets the key, not just the first.

`registration_token` is pinned to a literal in that file because the default path takes
the token from `xcsh_token.ce.uid`, which stays unknown at plan time even under
`mock_provider` — without the pin every assertion fails with "Unknown condition value"
rather than on its own merits.

Also corrects two code comments that asserted the node "refuses SSH as shipped"
(`modules/ce-node/main.tf`, `tests/ce_node.tftest.hcl`). Boot diagnostics are still
required and still justified: the serial console remains the only way into a CE that has
not finished first boot, because operator SSH depends on cloud-init having run and the SLI
interface being up.

`docs/` is deliberately untouched; a separate pass updates the guides.

## Cost of applying

`custom_data` forces replacement and cloud-init runs only at first boot, so there is no
in-place path onto existing nodes. Applying this **replaces all three CE VMs**. The plan
was confirmed to be exactly that and nothing else — 3 replacements, 43 other resources
no-op.

## Verification

Local: `terraform fmt -check -recursive`, `terraform validate`, `tflint --recursive`,
`terraform test` (18/18), `codespell`, `shellcheck`, `shfmt -d` all clean.

The rendered `custom_data` was decoded straight out of the plan JSON, parsed as YAML, and
checked to contain both `write_files` entries with the right mode, owner and a single
trailing newline on the key.

Live verification against the demo — three sites `ONLINE`, 3-way ECMP per peering, VIP
returning 200, a real `ssh admin@<SLI>` login on each CE and `execcli` over that session —
is reported in a comment on this PR.
