### PR TITLE
fix(xc-site): couple the CE site object's lifecycle to the CE VM instance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,10 +100,15 @@ module "xc_site" {
   source   = "./modules/xc-site"
   for_each = module.ce_topology.ce_nodes
 
-  site_name            = each.value.site_name
-  hostname             = each.value.hostname
-  interface_name       = each.value.interface_name
-  mgmt_nic_mac         = module.ce_node[each.key].mgmt_nic_mac
+  site_name      = each.value.site_name
+  hostname       = each.value.hostname
+  interface_name = each.value.interface_name
+  mgmt_nic_mac   = module.ce_node[each.key].mgmt_nic_mac
+  # Couples the site object's lifecycle to the CE VM INSTANCE (issue #674):
+  # replacing the VM replaces the site, which takes the registration bound to the
+  # destroyed instance with it. Must be virtual_machine_id, not the ARM resource
+  # id — the latter is name-derived and identical after a replacement.
+  ce_vm_instance_id    = module.ce_node[each.key].vm_instance_id
   rs_peer_ips          = module.azure_hub.rs_peer_ips
   ce_asn               = var.ce_asn
   rs_asn               = var.rs_asn

--- a/terraform/modules/ce-node/outputs.tf
+++ b/terraform/modules/ce-node/outputs.tf
@@ -19,8 +19,22 @@ output "vm_name" {
 }
 
 output "vm_id" {
-  description = "CE VM resource ID."
+  description = "CE VM ARM resource ID. Addresses the VM (this is what `az network bastion tunnel --target-resource-id` wants) — it is NOT a per-instance identity: see vm_instance_id."
   value       = azurerm_linux_virtual_machine.this.id
+}
+
+# The two ids above and below are easy to confuse and are not interchangeable.
+# vm_id is the ARM resource id, ".../virtualMachines/<hostname>" — derived from
+# the VM name and therefore byte-identical before and after a replacement, which
+# makes it the right handle for ADDRESSING the VM (Bastion tunnels) and useless
+# as a "this node was rebuilt" signal. This one is regenerated for every new
+# instance, and it is the same value the CE reports to F5 XC as the
+# registration's infra.instance_id — so it is the identity that binds an XC site
+# object to a specific node. modules/xc-site keys the site's replace_triggered_by
+# on it (see issue #674).
+output "vm_instance_id" {
+  description = "128-bit unique id of the CE VM INSTANCE (regenerated on replacement; equals the XC registration's infra.instance_id). Not the ARM resource id, which is name-derived and survives a replacement."
+  value       = azurerm_linux_virtual_machine.this.virtual_machine_id
 }
 
 output "identity_id" {

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -1,3 +1,28 @@
+# Parks the identity of the CE VM instance the site's node runs on, so the site
+# object has something to be coupled to. Nothing else reads it — its only job is
+# to be named in the site's replace_triggered_by below.
+#
+# WHY A SEPARATE RESOURCE. replace_triggered_by may only name managed resources
+# declared in the SAME module as the resource carrying the lifecycle block, and
+# the CE VM lives in modules/ce-node. Parking the id here is the standard way to
+# carry an external value across that boundary.
+#
+# WHY input AND NOT triggers_replace. This resource must never itself be
+# replaced — only observed. A changed `input` is an in-place UPDATE, which is
+# what replace_triggered_by reacts to; that keeps the resource cheap and its
+# behaviour on ADOPTION correct (see below).
+#
+# ADOPTION IS INERT. Adding this resource to a deployment that already exists
+# plans it as a CREATE, and a create of the referenced resource does NOT fire
+# replace_triggered_by — only a subsequent change to its value does. Verified on
+# Terraform v1.10.5 (the version .terraform-version pins) and again on v1.15.0:
+# adding the pair to a populated state plans "1 to add, 0 to change,
+# 0 to destroy". So this fix does not itself trigger the fleet-wide rebuild it
+# exists to prevent — no import, no targeted apply, no seeding.
+resource "terraform_data" "ce_vm" {
+  input = var.ce_vm_instance_id
+}
+
 # Single-node Secure Mesh v2 CE site with an EXPLICIT eth0/SLO interface. The
 # explicit interface is what makes XC auto-create the network_interface object
 # (var.interface_name) that the BGP peer binds to — without it a standalone bgp
@@ -13,6 +38,14 @@ resource "xcsh_securemesh_site_v2" "this" {
   # post-import plan. Sending `null` when the map is empty stops asking the provider to
   # distinguish "declared empty" from "absent" — something it cannot observe on import.
   # (The nested `interface_list.labels {}` marker is a separate class, fixed by xcsh #1244.)
+  #
+  # EXPECTED ONE-TIME DRIFT AFTER A NODE (RE)REGISTERS. F5 XC stamps the node's
+  # hardware facts onto the site as labels (host-os-version, hw-model,
+  # hw-serial-number, hw-vendor, hw-version) once the CE registers. The next plan
+  # therefore shows `- labels = {...} -> null` for that site, and applying it
+  # settles — XC does not re-stamp them. It is one more convergence pass in the
+  # already two-phase deploy, not drift to chase; observed on the site rebuilt by
+  # the #674 CE replacement.
   labels = length(var.labels) > 0 ? var.labels : null
 
   azure {
@@ -96,6 +129,43 @@ resource "xcsh_securemesh_site_v2" "this" {
       }
       volterra_software_version = var.sw_version == "" ? null : var.sw_version
     }
+  }
+
+  # Rebuild the site object whenever the CE VM instance it describes is rebuilt
+  # (issue #674).
+  #
+  # THE FAILURE THIS PREVENTS. A CE's runtime registration is bound to one node
+  # instance and holds the control plane's unique
+  # (tenant, cluster_name, hostname) index. Destroying the VM does NOT retire
+  # that registration, so the replacement node — same site, same hostname —
+  # cannot create its own: the create fails with UniqueSecondaryIndexViolation
+  # and retries on a ~65 s loop forever. Nothing recovers on its own, and worse,
+  # nothing in the graph noticed: with no reference to the node's identity
+  # anywhere, `terraform plan` reported "No changes" for the whole time the
+  # fleet was down.
+  #
+  # WHY REPLACING THE SITE IS THE FIX. Deleting the site object takes its
+  # registrations with it — observed live while replacing one CE: the site
+  # 404ed and the registration bound to the outgoing instance disappeared in the
+  # same poll — so the replacement node registers into a site whose index key is
+  # free. Deleting only the registration is not enough: the site keeps a status
+  # object that then rejects the node's workload request.
+  #
+  # THE ORDER IS THE POINT. Terraform runs this as: destroy site -> destroy VM
+  # -> create VM -> create site. The stale registration is therefore gone before
+  # the replacement node ever boots, and the site is back before the node
+  # finishes booting and registers. The outgoing node cannot slip a fresh
+  # registration into the gap: once its own registration is deleted it 404-loops
+  # against the name it persisted in registration-obj.yml instead of creating a
+  # new one.
+  #
+  # SAFE WHILE OTHER OBJECTS REFERENCE THE SITE. xcsh_bgp and the root HTTP load
+  # balancer's advertise_where both name this site, and F5 XC resolves those
+  # references lazily: deleting a site that both of them reference returns HTTP
+  # 200 and leaves them intact, and re-creating it under the same name re-binds
+  # them (verified against the live tenant with a throwaway site).
+  lifecycle {
+    replace_triggered_by = [terraform_data.ce_vm]
   }
 }
 

