### PR TITLE
feat(sitecli): harvest the on-box command surface over SSH, execution default-denied

### DIFF
--- a/scripts/sitecli_ssh_harvest.py
+++ b/scripts/sitecli_ssh_harvest.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Enumerate the Customer Edge Site CLI command surface over SSH.
+
+The `vpm/debug` API exposes 34 commands. The appliance itself offers many more,
+and `scripts/capture-sitecli.sh` cannot see them because they are not on that
+API at all. This drives the on-box CLI directly and writes down what it finds.
+
+Access
+------
+`admin`'s login shell is `/opt/bin/vpmu`, the Site CLI, reachable over SSH once
+cloud-init has written `/var/home/admin/.ssh/authorized_keys` (PR #672). Three
+things about that path are not guessable:
+
+  * `sshd` answers on the **SLI** address only. eth0 is renamed `a-i-eth0` and
+    carries no host IP — the Argo data plane owns it — so the management address
+    and the public address time out exactly as a closed security group would.
+    Reach the SLI address from a VM inside the VNet; hence --jump.
+  * `vpmu` panics without a tty (`go-prompt ... no such device or address`), so
+    a pty is mandatory, Enter is CR, and stdin must stay open. Closing stdin
+    ends the session before the command has rendered.
+  * The command text and the Enter byte must be **separate writes**. In one
+    write the newline lands in the buffer as a literal character and the CLI
+    answers `unknown command`, which reads as though the command is absent.
+
+Discovery
+---------
+`execcli` is a hidden command — it is not in the interactive menu — and takes a
+command name. Typing `execcli ` then TAB opens a completion menu carrying the
+appliance's own one-line description for each command. That menu is the
+authoritative catalog for this build.
+
+go-prompt caps the menu at six visible rows as an application setting, which a
+larger terminal does not change. So a six-row read is indistinguishable from a
+six-command surface: scroll with Down and accumulate until it stops yielding
+anything new.
+
+Safety
+------
+Execution is **default-denied**. Only names on READ_ONLY may be run; anything
+else is enumerated and never executed.
+
+This is deliberately an allow-list and not a deny-list. Argument arity is
+discoverable by running a command bare, and during the manual enumeration that
+preceded this script it was run against `vifdump` — packet capture, writing
+.pcap into /tmp inside the Argo container, on a node with a 31 GiB disk that was
+mid-registration. `vifdump` was on no deny-list because nobody had thought of
+it. That is the failure mode an allow-list closes: a command nobody anticipated
+is refused by default rather than permitted by omission.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+from pathlib import Path
+
+# --- pure parsing ------------------------------------------------------------
+
+# Menu rows are separated by a cursor-down, not a newline. Split before
+# stripping ANSI or every row concatenates onto one line.
+ROW_SEPARATOR = "\x1b[1B"
+
+ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[=>DM]")
+
+# Two or more spaces separate the padded name column from the description.
+COLUMNS = re.compile(r"\s{2,}")
+
+PROMPT = ">>> "
+
+
+def strip_ansi(text: str) -> str:
+    """Remove the escape sequences the Site CLI paints its output with."""
+    return ANSI.sub("", text)
+
+
+def parse_menu(raw: str) -> list[tuple[str, str]]:
+    """Extract (name, description) from one rendered completion menu.
+
+    Reads every row regardless of its colour codes: the selected row is drawn
+    differently from the rest, and keying on one colour pair silently drops it.
+    """
+    rows: list[tuple[str, str]] = []
+    for segment in raw.split(ROW_SEPARATOR):
+        text = strip_ansi(segment).strip()
+        if not text or text.startswith(PROMPT.strip()):
+            continue
+        parts = COLUMNS.split(text)
+        name = parts[0].strip()
+        # A command name is a single token. Anything else is prompt echo or a
+        # wrapped fragment, not a menu row.
+        if not name or " " in name:
+            continue
+        rows.append((name, parts[1].strip() if len(parts) > 1 else ""))
+    return rows
+
+
+class MenuAccumulator:
+    """Collects rows across a scrolling menu, first-seen order, no duplicates.
+
+    Consecutive pages overlap by all but one row, so de-duplication is not an
+    optimisation — without it the count is meaningless.
+    """
+
+    def __init__(self) -> None:
+        """Start with an empty, insertion-ordered set of commands."""
+        self.commands: dict[str, str] = {}
+
+    def absorb(self, raw: str) -> int:
+        """Add any unseen rows from one rendered page; return how many were new."""
+        added = 0
+        for name, description in parse_menu(raw):
+            if name not in self.commands:
+                self.commands[name] = description
+                added += 1
+        return added
+
+
+# --- safety ------------------------------------------------------------------
+
+# Commands that only read. Anything absent from this set is refused, including
+# commands from a future build that nobody has classified yet.
+READ_ONLY = frozenset(
+    {
+        # Argo data plane
+        "dropstats",
+        "dropstats-non-zero",
+        "flow-l",
+        "flow-l-match",
+        "nh",
+        "rt",
+        "vif",
+        "mpls",
+        # Routing and tunnels
+        "show-ip-bgp",
+        "show-ip-bgp-summary",
+        "show-ip-bgp-neighbors",
+        "show-ip-bgp-neighbors-advertised-route",
+        "ipsec-status",
+        "ipsec-statusall",
+        # Vega control plane
+        "vegactl-configuration-list",
+        "vegactl-introspect-dump-table",
+        "vegactl-introspect-get",
+        "vegactl-introspect-list-tracebuffers",
+        "vegactl-introspect-show-election",
+        "vegactl-introspect-show-tracebuffer",
+        # Envoy
+        "envoy-clusters",
+        "envoy-config-dump",
+        "envoy-hc-config-dump",
+        "envoy-listeners",
+        # Container runtimes
+        "crictl-ps",
+        "crictl-ps-a",
+        "crictl-images",
+        "crictl-inspect",
+        "crictl-logs",
+        "docker-ps",
+        "docker-ps-a",
+        "docker-images",
+        "docker-inspect",
+        "docker-logs",
+        # Service and cluster state
+        "systemctl-status-vpm",
+        "systemctl-status-crio",
+        "systemctl-status-docker",
+        "systemctl-status-kubelet",
+        "systemctl-status-iscsid",
+        "systemctl-status-multipathd",
+        "etcdctl-cluster-member-status",
+        "kubelet-get-params",
+        # Host inspection
+        "journalctl",
+        "netstat",
+        "lsof",
+        "ip",
+        "ip-link-show",
+        "check-mem",
+        "chronyc-sources",
+        "ping",
+        "tracepath",
+        "curl-host",
+        "curl-vega",
+        # Site CLI top level
+        "health",
+        "diagnosis",
+    }
+)
+
+
+class RefusedCommandError(RuntimeError):
+    """Raised rather than returned, so a refusal cannot be ignored by accident."""
+
+    def __init__(self, name: str) -> None:
+        """Build the refusal message from the command that was refused."""
+        super().__init__(
+            f"{name!r} is not on the read-only allow-list and will not be run. "
+            "Enumeration records that it exists; execution is default-denied.",
+        )
+        self.name = name
+
+
+def may_execute(name: str) -> bool:
+    """Report whether a command is on the read-only allow-list."""
+    return name in READ_ONLY
+
+
+def guard(name: str) -> None:
+    """Refuse any command that is not explicitly known to be read-only."""
+    if not may_execute(name):
+        raise RefusedCommandError(name)
+
+
+# --- the live session --------------------------------------------------------
+
+
+class SiteCliSession:
+    """A pty-backed SSH session to the Site CLI."""
+
+    def __init__(self, node: str, jump: str, key: str, user: str = "admin") -> None:
+        """Open a pty and start an SSH session to the node's Site CLI."""
+        master, slave = pty.openpty()
+        # Declare a large window before login. It does not widen the six-row
+        # completion menu, but it stops long usage text from being wrapped.
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 120, 220, 0, 0))
+        argv = [
+            "ssh",
+            "-tt",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "ConnectTimeout=10",
+            "-i",
+            key,
+        ]
+        if jump:
+            argv += ["-o", f"ProxyJump={jump}"]
+        argv.append(f"{user}@{node}")
+        self.proc = subprocess.Popen(  # noqa: S603 - fixed argv, resolved executable, no shell
+            argv,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            close_fds=True,
+        )
+        os.close(slave)
+        self.fd = master
+
+    def read_until_idle(self, idle: float = 2.0, hard: float = 30.0) -> str:
+        """Read until the stream goes quiet.
+
+        The Site CLI repaints its prompt continuously and prints no
+        end-of-output marker, so silence is the only usable completion signal.
+        """
+        deadline = time.time() + hard
+        last = time.time()
+        out = ""
+        while time.time() < deadline:
+            ready, _, _ = select.select([self.fd], [], [], 0.3)
+            if ready:
+                try:
+                    chunk = os.read(self.fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                out += chunk.decode("utf-8", "replace")
+                last = time.time()
+            elif time.time() - last > idle:
+                break
+        return out
+
+    def send(self, keys: str) -> None:
+        """Write keystrokes to the pty."""
+        os.write(self.fd, keys.encode())
+
+    def wait_for_prompt(self, hard: float = 60.0) -> str:
+        """Read until the prompt appears.
+
+        The banner queries vpm for system info and is slow, so waiting for the
+        prompt string beats guessing a delay.
+        """
+        deadline = time.time() + hard
+        out = ""
+        while time.time() < deadline:
+            out += self.read_until_idle(idle=1.5, hard=8)
+            if PROMPT in strip_ansi(out):
+                return out
+        message = "Site CLI prompt never appeared"
+        raise TimeoutError(message)
+
+    def scroll_menu(
+        self,
+        opener: str,
+        max_scrolls: int = 500,
+        patience: int = 30,
+    ) -> dict[str, str]:
+        """Open a completion menu and scroll it to exhaustion."""
+        self.send(opener)
+        self.read_until_idle(idle=1.5, hard=10)
+        self.send("\t")
+        acc = MenuAccumulator()
+        acc.absorb(self.read_until_idle(idle=3.0, hard=20))
+        barren = 0
+        for _ in range(max_scrolls):
+            self.send("\x1b[B")
+            if acc.absorb(self.read_until_idle(idle=0.4, hard=5)):
+                barren = 0
+            else:
+                barren += 1
+                if barren >= patience:
+                    break
+        # Abandon the half-typed line rather than submitting it.
+        self.send("\x03")
+        self.read_until_idle(idle=1.0, hard=5)
+        return acc.commands
+
+    def run(self, command: str, idle: float = 5.0, hard: float = 60.0) -> str:
+        """Run one allow-listed command and return its output, stripped of ANSI."""
+        guard(command)
+        self.send(
+            f"execcli {command}" if command not in {"health", "diagnosis"} else command
+        )
+        self.read_until_idle(idle=0.8, hard=5)
+        self.send("\r")  # separate write, or the newline becomes a literal
+        return strip_ansi(self.read_until_idle(idle=idle, hard=hard))
+
+    def close(self) -> None:
+        """Interrupt any half-typed line, end the session and release the pty."""
+        with contextlib.suppress(OSError):
+            self.send("\x03")
+            self.read_until_idle(idle=0.5, hard=3)
+        self.proc.terminate()
+        with contextlib.suppress(OSError):
+            os.close(self.fd)
+
+
+# --- entry point -------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Enumerate the command surface of one node and write the catalog."""
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    parser.add_argument("--node", required=True, help="CE SLI address, e.g. 10.0.3.5")
+    parser.add_argument(
+        "--jump", default="", help="jump host inside the VNet, e.g. azureuser@1.2.3.4"
+    )
+    parser.add_argument("--key", default=str(Path("~/.ssh/id_ed25519").expanduser()))
+    parser.add_argument("--site", default="", help="recorded as provenance only")
+    parser.add_argument("--build", default="", help="recorded as provenance only")
+    parser.add_argument(
+        "--site-state",
+        default="",
+        help="site_state at capture time. A menu read while PROVISIONING may be "
+        "a reduced set, so an absent command is not evidence of absence.",
+    )
+    parser.add_argument("--out", default="sitecli/exec-catalog.json")
+    args = parser.parse_args(argv)
+
+    session = SiteCliSession(args.node, args.jump, args.key)
+    try:
+        session.wait_for_prompt()
+        top_level = session.scroll_menu("")
+        exec_commands = session.scroll_menu("execcli ")
+    finally:
+        session.close()
+
+    catalog = {
+        "_provenance": {
+            "node": args.node,
+            "site": args.site,
+            "build": args.build,
+            "site_state": args.site_state,
+            "source": "Site CLI completion menu over SSH",
+        },
+        "top_level": dict(sorted(top_level.items())),
+        "execcli": dict(sorted(exec_commands.items())),
+        "counts": {"top_level": len(top_level), "execcli": len(exec_commands)},
+    }
+    with Path(args.out).open("w", encoding="utf-8") as handle:
+        json.dump(catalog, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+    print(
+        f"{len(top_level)} top-level and {len(exec_commands)} execcli commands "
+        f"-> {args.out}"
+    )
+    if not args.site_state:
+        print("warning: --site-state not recorded; absence of a command proves nothing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sitecli_ssh_harvest.py
+++ b/scripts/sitecli_ssh_harvest.py
@@ -249,12 +249,18 @@ class SiteCliSession:
         if jump:
             argv += ["-o", f"ProxyJump={jump}"]
         argv.append(f"{user}@{node}")
-        self.proc = subprocess.Popen(  # noqa: S603 - fixed argv, resolved executable, no shell
-            argv,
-            stdin=slave,
-            stdout=slave,
-            stderr=slave,
-            close_fds=True,
+        self._stack = contextlib.ExitStack()
+        # The session must outlive this constructor, so the process cannot sit in
+        # a `with` block here — that would terminate it before a single command
+        # ran. An ExitStack gives the same guaranteed teardown, unwound by close().
+        self.proc = self._stack.enter_context(
+            subprocess.Popen(  # noqa: S603 - fixed argv, resolved executable, no shell
+                argv,
+                stdin=slave,
+                stdout=slave,
+                stderr=slave,
+                close_fds=True,
+            ),
         )
         os.close(slave)
         self.fd = master
@@ -344,6 +350,7 @@ class SiteCliSession:
             self.send("\x03")
             self.read_until_idle(idle=0.5, hard=3)
         self.proc.terminate()
+        self._stack.close()
         with contextlib.suppress(OSError):
             os.close(self.fd)
 
@@ -353,7 +360,9 @@ class SiteCliSession:
 
 def main(argv: list[str] | None = None) -> int:
     """Enumerate the command surface of one node and write the catalog."""
-    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    parser = argparse.ArgumentParser(
+        description=(__doc__ or "").split("\n", maxsplit=1)[0]
+    )
     parser.add_argument("--node", required=True, help="CE SLI address, e.g. 10.0.3.5")
     parser.add_argument(
         "--jump", default="", help="jump host inside the VNet, e.g. azureuser@1.2.3.4"

--- a/tests/sitecli_harvest_test.py
+++ b/tests/sitecli_harvest_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Hermetic tests for scripts/sitecli_ssh_harvest.py.
 
+Run via tests/test-sitecli-harvest.sh, which is what CI globs.
+
 No network, no pty, no CE. Everything under test is a pure function that takes
 bytes the appliance already produced and decides something about them.
 
@@ -112,7 +114,7 @@ def test_a_description_containing_spaces_is_not_split_further():
 
 
 def test_empty_input_yields_nothing():
-    assert h.parse_menu("") == []
+    assert not h.parse_menu("")
 
 
 # --- accumulation across a scrolling menu ------------------------------------

--- a/tests/test-sitecli-harvest.py
+++ b/tests/test-sitecli-harvest.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Hermetic tests for scripts/sitecli_ssh_harvest.py.
+
+No network, no pty, no CE. Everything under test is a pure function that takes
+bytes the appliance already produced and decides something about them.
+
+The escape structure in the fixtures is copied from a real capture of the Site
+CLI completion menu. It is not decorative: each detail is a way the parser can
+be wrong.
+
+  - Rows are separated by cursor-down (ESC[1B), never by newlines. Strip ANSI
+    before splitting and all 82 rows concatenate into a single line.
+  - The selected row uses different colour codes from the unselected ones, so a
+    parser keyed on one colour pair silently sees a fraction of the menu.
+  - Columns are space-padded to a fixed width, so name and description must be
+    split on a run of spaces rather than a single one.
+  - The prompt is redrawn inside the same stream and is not a menu row.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sitecli_ssh_harvest as h
+
+ESC = "\x1b"
+DOWN = f"{ESC}[1B"
+NAME_SELECTED = f"{ESC}[1;30;106m"
+NAME_PLAIN = f"{ESC}[0;97;46m"
+DESC_SELECTED = f"{ESC}[0;30;106m"
+DESC_PLAIN = f"{ESC}[0;97;46m"
+
+
+def row(name, desc, selected=False):
+    """Render one menu row the way go-prompt draws it."""
+    name_colour = NAME_SELECTED if selected else NAME_PLAIN
+    desc_colour = DESC_SELECTED if selected else DESC_PLAIN
+    return (
+        f"{DOWN}{name_colour} {name:<38} {desc_colour} {desc:<110} "
+        f"{ESC}[0;39;100m {ESC}[0;39;49m"
+    )
+
+
+FIRST_PAGE = (
+    f"{ESC}[12D{ESC}[?25l{ESC}[0;94;49m>>> {ESC}[0;39;49mexeccli {ESC}[J"
+    + f"{ESC}D" * 6
+    + f"{ESC}M" * 6
+    + row("nh", "invoke argo nh command", selected=True)
+    + row("dropstats", "dump argo dropstats")
+    + row("vifdump-file-rm", "rm argo /tmp/*.pcap file")
+    + row("vif", "invoke argo vif command")
+    + row("vifdump-d", "Capture dropped packets on specified vif id or all vif")
+    + row("rt", "invoke argo rt command")
+)
+
+# The window scrolled by one: five rows repeat, one is new. A harvester that
+# does not de-duplicate reports 12 commands where there are 7.
+SECOND_PAGE = (
+    row("dropstats", "dump argo dropstats")
+    + row("vifdump-file-rm", "rm argo /tmp/*.pcap file")
+    + row("vif", "invoke argo vif command")
+    + row("vifdump-d", "Capture dropped packets on specified vif id or all vif")
+    + row("rt", "invoke argo rt command", selected=True)
+    + row("flow-l", "dump argo flow info")
+)
+
+
+def refuses(name):
+    """Report whether the guard rejects a command."""
+    try:
+        h.guard(name)
+    except h.RefusedCommandError:
+        return True
+    return False
+
+
+# --- menu parsing ------------------------------------------------------------
+
+
+def test_extracts_every_row_on_a_page():
+    assert [n for n, _ in h.parse_menu(FIRST_PAGE)] == [
+        "nh",
+        "dropstats",
+        "vifdump-file-rm",
+        "vif",
+        "vifdump-d",
+        "rt",
+    ]
+
+
+def test_reads_the_selected_row_too():
+    # The selected row carries different colour codes. It is a real command.
+    assert ("nh", "invoke argo nh command") in h.parse_menu(FIRST_PAGE)
+
+
+def test_keeps_descriptions_intact():
+    rows = dict(h.parse_menu(FIRST_PAGE))
+    assert rows["vifdump-d"] == "Capture dropped packets on specified vif id or all vif"
+
+
+def test_ignores_the_prompt_redraw():
+    names = [n for n, _ in h.parse_menu(FIRST_PAGE)]
+    assert "execcli" not in names
+    assert ">>>" not in names
+
+
+def test_a_description_containing_spaces_is_not_split_further():
+    rows = dict(h.parse_menu(row("files", "perform file operations on node")))
+    assert rows["files"] == "perform file operations on node"
+
+
+def test_empty_input_yields_nothing():
+    assert h.parse_menu("") == []
+
+
+# --- accumulation across a scrolling menu ------------------------------------
+
+
+def test_overlapping_pages_deduplicate():
+    acc = h.MenuAccumulator()
+    assert acc.absorb(FIRST_PAGE) == 6
+    assert acc.absorb(SECOND_PAGE) == 1
+    assert len(acc.commands) == 7
+
+
+def test_order_is_first_seen():
+    acc = h.MenuAccumulator()
+    acc.absorb(FIRST_PAGE)
+    acc.absorb(SECOND_PAGE)
+    names = list(acc.commands)
+    assert names[0] == "nh"
+    assert names[-1] == "flow-l"
+
+
+def test_a_repeated_page_adds_nothing():
+    acc = h.MenuAccumulator()
+    acc.absorb(FIRST_PAGE)
+    assert acc.absorb(FIRST_PAGE) == 0
+
+
+# --- execution is default-denied ---------------------------------------------
+#
+# The guard that did not exist when `vifdump` was probed with no arguments on a
+# registering node. A deny-list would not have helped: vifdump was on no list.
+# Only an explicit allow-list refuses a command nobody thought about.
+
+
+def test_a_known_read_only_command_is_allowed():
+    assert h.may_execute("crictl-ps")
+    assert h.may_execute("show-ip-bgp-summary")
+
+
+def test_packet_capture_is_refused():
+    for name in ("vifdump", "vifdump-d", "vifdump-stop", "vifdump-file-rm"):
+        assert not h.may_execute(name), name
+
+
+def test_mutating_commands_are_refused():
+    for name in (
+        "docker-prune",
+        "systemctl-restart-vpm",
+        "ip-link-set",
+        "edit-etc-hosts",
+        "get-auxilary-root-access-to-node",
+        "kubelet-add-param",
+        "factory-reset",
+    ):
+        assert not h.may_execute(name), name
+
+
+def test_an_unknown_command_is_refused():
+    # The whole point: a command nobody has classified yet cannot be run.
+    assert not h.may_execute("some-command-from-a-future-build")
+    assert not h.may_execute("")
+
+
+def test_guard_raises_rather_than_returning_quietly():
+    assert refuses("vifdump")
+    assert not refuses("crictl-ps")
+
+
+def test_allow_list_contains_no_mutating_verb():
+    # A cheap tripwire for future edits to the allow-list.
+    forbidden = ("restart", "prune", "edit-", "-set", "add-param", "remove", "reset")
+    for name in h.READ_ONLY:
+        assert not any(word in name for word in forbidden), (
+            f"{name} looks mutating but is on the read-only allow-list"
+        )
+
+
+def run_one(fn):
+    """Run one test and return its failure message, or None if it passed."""
+    try:
+        fn()
+    except AssertionError as exc:
+        return str(exc) or "assertion failed"
+    return None
+
+
+def main():
+    """Run every test_* in this module and report like the shell suites do."""
+    logging.basicConfig(format="%(message)s", level=logging.INFO, stream=sys.stdout)
+    log = logging.getLogger("sitecli-harvest")
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        failure = run_one(fn)
+        if failure is None:
+            log.info("[OK] %s", name)
+        else:
+            log.info("[FAIL] %s - %s", name, failure)
+            failures += 1
+    log.info("sitecli-harvest tests %s", "FAILED" if failures else "passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test-sitecli-harvest.sh
+++ b/tests/test-sitecli-harvest.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Runs the Python unit tests for scripts/sitecli_ssh_harvest.py.
+#
+# This wrapper exists because the shared Shell Unit Tests job globs
+# `tests/test-*.sh` and nothing else, so a bare .py test would never run in CI.
+# Everything it drives is hermetic: no network, no pty, no Customer Edge.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+exec python3 "${REPO_ROOT}/tests/test-sitecli-harvest.py"

--- a/tests/test-sitecli-harvest.sh
+++ b/tests/test-sitecli-harvest.sh
@@ -3,8 +3,9 @@
 #
 # This wrapper exists because the shared Shell Unit Tests job globs
 # `tests/test-*.sh` and nothing else, so a bare .py test would never run in CI.
+# The Python module is named for pylint's snake_case rule, not the glob.
 # Everything it drives is hermetic: no network, no pty, no Customer Edge.
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
-exec python3 "${REPO_ROOT}/tests/test-sitecli-harvest.py"
+exec python3 "${REPO_ROOT}/tests/sitecli_harvest_test.py"


### PR DESCRIPTION
Closes #675. Follow-up work is tracked in #679.

## Why

The documented Site CLI surface in this repo comes from the `vpm/debug` API: 34
commands. The appliance's own surface is larger, and the extra commands are not on
that API at all, so `scripts/capture-sitecli.sh` structurally cannot reach them.

`execcli` is a **hidden** Site CLI command — absent from the interactive menu — that
takes a command name. `execcli ` + TAB opens a completion menu carrying the appliance's
own one-line description for each command. That menu is the authoritative catalog for a
build, and this script reads it.

## Safety: default-denied, not deny-listed

Argument arity is discoverable by running a command bare. During the manual enumeration
that preceded this script, that was done to `vifdump` — packet capture writing `.pcap`
into `/tmp` inside the Argo container, on a node with a 31 GiB disk that was
mid-registration. It returned no error, so whether a capture started is unknown.

A deny-list would not have prevented it: `vifdump` was on no list. Only names on the
explicit `READ_ONLY` allow-list may be executed; everything else is enumerated and
never run, including commands from a future build that nobody has classified.

## What is tested, and how the tests were checked

15 hermetic tests — no network, no pty, no CE — over the two pure parts: menu parsing
and the safety decision.

The fixtures reproduce the real escape structure rather than a tidied version of it,
because each detail is a way the parser silently sees a fraction of the menu:

| Detail | What a naive parser does |
| --- | --- |
| Rows separated by cursor-down (`ESC[1B`), not newlines | All 82 rows concatenate onto one line |
| The selected row uses different colour codes | Keying on one colour pair drops it |
| Space-padded columns | Splitting on a single space mangles descriptions |
| The prompt is redrawn in the same stream | `execcli` is read as a command name |

Two checks that the tests are worth anything:

- **Validated against the real bytes.** Replaying tonight's actual captured menu through
  `parse_menu` yields the same six rows with the same descriptions as the fixture.
- **The guard was proven to fire.** Putting `vifdump` on the allow-list makes
  `test_packet_capture_is_refused` and `test_guard_raises_rather_than_returning_quietly`
  fail and the suite exit 1. Restored, it exits 0.

```
$ bash tests/test-sitecli-harvest.sh
[OK] test_a_description_containing_spaces_is_not_split_further
... 15 tests ...
sitecli-harvest tests passed
```

The `.sh` wrapper exists because the shared Shell Unit Tests job globs `tests/test-*.sh`
and would never run a bare `.py`.

`ruff check` and `ruff format` clean against the repo's `.ruff.toml`; `pre-commit` passes.
The one `noqa` is `S603` on the `ssh` invocation, matching the existing convention in
`scripts/serial_console_capture.py` (fixed argv, resolved executable, no shell).

## Not in this PR

The script has **not been run against a node in this PR**. The demo site is `FAILED` via
#674 and the other developer's deployment is still settling, so the CEs are not to be
touched. Running it, committing `sitecli/exec-catalog.json` and correcting
`sitecli/command-classification.json` are **#679**, split out for that reason.

The open question there matters for reading the earlier measurements: the 82-command enumeration
was taken while the node was `PROVISIONING`, so an absent command is not yet evidence of
absence. `--site-state` is a required piece of provenance for exactly that reason, and
the script warns when it is omitted.

## Lint parity

The first push failed `PYTHON_PYLINT`, because only ruff was reproduced locally. pylint
and mypy are now installed and run against the repo configs at the same pylint version
CI uses (4.0.6): **10.00/10**, mypy clean, ruff and ruff-format clean. All four findings
were fixed at the source; none suppressed.

The module/wrapper split is the interesting one: pylint wants a snake_case module name
and the Shell Unit Tests job globs `tests/test-*.sh`. Naming the Python module
`sitecli_harvest_test.py` and the wrapper `test-sitecli-harvest.sh` satisfies both
instead of trading one off against the other.
