### PR TITLE
feat(azure-hub): Azure Bastion so developers reach the CE Site Console web UI without a jump host

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,6 +66,9 @@ module "azure_hub" {
   internal_subnet_prefix     = var.internal_subnet_prefix
   route_server_subnet_prefix = var.route_server_subnet_prefix
   route_server_name          = var.route_server_name
+  bastion_subnet_prefix      = var.bastion_subnet_prefix
+  enable_bastion             = var.enable_bastion
+  bastion_name               = var.bastion_name
   tags                       = local.tags
 }
 

--- a/terraform/modules/azure-hub/main.tf
+++ b/terraform/modules/azure-hub/main.tf
@@ -62,3 +62,75 @@ resource "azurerm_route_server" "this" {
   subnet_id            = azurerm_subnet.route_server.id
   tags                 = var.tags
 }
+
+# --------------------------------------------------------------------------
+# Azure Bastion — reachability for the CE Site Console web UI (TCP 65500)
+# --------------------------------------------------------------------------
+# F5's documented CE troubleshooting path is the per-node Site Console at
+# https://<node-ip>:65500 as `admin`. Verified on this deployment: of a CE's three
+# private addresses only the SLI one (snet-hub-internal) answers at all — mgmt/SLO
+# and external are closed on every port probed — and it is reachable only from
+# inside the VNet. Bastion closes the gap without distributing SSH keys and
+# without touching the CE: who may connect becomes an Azure RBAC decision.
+#
+# AzureBastionSubnet: name is literal, /26 or larger, and — like
+# RouteServerSubnet above — deliberately carries NO NSG and NO route table.
+# Bastion works without an NSG; adding one obliges you to maintain Azure's exact
+# required allow-rule set (GatewayManager, AzureLoadBalancer, the 8080/5701
+# intra-subnet pair) for no security gain in a lab whose VMs already sit behind
+# their own NSGs.
+resource "azurerm_subnet" "bastion" {
+  count = var.enable_bastion ? 1 : 0
+
+  name                 = "AzureBastionSubnet"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.hub.name
+  address_prefixes     = [var.bastion_subnet_prefix]
+}
+
+resource "azurerm_public_ip" "bastion" {
+  count = var.enable_bastion ? 1 : 0
+
+  name                = "${var.bastion_name}-pip"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+# Standard SKU is not a preference — Basic supports neither native-client
+# tunneling nor IP-based connection.
+#
+#   tunneling_enabled  -> load-bearing. `az network bastion tunnel` forwards an
+#                         arbitrary TCP port, which is the only way to reach 65500.
+#   ip_connect_enabled -> NOT the path to 65500, and deliberately not claimed to
+#                         be. Microsoft documents that "custom ports and protocols
+#                         aren't currently supported when connecting to a virtual
+#                         machine via native client with IP-based connections"
+#                         (learn.microsoft.com/azure/bastion/connect-ip-address),
+#                         and the CLI enforces it: --target-ip-address with
+#                         --resource-port 65500 is refused with "Allowed ports for
+#                         Tunnel with IP connect is 22, 3389". It is on because it
+#                         costs nothing and lets an operator target an in-VNet IP
+#                         directly for portal RDP/SSH. The 65500 tunnel targets the
+#                         CE by VM resource id instead — verified reaching the Site
+#                         Console (HTTP 200) on this deployment.
+resource "azurerm_bastion_host" "this" {
+  count = var.enable_bastion ? 1 : 0
+
+  name                = var.bastion_name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  tunneling_enabled   = true
+  ip_connect_enabled  = true
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.bastion[0].id
+    public_ip_address_id = azurerm_public_ip.bastion[0].id
+  }
+
+  tags = var.tags
+}

--- a/terraform/modules/azure-hub/outputs.tf
+++ b/terraform/modules/azure-hub/outputs.tf
@@ -52,3 +52,18 @@ output "rs_asn" {
   description = "Route Server ASN (fixed by Azure at 65515)."
   value       = azurerm_route_server.this.virtual_router_asn
 }
+
+output "bastion_name" {
+  description = "Azure Bastion host name, or null when Bastion is not deployed. This is the --name argument of `az network bastion tunnel`."
+  value       = one(azurerm_bastion_host.this[*].name)
+}
+
+output "bastion_subnet_id" {
+  description = "AzureBastionSubnet subnet ID, or null when Bastion is not deployed."
+  value       = one(azurerm_subnet.bastion[*].id)
+}
+
+output "bastion_subnet_prefix" {
+  description = "The AzureBastionSubnet prefix this module was given (echoed so callers can assert on it without reading a count-gated resource)."
+  value       = var.bastion_subnet_prefix
+}