--- a/terraform/modules/xc-site/outputs.tf
+++ b/terraform/modules/xc-site/outputs.tf
@@ -13,6 +13,15 @@ output "interface_name" {
   value       = var.interface_name
 }
 
+# The node identity the site object is currently coupled to. Compare it against
+# the registration's own infra.instance_id (visible in the F5 XC API, not yet on
+# the xcsh_site_registration data source — provider issue #1376) to tell whether
+# a site is still bound to a node that no longer exists.
+output "bound_vm_instance_id" {
+  description = "CE VM instance id the site object is bound to. Replacing that instance replaces the site (issue #674)."
+  value       = terraform_data.ce_vm.output
+}
+
 output "registration_name" {
   description = "Runtime registration name (r-<uuid>) resolved from the site name; null until the CE has registered."
   value       = data.xcsh_site_registration.this.found ? data.xcsh_site_registration.this.name : null

--- a/terraform/modules/xc-site/variables.tf
+++ b/terraform/modules/xc-site/variables.tf
@@ -18,6 +18,16 @@ variable "mgmt_nic_mac" {
   type        = string
 }
 
+variable "ce_vm_instance_id" {
+  description = "128-bit unique id of the CE VM instance this site's node runs on (azurerm_linux_virtual_machine.virtual_machine_id — the same value the CE reports as the registration's infra.instance_id). Required, and deliberately NOT the ARM resource id, which is name-derived and identical after a replacement. The site object's lifecycle is coupled to it so that rebuilding the node rebuilds the site instead of leaving a registration bound to a destroyed instance (issue #674)."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.ce_vm_instance_id) != ""
+    error_message = "ce_vm_instance_id must be the CE VM's virtual_machine_id; an empty value would couple every node's site to the same key."
+  }
+}
+
 variable "rs_peer_ips" {
   description = "List of Azure Route Server BGP peer IPs (virtual_router_ips), e.g. [10.0.4.4, 10.0.4.5]. Values may be unknown until apply; the count of peers comes from rs_peer_count so the peers block expands at plan time."
   type        = list(string)

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -75,6 +75,17 @@ output "xc_site_names" {
   value       = { for k, m in module.xc_site : k => m.site_name }
 }
 
+# Makes the site-to-node binding that closes #674 observable from the CLI. Each
+# value is the CE VM instance id its XC site object is coupled to; the matching
+# registration reports the same value as infra.instance_id. When the two disagree
+# the site is bound to a node that no longer exists — the state in which a
+# rebuilt CE can never register. (The registration side is not on the
+# xcsh_site_registration data source yet: provider issue #1376.)
+output "ce_bound_instance_ids" {
+  description = "Per-CE VM instance id each XC site object is bound to. Compare with the registration's infra.instance_id to spot a site still bound to a destroyed node."
+  value       = { for k, m in module.xc_site : k => m.bound_vm_instance_id }
+}
+
 output "xc_interface_names" {
   description = "Per-CE auto-derived network_interface object names (BGP peer bind target)."
   value       = { for k, m in module.xc_site : k => m.interface_name }

--- a/terraform/tests/bgp.tftest.hcl
+++ b/terraform/tests/bgp.tftest.hcl
@@ -13,14 +13,15 @@ run "bgp_two_peers" {
   }
 
   variables {
-    site_name      = "ar-bgp-eastus02"
-    hostname       = "f5-xc-ce-vm-02"
-    interface_name = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
-    mgmt_nic_mac   = "60:45:bd:ef:07:9f"
-    rs_peer_ips    = ["10.0.4.4", "10.0.4.5"]
-    ce_asn         = 64512
-    rs_asn         = 65515
-    enable_bgp     = true
+    site_name         = "ar-bgp-eastus02"
+    hostname          = "f5-xc-ce-vm-02"
+    interface_name    = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac      = "60:45:bd:ef:07:9f"
+    ce_vm_instance_id = "d6c33249-b85d-4936-a994-f971d4b2cdb9"
+    rs_peer_ips       = ["10.0.4.4", "10.0.4.5"]
+    ce_asn            = 64512
+    rs_asn            = 65515
+    enable_bgp        = true
   }
 
   assert {

--- a/terraform/tests/ce_node.tftest.hcl
+++ b/terraform/tests/ce_node.tftest.hcl
@@ -79,4 +79,91 @@ run "ce_vm_and_nics" {
     condition     = azurerm_linux_virtual_machine.this.boot_diagnostics[0].storage_account_uri == null
     error_message = "CE boot diagnostics must use Azure-managed storage (no storage_account_uri)."
   }
+
+}
+
+# modules/xc-site couples the XC site object's lifecycle to vm_instance_id, so it
+# has to identify the VM INSTANCE. The ARM resource id looks like a perfectly
+# good identifier and is the obvious thing to reach for, but it is
+# ".../virtualMachines/<hostname>" — byte-identical before and after a
+# replacement — so wiring it would leave the coupling permanently inert and bring
+# back #674 with no visible symptom.
+#
+# This run applies (against the mocked provider — still no Azure credentials)
+# because both candidate attributes are computed, and a plan leaves them
+# known-after-apply and therefore unassertable. Only virtual_machine_id is
+# overridden; every other computed attribute keeps the value the mock invents, so
+# reading the wrong one fails the comparison instead of quietly passing.
+run "vm_instance_id_is_the_instance_id_not_the_arm_resource_id" {
+  command = apply
+
+  module {
+    source = "./modules/ce-node"
+  }
+
+  variables {
+    hostname            = "f5-xc-ce-vm-01"
+    resource_group_name = "rmordasiewicz-f5-xc-ce-infra"
+    location            = "eastus"
+    zone                = "1"
+    vm_size             = "Standard_D8_v4"
+    mgmt_subnet_id      = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/snet-hub-management"
+    external_subnet_id  = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/snet-hub-external"
+    internal_subnet_id  = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/snet-hub-internal"
+    mgmt_private_ip     = "10.0.1.4"
+    admin_username      = "azureuser"
+    ssh_public_key      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+    custom_data         = "IyNjbG91ZC1jb25maWcK"
+    tags                = {}
+  }
+
+  # The mocked provider invents ids like "7251r305", and azurerm parses resource
+  # ids client-side, so every id this module feeds into another resource needs a
+  # well-formed one or the apply fails before any assertion runs.
+  override_resource {
+    target = azurerm_public_ip.mgmt
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/f5-xc-ce-vm-01-mgmt-pip"
+    }
+  }
+
+  override_resource {
+    target = azurerm_network_interface.mgmt
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/f5-xc-ce-vm-01-mgmt-nic"
+    }
+  }
+
+  override_resource {
+    target = azurerm_network_interface.external
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/f5-xc-ce-vm-01-external-nic"
+    }
+  }
+
+  override_resource {
+    target = azurerm_network_interface.internal
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/f5-xc-ce-vm-01-internal-nic"
+    }
+  }
+
+  override_resource {
+    target = azurerm_user_assigned_identity.this
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/f5-xc-ce-vm-01-identity"
+    }
+  }
+
+  override_resource {
+    target = azurerm_linux_virtual_machine.this
+    values = {
+      virtual_machine_id = "5efa1cf7-73ec-4bd2-b8d1-1e0d0a41bd12"
+    }
+  }
+
+  assert {
+    condition     = output.vm_instance_id == "5efa1cf7-73ec-4bd2-b8d1-1e0d0a41bd12"
+    error_message = "vm_instance_id must expose virtual_machine_id (regenerated per instance), not the name-derived ARM resource id."
+  }
 }