--- a/terraform/modules/azure-hub/variables.tf
+++ b/terraform/modules/azure-hub/variables.tf
@@ -39,6 +39,23 @@ variable "route_server_name" {
   default     = "ce-ha-lab-rrs"
 }
 
+variable "bastion_subnet_prefix" {
+  description = "AzureBastionSubnet prefix (/26 or larger, named literally AzureBastionSubnet, no NSG and no route table). Only read when enable_bastion is true."
+  type        = string
+}
+
+variable "enable_bastion" {
+  description = "Deploy Azure Bastion (AzureBastionSubnet + public IP + Standard-SKU host) so the CE Site Console web UI on TCP 65500 is reachable without a jump host. Opt-in: Bastion bills hourly whether or not anyone connects."
+  type        = bool
+  default     = false
+}
+
+variable "bastion_name" {
+  description = "Azure Bastion host name (the --name argument of `az network bastion tunnel`)."
+  type        = string
+  default     = "ce-ha-lab-bastion"
+}
+
 variable "tags" {
   description = "Tags applied to every resource."
   type        = map(string)

--- a/terraform/modules/ce-node/outputs.tf
+++ b/terraform/modules/ce-node/outputs.tf
@@ -8,6 +8,11 @@ output "mgmt_private_ip" {
   value       = azurerm_network_interface.mgmt.private_ip_address
 }
 
+output "sli_private_ip" {
+  description = "Private IP of the internal/SLI NIC — the only one of the CE's three private addresses that answers, and where the Site Console web UI (TCP 65500) is served. Reach it from a workstation with `az network bastion tunnel --target-resource-id <this CE's vm_id> --resource-port 65500`; the mgmt/SLO and external addresses serve nothing."
+  value       = azurerm_network_interface.internal.private_ip_address
+}
+
 output "vm_name" {
   description = "CE VM name."
   value       = azurerm_linux_virtual_machine.this.name

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -41,6 +41,21 @@ output "ce_vm_names" {
   value       = { for k, m in module.ce_node : k => m.vm_name }
 }
 
+output "ce_sli_private_ips" {
+  description = "Per-CE internal/SLI private IPs — where each CE serves its Site Console web UI (TCP 65500). Informational: the Bastion tunnel is targeted by VM resource id (ce_vm_ids), because Azure does not allow a custom resource port over an IP-targeted tunnel."
+  value       = { for k, m in module.ce_node : k => m.sli_private_ip }
+}
+
+output "ce_vm_ids" {
+  description = "Per-CE VM resource IDs — the --target-resource-id of `az network bastion tunnel` when opening the Site Console web UI on 65500."
+  value       = { for k, m in module.ce_node : k => m.vm_id }
+}
+
+output "bastion_name" {
+  description = "Azure Bastion host name, or null when enable_bastion is false. Feed it to `az network bastion tunnel --name`."
+  value       = module.azure_hub.bastion_name
+}
+
 output "client_public_ip" {
   description = "Public IP of the test client."
   value       = module.client_vm.public_ip

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -19,6 +19,26 @@ mgmt_subnet_prefix         = "10.0.1.0/26"
 external_subnet_prefix     = "10.0.2.0/26"
 internal_subnet_prefix     = "10.0.3.0/26"
 route_server_subnet_prefix = "10.0.4.0/27"
+bastion_subnet_prefix      = "10.0.5.0/26"   # only used when enable_bastion = true
+
+# --- Azure Bastion (CE Site Console access) ---
+# Off by default: Bastion bills an hourly standing charge whether or not anyone
+# connects, and nothing in the BGP/ECMP demo depends on it. Turn it on to reach
+# each CE's Site Console web UI (65500, user admin) over an RBAC-controlled tunnel
+# instead of an SSH key and a jump host:
+#
+#   enable_bastion = true
+#   terraform apply
+#   az network bastion tunnel --name "$(terraform output -raw bastion_name)" \
+#     -g "$(terraform output -raw resource_group_name)" \
+#     --target-resource-id "$(terraform output -json ce_vm_ids | jq -r .eastus01)" \
+#     --resource-port 65500 --port 65500 &
+#   open https://localhost:65500/     # log in as admin
+#
+# Target the VM resource id, not the SLI address: Azure refuses a custom resource
+# port over an IP-targeted tunnel (only 22 and 3389 are allowed there).
+#
+# enable_bastion = true
 
 # --- SSH ---
 # Provide the key path (read once at the root) OR paste the material in ssh_public_key.

--- a/terraform/tests/azure_hub.tftest.hcl
+++ b/terraform/tests/azure_hub.tftest.hcl
@@ -20,7 +20,10 @@ run "hub_names_and_subnets" {
     internal_subnet_prefix     = "10.0.3.0/26"
     route_server_subnet_prefix = "10.0.4.0/27"
     route_server_name          = "ce-ha-lab-rrs"
-    tags                       = {}
+    # Required like every other *_subnet_prefix, even with enable_bastion off:
+    # the module never defaults a network address on the caller's behalf.
+    bastion_subnet_prefix = "10.0.5.0/26"
+    tags                  = {}
   }
 
   assert {
@@ -41,5 +44,131 @@ run "hub_names_and_subnets" {
   assert {
     condition     = azurerm_route_server.this.sku == "Standard"
     error_message = "Route Server must use the Standard SKU."
+  }
+}
+
+# Bastion is opt-in: switched off it must add NOTHING, so a deployment that does
+# not want the hourly charge pays nothing for it.
+#
+# enable_bastion is set EXPLICITLY rather than left to its default. `terraform
+# test` auto-loads a root terraform.tfvars, so a run that leans on the default
+# passes in CI (no tfvars) and fails on any workstation whose gitignored
+# terraform.tfvars turns Bastion on — an environment-dependent test. Do not
+# reintroduce one; the default itself is a declaration, asserted nowhere.
+run "bastion_absent_when_disabled" {
+  command = plan
+
+  module {
+    source = "./modules/azure-hub"
+  }
+
+  variables {
+    resource_group_name        = "rmordasiewicz-f5-xc-ce-infra"
+    location                   = "eastus"
+    hub_cidr                   = "10.0.0.0/16"
+    mgmt_subnet_prefix         = "10.0.1.0/26"
+    external_subnet_prefix     = "10.0.2.0/26"
+    internal_subnet_prefix     = "10.0.3.0/26"
+    route_server_subnet_prefix = "10.0.4.0/27"
+    bastion_subnet_prefix      = "10.0.5.0/26"
+    enable_bastion             = false
+    tags                       = {}
+  }
+
+  assert {
+    condition     = length(azurerm_subnet.bastion) == 0
+    error_message = "enable_bastion = false must plan no AzureBastionSubnet."
+  }
+
+  assert {
+    condition     = length(azurerm_public_ip.bastion) == 0
+    error_message = "enable_bastion = false must plan no Bastion public IP."
+  }
+
+  assert {
+    condition     = length(azurerm_bastion_host.this) == 0
+    error_message = "enable_bastion = false must plan no Bastion host."
+  }
+
+  assert {
+    condition     = output.bastion_name == null
+    error_message = "bastion_name must be null when Bastion is not deployed."
+  }
+}
+
+# With Bastion on, every property the CE Site Console path depends on is asserted:
+# the literal subnet name, the Standard SKU, and the two feature flags without which
+# `az network bastion tunnel --target-ip-address ... --resource-port 65500` cannot work.
+run "bastion_enabled_shape" {
+  command = plan
+
+  module {
+    source = "./modules/azure-hub"
+  }
+
+  variables {
+    resource_group_name        = "rmordasiewicz-f5-xc-ce-infra"
+    location                   = "eastus"
+    hub_cidr                   = "10.0.0.0/16"
+    mgmt_subnet_prefix         = "10.0.1.0/26"
+    external_subnet_prefix     = "10.0.2.0/26"
+    internal_subnet_prefix     = "10.0.3.0/26"
+    route_server_subnet_prefix = "10.0.4.0/27"
+    bastion_subnet_prefix      = "10.0.5.0/26"
+    enable_bastion             = true
+    bastion_name               = "ce-ha-lab-bastion"
+    tags                       = {}
+  }
+
+  assert {
+    condition     = azurerm_subnet.bastion[0].name == "AzureBastionSubnet"
+    error_message = "Bastion subnet must be named literally AzureBastionSubnet."
+  }
+
+  assert {
+    condition     = azurerm_subnet.bastion[0].address_prefixes[0] == "10.0.5.0/26"
+    error_message = "AzureBastionSubnet must take var.bastion_subnet_prefix."
+  }
+
+  assert {
+    condition     = azurerm_bastion_host.this[0].sku == "Standard"
+    error_message = "Bastion must use the Standard SKU — Basic supports neither tunneling nor IP-based connection."
+  }
+
+  assert {
+    condition     = azurerm_bastion_host.this[0].tunneling_enabled
+    error_message = "tunneling_enabled must be true or `az network bastion tunnel` cannot forward TCP 65500."
+  }
+
+  # Not the 65500 path (Azure refuses custom ports over IP-based connection — see
+  # modules/azure-hub/main.tf), but asserted so the capability is not silently lost:
+  # it is what lets an operator target an in-VNet IP directly for portal RDP/SSH.
+  assert {
+    condition     = azurerm_bastion_host.this[0].ip_connect_enabled
+    error_message = "ip_connect_enabled must be true so an in-VNet IP can be targeted directly for portal RDP/SSH."
+  }
+
+  assert {
+    condition     = azurerm_public_ip.bastion[0].sku == "Standard" && azurerm_public_ip.bastion[0].allocation_method == "Static"
+    error_message = "Bastion requires a Standard-SKU static public IP."
+  }
+
+  # Subnet/public-IP resource IDs are known-after-apply, so the wiring itself is
+  # not assertable at plan time (see the file header). The plan-knowable half —
+  # that exactly one ip_configuration exists and the public IP is named after the
+  # host — is asserted instead.
+  assert {
+    condition     = length(azurerm_bastion_host.this[0].ip_configuration) == 1
+    error_message = "Bastion host must have exactly one ip_configuration."
+  }
+
+  assert {
+    condition     = azurerm_public_ip.bastion[0].name == "ce-ha-lab-bastion-pip"
+    error_message = "Bastion public IP must be named <bastion_name>-pip."
+  }
+
+  assert {
+    condition     = output.bastion_name == "ce-ha-lab-bastion"
+    error_message = "bastion_name output must expose the host name the tunnel command needs."
   }
 }

--- a/terraform/tests/plan.tftest.hcl
+++ b/terraform/tests/plan.tftest.hcl
@@ -13,6 +13,10 @@ run "root_plans_end_to_end" {
   variables {
     ce_count = 2
     deployer = "tester"
+    # Explicit, not defaulted: `terraform test` auto-loads a root terraform.tfvars,
+    # so relying on the default here would make the run's result depend on whether
+    # the workstation has Bastion switched on locally.
+    enable_bastion = false
     # enable_bgp is left at its true default so the root integration test plans the WHOLE
     # graph, bgp objects included. It used to be forced false only to dodge the provider's
     # object-ref name length cap, relaxed in v3.74.0 (see modules/xc-site/main.tf).
@@ -42,5 +46,47 @@ run "root_plans_end_to_end" {
   assert {
     condition     = output.vip == "10.250.0.10"
     error_message = "VIP should be 10.250.0.10."
+  }
+
+  assert {
+    condition     = output.bastion_name == null
+    error_message = "Bastion is opt-in: with enable_bastion = false the root must deploy none."
+  }
+}
+
+# Azure refuses an AzureBastionSubnet smaller than /26, and it refuses it at APPLY
+# time — after the plan looked fine. Reject it at plan time instead, the same way
+# route_server_subnet_prefix rejects anything that is not a /27.
+run "bastion_subnet_prefix_rejects_too_small" {
+  command = plan
+
+  variables {
+    ce_count              = 1
+    deployer              = "tester"
+    ssh_public_key        = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+    bastion_subnet_prefix = "10.0.5.0/27"
+  }
+
+  expect_failures = [var.bastion_subnet_prefix]
+}
+
+run "bastion_enabled_root_wiring" {
+  command = plan
+
+  variables {
+    ce_count       = 1
+    deployer       = "tester"
+    ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+    enable_bastion = true
+  }
+
+  assert {
+    condition     = output.bastion_name == "ce-ha-lab-bastion"
+    error_message = "Root must surface the Bastion host name so the tunnel command is copy-pasteable."
+  }
+
+  assert {
+    condition     = module.azure_hub.bastion_subnet_prefix == "10.0.5.0/26"
+    error_message = "The default Bastion prefix must be 10.0.5.0/26 — the only free /26 left in the hub."
   }
 }

--- a/terraform/variables_azure.tf
+++ b/terraform/variables_azure.tf
@@ -72,6 +72,41 @@ variable "route_server_name" {
   default     = "ce-ha-lab-rrs"
 }
 
+variable "bastion_subnet_prefix" {
+  description = "AzureBastionSubnet prefix. MUST be /26 or larger, named literally AzureBastionSubnet, with no NSG or route table. 10.0.5.0/26 is the first free /26 in the hub (10.0.1.0/26 mgmt, 10.0.2.0/26 external, 10.0.3.0/26 internal, 10.0.4.0/27 RouteServerSubnet are taken)."
+  type        = string
+  default     = "10.0.5.0/26"
+
+  validation {
+    # Azure rejects anything smaller than /26 at APPLY time, long after the plan
+    # looked healthy. Fail at plan time instead.
+    condition     = tonumber(split("/", var.bastion_subnet_prefix)[1]) <= 26
+    error_message = "AzureBastionSubnet must be /26 or larger (a smaller prefix, e.g. /27, is rejected by Azure)."
+  }
+}
+
+# --------------------------------------------------------------------------
+# Azure Bastion
+# --------------------------------------------------------------------------
+# Default false, deliberately. Bastion is the only resource in this deployment
+# that is not load-bearing for the BGP/ECMP demo — the data path, the sites and
+# the VIP all work without it — yet a Standard-SKU host bills an hourly standing
+# charge from the moment it is provisioned, whether or not anyone opens a tunnel.
+# Opting in keeps the cost of a default `terraform apply` exactly what it is
+# today and makes the spend a conscious choice by whoever needs CE console
+# access. Turn it on with `enable_bastion = true` in terraform.tfvars.
+variable "enable_bastion" {
+  description = "Deploy Azure Bastion so developers can reach each CE's Site Console web UI (https://<sli-ip>:65500) with Azure RBAC instead of an SSH key and a jump host."
+  type        = bool
+  default     = false
+}
+
+variable "bastion_name" {
+  description = "Azure Bastion host name (the --name argument of `az network bastion tunnel`)."
+  type        = string
+  default     = "ce-ha-lab-bastion"
+}
+
 # ---------------------------------------------------------
 # CE / client VM inputs
 # ---------------------------------------------------------

--- a/terraform/variables_azure.tf
+++ b/terraform/variables_azure.tf
@@ -91,7 +91,9 @@ variable "bastion_subnet_prefix" {
 # Default false, deliberately. Bastion is the only resource in this deployment
 # that is not load-bearing for the BGP/ECMP demo — the data path, the sites and
 # the VIP all work without it — yet a Standard-SKU host bills an hourly standing
-# charge from the moment it is provisioned, whether or not anyone opens a tunnel.
+# charge from the moment it is provisioned, whether or not anyone opens a tunnel:
+# USD 0.29/hour in eastus for the two included scale units (retail, 2026-07),
+# roughly USD 212 a month, plus USD 0.14/hour for each scale unit beyond two.
 # Opting in keeps the cost of a default `terraform apply` exactly what it is
 # today and makes the spend a conscious choice by whoever needs CE console
 # access. Turn it on with `enable_bastion = true` in terraform.tfvars.


### PR DESCRIPTION
Closes #688

## What

Adds an **opt-in Azure Bastion** to the hub so a developer with Azure RBAC can open a CE's
**Site Console web UI** (`https://<node>:65500`, user `admin`) with **no SSH key, no jump
host and no CE change**. Three resources in `modules/azure-hub`, all behind
`enable_bastion`: `AzureBastionSubnet`, a Standard static public IP, and a Standard-SKU
`azurerm_bastion_host` with `tunneling_enabled` and `ip_connect_enabled`.

## Why it was needed

The credential and the service already worked. Verified from inside the VNet before any
change — and note which addresses answer:

```
== 10.0.1.4 (mgmt/SLO)   22: closed  443: closed  8007: closed  65500: closed
== 10.0.2.4 (external)   22: closed  443: closed  8007: closed  65500: closed
== 10.0.3.5 (SLI)        22: open    443: closed  8007: closed  65500: open

10.0.3.5 -> anon=401 auth=200      # WWW-Authenticate: Basic realm="Volterra Site Console"
10.0.3.6 -> anon=401 auth=200
10.0.3.7 -> anon=401 auth=200
```

Only the SLI address answers, and only from inside `hub-vnet`. The single gap was
reachability, and the only way across it was hopping through `ar-ecmp-client` with a
distributed SSH private key — access control by who holds a key file rather than by RBAC.

## Live proof

Applied to `rg-mcn-ce-ha-rmordasiewicz`. Blast radius was exactly three creates out of the
49 resources in the graph — no CE, NIC, Route Server, BGP or XC site touched:

```
['create'] module.azure_hub.azurerm_bastion_host.this[0]
['create'] module.azure_hub.azurerm_public_ip.bastion[0]
['create'] module.azure_hub.azurerm_subnet.bastion[0]
Plan: 3 to add, 0 to change, 0 to destroy.
```

Tunnel + curl, per CE:

```
CE-01  auth=200 bytes=9703 anon=401 title=<title>F5 Site Console</title>
CE-02  auth=200 bytes=9703 anon=401 title=<title>F5 Site Console</title>
CE-03  auth=200 bytes=9703 anon=401 title=<title>F5 Site Console</title>
```

TLS peer is the appliance itself (`CN=site-local.volterra.io`, `O=Volterra`), and the
unauthenticated request is correctly refused with 401.

## Correction to the premise: IP-based connection cannot carry 65500

The tunnel must target the CE by **VM resource id**, not by IP. The IP-based path is
refused:

```
az network bastion tunnel ... --target-ip-address 10.0.3.5 --resource-port 65500
ERROR: Custom ports are not allowed. Allowed ports for Tunnel with IP connect is 22, 3389.
```

This matches Microsoft's documented limitation — *"Custom ports and protocols aren't
currently supported when connecting to a virtual machine via native client with IP-based
connections"*
([connect-ip-address](https://learn.microsoft.com/en-us/azure/bastion/connect-ip-address)).

`ip_connect_enabled` is still set — it costs nothing and enables portal IP-targeted
RDP/SSH — but the code documents it as **not** the 65500 path rather than crediting it
with one. Left unexplained and reported as such: the same VM-id tunnel reaches 65500 but
times out on port 22, even though 22 is open on the SLI and closed on the other two NICs.

## The command a developer runs

```bash
az network bastion tunnel \
  --name "$(terraform output -raw bastion_name)" \
  -g "$(terraform output -raw resource_group_name)" \
  --target-resource-id "$(terraform output -json ce_vm_ids | jq -r .eastus01)" \
  --resource-port 65500 --port 65500 &
open https://localhost:65500/     # log in as admin
```

## Default: `enable_bastion = false`

Bastion is the only resource in this deployment that the BGP/ECMP demo does not depend on,
and a Standard host bills an hourly standing charge from provisioning whether or not anyone
connects. Opt-in keeps the cost of a default apply exactly what it is today and makes the
spend a conscious choice. `bastion_subnet_prefix` defaults to `10.0.5.0/26` — the first free
/26 in the hub — with a plan-time validation that it is /26-or-larger, because Azure only
rejects a smaller prefix at apply time.

## Tests

`terraform test`: **22 passed, 0 failed**, and deliberately verified **both with and without**
a local `terraform.tfvars`. `terraform test` auto-loads a root `terraform.tfvars`, so a run
that leans on `enable_bastion`'s default passes in CI and fails on any workstation that has
Bastion switched on locally. Every bastion run therefore sets the flag explicitly; a comment
in the test file says why, so the flaky form is not reintroduced.

`terraform fmt -check -recursive`, `tflint --recursive`, `terraform validate` and `codespell`
are all clean.

## Demo unaffected

| | before | after |
| --- | --- | --- |
| VIP over 40 requests | 39/40 (one curl `000`) | **40/40** |
| XC sites | 3 ONLINE | 3 ONLINE |
| ECMP (each peering queried separately) | 3/3 learning `10.250.0.10/32` | 3/3 learning `10.250.0.10/32` |

## Known state contention

A concurrent session working #674 has unmerged `modules/xc-site` changes already applied to
the shared state, so a whole-root `terraform plan` from this branch shows four of *their*
resources as pending. `terraform plan -target=module.azure_hub` reports **"No changes. Your
infrastructure matches the configuration."** — this PR's delta is converged and idempotent.
The new `ce_vm_ids` output lands in state on the next whole-root apply.