--- a/terraform/tests/ce_replacement.tftest.hcl
+++ b/terraform/tests/ce_replacement.tftest.hcl
@@ -1,0 +1,93 @@
+# Plan-level test for the CE-replacement coupling that closes #674.
+#
+# Replacing a CE VM used to leave the XC site object — and with it the
+# registration bound to the destroyed node — untouched. The stale registration
+# holds the control plane's unique (tenant, cluster_name, hostname) index, so the
+# replacement node's own registration can never be created and the site wedges,
+# while `terraform plan` reports "No changes" because nothing in the graph ever
+# referenced the node's instance identity.
+#
+# modules/xc-site now takes that identity as ce_vm_instance_id and parks it in
+# terraform_data.ce_vm, which the site resource names in replace_triggered_by.
+#
+# WHAT THESE RUNS CAN AND CANNOT SEE. A lifecycle meta-argument is not part of a
+# plan, so no assertion here can observe replace_triggered_by itself. What is
+# assertable is the value it keys on: that the module parks the instance id it
+# was handed, and that the root hands it the VM's `virtual_machine_id` (the
+# 128-bit id Azure regenerates for a replacement VM) rather than the ARM resource
+# `id`, which is derived from the VM name and is therefore IDENTICAL before and
+# after a replacement — wiring that would silently disable the whole mechanism.
+# The discriminating check for the meta-argument is a live single-CE replacement,
+# recorded on the pull request.
+
+mock_provider "xcsh" {}
+
+# The module parks exactly the instance id it is handed, and exposes it so an
+# operator can compare it against the registration's own infra.instance_id.
+run "site_is_keyed_to_the_ce_vm_instance_id" {
+  command = apply
+
+  module {
+    source = "./modules/xc-site"
+  }
+
+  variables {
+    site_name         = "ar-bgp-eastus01"
+    hostname          = "f5-xc-ce-vm-01"
+    interface_name    = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac      = "7c:1e:52:18:c1:77"
+    ce_vm_instance_id = "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
+    rs_peer_ips       = ["10.0.4.4", "10.0.4.5"]
+    ce_asn            = 64512
+    rs_asn            = 65515
+    # Not under test here; bgp.tftest.hcl covers the peer wiring.
+    enable_bgp           = false
+    approve_registration = false
+  }
+
+  assert {
+    condition     = terraform_data.ce_vm.input == "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
+    error_message = "terraform_data.ce_vm must park the CE VM instance id the site's replace_triggered_by keys on."
+  }
+
+  assert {
+    condition     = output.bound_vm_instance_id == "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
+    error_message = "bound_vm_instance_id must report the instance the site object is bound to."
+  }
+
+  # The site keeps its stable identity: the coupling replaces the object, it does
+  # not rename it. A renamed site would orphan the bgp object and the LB
+  # advertise rule, which both reference it by name.
+  assert {
+    condition     = xcsh_securemesh_site_v2.this.name == "ar-bgp-eastus01"
+    error_message = "The instance-id coupling must not change the site name."
+  }
+}
+
+# A different node yields a different key. This is the whole point: two nodes
+# that differ only by instance id must not share a trigger value.
+run "a_different_instance_yields_a_different_key" {
+  command = apply
+
+  module {
+    source = "./modules/xc-site"
+  }
+
+  variables {
+    site_name            = "ar-bgp-eastus01"
+    hostname             = "f5-xc-ce-vm-01"
+    interface_name       = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac         = "7c:1e:52:18:c1:77"
+    ce_vm_instance_id    = "81ab781d-36e0-42b0-aa3b-f1ba2c935e24"
+    rs_peer_ips          = ["10.0.4.4", "10.0.4.5"]
+    ce_asn               = 64512
+    rs_asn               = 65515
+    enable_bgp           = false
+    approve_registration = false
+  }
+
+  assert {
+    condition     = terraform_data.ce_vm.input == "81ab781d-36e0-42b0-aa3b-f1ba2c935e24"
+    error_message = "The parked key must track the instance id, not the site or host name."
+  }
+}

--- a/terraform/tests/plan.tftest.hcl
+++ b/terraform/tests/plan.tftest.hcl
@@ -52,6 +52,21 @@ run "root_plans_end_to_end" {
     condition     = output.bastion_name == null
     error_message = "Bastion is opt-in: with enable_bastion = false the root must deploy none."
   }
+
+  # Every CE site is coupled to its own node instance (issue #674): exactly one
+  # binding per node, keyed by that node. The VALUES cannot be checked here —
+  # virtual_machine_id is computed, so at plan time each binding is
+  # known-after-apply — but the SHAPE can, and a binding that is fleet-wide
+  # rather than per-node would show up as a key set that does not match
+  # ce_nodes. That the bound value is the instance id and not the (name-derived,
+  # replacement-stable) ARM resource id is pinned in ce_node.tftest.hcl.
+  assert {
+    condition = (
+      length(output.ce_bound_instance_ids) == length(output.ce_nodes) &&
+      alltrue([for k in keys(output.ce_nodes) : contains(keys(output.ce_bound_instance_ids), k)])
+    )
+    error_message = "Every CE node must contribute exactly one site-to-instance binding, keyed by that node."
+  }
 }
 
 # Azure refuses an AzureBastionSubnet smaller than /26, and it refuses it at APPLY

--- a/terraform/tests/registration_approval.tftest.hcl
+++ b/terraform/tests/registration_approval.tftest.hcl
@@ -23,13 +23,14 @@ run "no_approval_before_the_ce_registers" {
   }
 
   variables {
-    site_name      = "ar-bgp-eastus01"
-    hostname       = "f5-xc-ce-vm-01"
-    interface_name = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
-    mgmt_nic_mac   = "7c:1e:52:18:c1:77"
-    rs_peer_ips    = ["10.0.4.4", "10.0.4.5"]
-    ce_asn         = 64512
-    rs_asn         = 65515
+    site_name         = "ar-bgp-eastus01"
+    hostname          = "f5-xc-ce-vm-01"
+    interface_name    = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac      = "7c:1e:52:18:c1:77"
+    ce_vm_instance_id = "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
+    rs_peer_ips       = ["10.0.4.4", "10.0.4.5"]
+    ce_asn            = 64512
+    rs_asn            = 65515
     # Not under test here; the real 71-char interface name is covered by bgp.tftest.hcl.
     enable_bgp           = false
     approve_registration = true
@@ -74,6 +75,7 @@ run "approval_uses_the_resolved_registration_name" {
     hostname             = "f5-xc-ce-vm-01"
     interface_name       = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
     mgmt_nic_mac         = "7c:1e:52:18:c1:77"
+    ce_vm_instance_id    = "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
     rs_peer_ips          = ["10.0.4.4", "10.0.4.5"]
     ce_asn               = 64512
     rs_asn               = 65515
@@ -135,6 +137,7 @@ run "approve_registration_false_plans_no_approval" {
     hostname             = "f5-xc-ce-vm-01"
     interface_name       = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
     mgmt_nic_mac         = "7c:1e:52:18:c1:77"
+    ce_vm_instance_id    = "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
     rs_peer_ips          = ["10.0.4.4", "10.0.4.5"]
     ce_asn               = 64512
     rs_asn               = 65515

--- a/terraform/tests/xc_site.tftest.hcl
+++ b/terraform/tests/xc_site.tftest.hcl
@@ -11,13 +11,14 @@ run "site_and_interface_binding" {
   }
 
   variables {
-    site_name      = "ar-bgp-eastus01"
-    hostname       = "f5-xc-ce-vm-01"
-    interface_name = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
-    mgmt_nic_mac   = "7c:1e:52:18:c1:77"
-    rs_peer_ips    = ["10.0.4.4", "10.0.4.5"]
-    ce_asn         = 64512
-    rs_asn         = 65515
+    site_name         = "ar-bgp-eastus01"
+    hostname          = "f5-xc-ce-vm-01"
+    interface_name    = "ves-io-securemesh-site-v2-ar-bgp-eastus01-network-f5-xc-ce-vm-01-eth0-0"
+    mgmt_nic_mac      = "7c:1e:52:18:c1:77"
+    ce_vm_instance_id = "89e6c538-6bc2-4c2c-a37e-d6149c1708ce"
+    rs_peer_ips       = ["10.0.4.4", "10.0.4.5"]
+    ce_asn            = 64512
+    rs_asn            = 65515
     # enable_bgp left at its true default. It used to be forced false because the real
     # 71-char interface name asserted below exceeded the provider's object-ref name cap;
     # v3.74.0 relaxed that cap, so the real name now validates as an INPUT, not merely as


### PR DESCRIPTION
Closes #674

## The problem

Replacing a CE VM wedged the deployment permanently. The registration belonging to
the destroyed node holds the control plane's unique
`(tenant, cluster_name, hostname)` index, and destroying a VM never retires it, so
the replacement node — same site, same hostname — could never create its own:
`UniqueSecondaryIndexViolationError`, retried on a ~65 s loop forever. Worse,
nothing in the Terraform graph referenced the node's identity, so `terraform plan`
reported **"No changes"** the entire time the fleet was down.

## The design

Couple the XC site object's lifecycle to the CE VM **instance**.

`modules/xc-site` takes the new required input `ce_vm_instance_id`, parks it in
`terraform_data.ce_vm`, and the site names that resource in
`replace_triggered_by`. Replacing the VM therefore replaces the site object —
and deleting the site takes its registrations with it, so the index key is free
before the replacement node ever boots.

Three choices worth calling out.

**`virtual_machine_id`, not the ARM resource id.** The obvious identifier,
`azurerm_linux_virtual_machine.this.id`, is `.../virtualMachines/<hostname>` —
byte-identical before and after a replacement. Wiring it would leave the coupling
permanently inert with no visible symptom. `virtual_machine_id` is regenerated per
instance, and it is *the same value* the CE reports to F5 XC as the registration's
`infra.instance_id` — verified against the live tenant:

| node | `virtual_machine_id` | registration `infra.instance_id` |
| --- | --- | --- |
| eastus01 | `89e6c538-6bc2-4c2c-a37e-d6149c1708ce` | `89e6c538-6bc2-4c2c-a37e-d6149c1708ce` |
| eastus02 | `d6c33249-b85d-4936-a994-f971d4b2cdb9` | `d6c33249-b85d-4936-a994-f971d4b2cdb9` |
| eastus03 | `483b2853-962e-4d96-a509-bdff40f510ac` | `483b2853-962e-4d96-a509-bdff40f510ac` |

So this keys on exactly the identity provider issue
f5-sales-demo/terraform-provider-xcsh#1376 proposes to expose from the
registration side. This PR does not wait on it: it takes the Terraform-side half,
which is available today. `#1376` remains the way to make the *stale* binding
directly readable, and the new `ce_bound_instance_ids` root output is the manual
pairing in the meantime.

**Replace the site, not just the registration.** Deleting only the registration is
known not to be enough — the site keeps a status object that then rejects the
node's workload request, and the node has by then persisted `registration-obj.yml`
pinning it to a name that now 404s.

**`input`, not `triggers_replace`.** The trigger resource must be *observed*, never
replaced. A changed `input` is an in-place update, which is what
`replace_triggered_by` reacts to.

### Adoption does not cause a mass replacement

The trap with this design is that adopting it naively could replace all three site
objects on the first apply, forcing all three VMs with it — the fix causing the
rebuild it exists to prevent. It does not, because **a `create` of the referenced
resource does not fire `replace_triggered_by`; only a later change to its value
does.** Verified on Terraform v1.10.5 (the pinned version) and v1.15.0 in a scratch
config, and then on the live deployment:

```
$ terraform plan   # against the live 3-CE deployment
  # module.xc_site["eastus01"].terraform_data.ce_vm will be created
  # module.xc_site["eastus02"].terraform_data.ce_vm will be created
  # module.xc_site["eastus03"].terraform_data.ce_vm will be created
Plan: 3 to add, 0 to change, 0 to destroy.
```

Zero site replacements, zero VM replacements. No import, no targeted seeding, no
`moved` block. After applying, all three sites stayed `ONLINE` on their original
registrations, and `ce_bound_instance_ids` came back matching all three
`infra.instance_id` values exactly.

## Live validation — one CE replaced, on the running demo

The demo runs 3-way ECMP, so exactly one CE (`eastus01`) was replaced; two kept
serving throughout.

**The mechanism, second by second** (`registrations_by_site/ar-bgp-eastus01`
polled every 10 s):

```
03:02:56 site=present regs=[r-0d38df20 ONLINE iid=89e6c538-...]   <- stale-to-be
03:03:08 site=404             regs=[NONE]                          <- site deleted, registration went WITH it
   ...   (VM destroyed, VM re-created)
03:05:51 site=present regs=[NONE]                                  <- site re-created, index key free
03:06:37 site=present regs=[r-47a59563 PENDING iid=776f8010-...]   <- new node registers cleanly
03:07:53 site=present regs=[r-47a59563 ADMITTED iid=776f8010-...]  <- approval applied by Terraform
```

That 03:03:08 line is the whole fix: deleting the site object **does** cascade to
its registrations, so the `(tenant, cluster_name, hostname)` key was free by the
time the replacement node booted.

- **The wedge did not recur.** No `UniqueSecondaryIndexViolationError`, no
  `WAITING_FOR_CONFIG` loop, and **no manual registration `DELETE` at any point.**
- The plan for the replacement was `2 to add, 1 to change, 2 to destroy`, scoped to
  one node: the VM replaced as requested, `terraform_data.ce_vm` updated in place,
  and `xcsh_securemesh_site_v2.this` *"will be replaced due to changes in
  replace_triggered_by"*. `eastus02`/`eastus03` were untouched.
- Deleting a site that `xcsh_bgp` and the LB's `advertise_where` both reference is
  safe: F5 XC resolves those by name and lazily. Probed first with a throwaway site
  (`DELETE` → HTTP 200, both referrers intact, re-create under the same name
  re-binds) rather than discovered on the live demo.

**After (`ar-bgp-eastus01` back ONLINE at 03:24:18, ~21 min end to end):**

- All three sites `ONLINE`, exactly one registration each, `eastus01` now bound to
  the new instance `776f8010-...`.
- All three Route Server peerings advertise the VIP again
  (`10.0.1.4` / `.5` / `.6`, queried per peering), and the client NIC effective
  route table shows `10.250.0.10/32` with all three next hops — 3-way ECMP
  restored. The `xcsh_bgp` object was *not* replaced and re-bound to the
  recreated site on its own.
- Operator SSH works on the replaced node: `admin@10.0.3.5` via ProxyJump through
  `ar-ecmp-client`, new host key as expected, SiteCLI banner and
  `panic: no such device or address` (the documented "auth succeeded, no TTY"
  signal). `Uptime` confirmed it is the new instance.
- Whole-root `terraform plan`: **No changes.**

### VIP success rate

Measured from the in-VNet client with `-H 'Host: ar-bgp-ecmp.bankexample.com'`, in
batches of 60.

| | samples | success | rate |
| --- | --- | --- | --- |
| Before | 120 (2 batches) | 112 | 93.3 % |
| During the rebuild (2 CEs serving) | 40 | 40 | 100 % |
| After | 660 (11 batches) | 651 | 98.6 % |

(Two further post-replacement batches were run but their counts scrolled out of
the captured output, so they are excluded rather than estimated.)

**I would not claim the pre-existing degradation is fixed.** The failure mode is
unchanged — `curl: (28) Operation timed out after 5000 ms with 0 bytes received`,
i.e. the same level-`000` failure — and it is *bursty*: nine of the eleven
post-replacement batches were 60/60, but one was 54/60 and one 57/60. Two batches
of 60 taken back to back would have read as "100 %, fixed". The higher after-rate
is most likely the larger sample catching the quiet periods; the defect predates
this work and survives it, and diagnosing it is out of scope here.

## Tests

`terraform test`: **25 passed, 0 failed** (3 runs added by this PR).

- `tests/ce_replacement.tftest.hcl` (new) — the module parks the instance id it is
  handed and publishes it; a different instance yields a different key; the
  coupling does not rename the site.
- `tests/ce_node.tftest.hcl` — new run pinning `vm_instance_id` to
  `virtual_machine_id`. Confirmed discriminating: rewiring the output to the ARM
  resource id turns the suite red.
- `tests/plan.tftest.hcl` — one binding per node, keyed by that node.

A `lifecycle` meta-argument is not part of a plan, so no unit test can observe
`replace_triggered_by` itself. That is what the live replacement above is for.

## Notes for the reviewer

- `modules/ce-node` now exposes **both** ids. I had originally removed `vm_id`
  (the ARM resource id) as a footgun, since it had no callers; the Bastion work
  that merged mid-flight (#691) gave it one — `az network bastion tunnel
  --target-resource-id` — so it is back, with a comment on each output saying
  which is for *addressing* the VM and which is for *identifying the instance*.
  Getting these two confused is precisely how #674 would silently come back.
- `ce_vm_instance_id` is required with no default, so every call site has to make
  the choice explicitly.
- **Expected one-time drift after any CE registers**, newly documented in
  `modules/xc-site/main.tf`: F5 XC stamps the node's hardware facts onto the site
  as labels, so the next plan shows `- labels = {...} -> null` for that site.
  Applying it settles; XC does not re-stamp. Seen on the rebuilt `eastus01` and
  applied, which is how the whole-root plan reached "No changes".
- Rebased onto `main` after #691 (Azure Bastion) merged mid-flight. The whole-root
  plan was re-checked afterwards and does **not** destroy
  `azurerm_bastion_host.this[0]`, `azurerm_public_ip.bastion[0]` or
  `azurerm_subnet.bastion[0]`; `ce-ha-lab-bastion` is still `Succeeded`.
