### PR TITLE
feat(xc): make the F5 XC tenant configuration, not ambient environment

### DIFF
--- a/scripts/pre-commit-local.sh
+++ b/scripts/pre-commit-local.sh
@@ -38,6 +38,15 @@ else
   printf 'CE Site CLI checks skipped (no related paths staged)\n'
 fi
 
+# The tenant guard's extraction logic (issue #696). Sub-second, and the branch it
+# covers — XCSH_API_URL naming the WRONG tenant — is unreachable from
+# `terraform test`, which cannot set an environment variable. Nothing else runs it.
+if staged | grep -qE '^(terraform/scripts/xc-env-tenant\.sh|tests/test-xc-env-tenant\.sh|scripts/pre-commit-local\.sh)$'; then
+  run "XC tenant guard extraction tests" bash tests/test-xc-env-tenant.sh
+else
+  printf 'XC tenant guard checks skipped (no related paths staged)\n'
+fi
+
 # shfmt is enforced by the Lint Code Base gate (super-linter SHELL_SHFMT) but is
 # absent from .pre-commit-config.yaml, which is governance-managed. Without this,
 # a formatting-only failure is only discoverable after pushing — which is exactly

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,11 @@
 locals {
+  # --- F5 XC tenant endpoint ---
+  # Every F5 XC tenant is served at https://<tenant>.console.ves.volterra.io, so
+  # naming the tenant is enough to name the API. providers.tf feeds this to the
+  # xcsh provider's api_url, which is what makes the TENANT A PROPERTY OF THE
+  # CONFIGURATION rather than of whatever XCSH_API_URL the shell happens to hold.
+  xc_api_url = "https://${var.expected_xc_tenant}.console.ves.volterra.io"
+
   # --- Deployer resolution (4-tier fallback) ---
   # 1. Explicit override via var.deployer
   # 2a. Azure AD: given_name initial + surname

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,6 +16,40 @@
 # approval, and a re-apply once the CEs have registered creates them. The bgp/LB
 # objects can be applied before ONLINE; they converge once the CE is up.
 
+# Guard: the F5 XC tenant in the environment MUST be the one this deployment
+# belongs to.
+#
+# providers.tf already pins the xcsh endpoint to var.expected_xc_tenant, so a
+# stray XCSH_API_URL can no longer redirect the deployment. What it can still do
+# is mean the operator's TOKEN belongs to a different tenant — and the symptom of
+# that is a bare 401 from the first API call, which reads like an expired
+# credential and not like "you are pointed at the wrong tenant". This turns it
+# into a sentence that says so.
+#
+# It is not hypothetical. The MCN demo was built in f5-sales-demo; the credential
+# file later started exporting an f5-amer-ent XCSH_API_URL; subsequent applies
+# minted an f5-amer-ent token, the CE VMs re-registered there, and their
+# f5-sales-demo registrations were abandoned. Every plan in between was clean,
+# because nothing in the configuration had an opinion about the tenant (#696).
+#
+# The external program reads the environment and nothing else — no credential, no
+# network call — which is what keeps `terraform test` and CI's
+# `terraform init -backend=false` credential-free. Where XCSH_API_URL is unset the
+# program reports an empty tenant and the guard abstains.
+#
+# postcondition, not check{}: a check block only WARNS, and a warning scrolls past
+# in exactly the situation this exists to stop.
+data "external" "xc_env_tenant" {
+  program = ["${path.module}/scripts/xc-env-tenant.sh"]
+
+  lifecycle {
+    postcondition {
+      condition     = contains(["", var.expected_xc_tenant], self.result.tenant)
+      error_message = "Wrong F5 XC tenant. XCSH_API_URL in this environment names tenant '${self.result.tenant}', but this deployment belongs to '${var.expected_xc_tenant}' (state key mcn.tfstate). Source the credential file for '${var.expected_xc_tenant}', or — if you really do mean to act on '${self.result.tenant}' — say so explicitly with -var expected_xc_tenant=${self.result.tenant} and a state key of its own."
+    }
+  }
+}
+
 # Guard: the HA VIP MUST be outside every VNet CIDR, or Azure prefers the VNet
 # system route over the more-specific BGP /32. Masks the VIP to each CIDR's prefix
 # length and compares network addresses (a correct containment test for any prefix).
@@ -146,15 +180,17 @@ module "client_vm" {
 # ---------------------------------------------------------
 
 # The application namespace (origin pool + VIP load balancer live here) is an
-# input, never an owned object. This deployment CANNOT create a namespace:
-# POST /api/web/namespaces is 403 for every name with the deploying credential,
-# because namespace creation is tenant-scoped in this shared enterprise tenant
-# (issue #634). A `resource` block therefore expresses semantics the API does not
-# permit, and the only way to make an apply succeed was to import a namespace
-# somebody else owns — which put a personal namespace, and the unrelated demos
-# living in it, on the destroy list (issue #637).
+# input, never an owned object. `multi-cloud-networking` predates this deployment
+# and outlives it, and a `resource` block would put a namespace full of other
+# people's demos on this stack's destroy list — which is how issue #637 happened.
 #
-# Reading it instead means Terraform never creates, updates or destroys it. The
+# Issues #634 ("cannot be recreated, POST is 403") and #639 ("defaults to a
+# namespace that no longer exists") were symptoms of reading the WRONG TENANT, not
+# of a permissions or lifecycle problem: the namespace exists, in f5-sales-demo,
+# and always did. The tenant guard at the top of this file is the actual fix (#696).
+# Reading rather than owning the namespace is still correct, for the #637 reason.
+#
+# Reading it means Terraform never creates, updates or destroys it. The
 # read still gives the pool and the load balancer their apply-time ordering: they
 # take their namespace from this data source, so a missing namespace fails the
 # plan loudly rather than half-applying. `namespace` is empty because a namespace

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -67,6 +67,30 @@ output "client_nic_name" {
 }
 
 # ---------------------------------------------------------
+# XC tenant
+# ---------------------------------------------------------
+
+output "xc_tenant" {
+  description = "F5 XC tenant this deployment writes to. Config-controlled (var.expected_xc_tenant), not taken from XCSH_API_URL."
+  value       = var.expected_xc_tenant
+}
+
+output "xc_api_url" {
+  description = "F5 XC API endpoint the xcsh provider is pinned to, derived from var.expected_xc_tenant."
+  value       = local.xc_api_url
+}
+
+# The other half of the tenant guard's comparison, published so an operator can
+# see what their shell is claiming without having to trip the guard to find out —
+# `terraform output xc_env_tenant` answers "which tenant am I sourced for?".
+# Empty means XCSH_API_URL is unset, which is the CI case and which the guard
+# treats as no opinion rather than as a mismatch.
+output "xc_env_tenant" {
+  description = "F5 XC tenant named by XCSH_API_URL in the environment this ran in, or empty when unset. Diagnostic only: xc_tenant is what the deployment actually targets."
+  value       = data.external.xc_env_tenant.result.tenant
+}
+
+# ---------------------------------------------------------
 # XC data-plane
 # ---------------------------------------------------------
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,14 +1,23 @@
-# The xcsh provider authenticates from the environment — no secrets in code.
-# Export one of the following credential sets before running Terraform:
+# The xcsh provider takes its CREDENTIAL from the environment — no secrets in
+# code — but NOT its endpoint. Export one of the following before running
+# Terraform:
 #
-#   Token auth:  XCSH_API_URL + XCSH_API_TOKEN
-#   P12 auth:    XCSH_API_URL + XCSH_P12_FILE + XCSH_P12_PASSWORD
-#   PEM auth:    XCSH_API_URL + XCSH_CERT + XCSH_KEY
+#   Token auth:  XCSH_API_TOKEN
+#   P12 auth:    XCSH_P12_FILE + XCSH_P12_PASSWORD
+#   PEM auth:    XCSH_CERT + XCSH_KEY
 #
-# See terraform/README notes / CONTRIBUTING.md for local dev setup
-# (dev_overrides + env). The plan-level tests mock this provider, so no XC
-# credentials are needed to run `terraform test`.
-provider "xcsh" {}
+# api_url is set here, from var.expected_xc_tenant, and deliberately overrides any
+# XCSH_API_URL in the environment. The tenant is not an ambient property of the
+# operator's shell: it is which deployment this is, it belongs in version control
+# next to the state key, and it is the one thing a credential file must not be
+# able to change silently. It once did — see the guard in main.tf and issue #696.
+#
+# A credential minted for a different tenant now fails against this URL instead of
+# succeeding somewhere unintended. The plan-level tests mock this provider, so no
+# XC credentials are needed to run `terraform test`.
+provider "xcsh" {
+  api_url = local.xc_api_url
+}
 
 # Azure — deploys the hub VNet, Route Server, CE VMs and the test client.
 # Auth comes from the environment (az CLI login locally; ARM_* / a service

--- a/terraform/scripts/xc-env-tenant.sh
+++ b/terraform/scripts/xc-env-tenant.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# Reports the F5 XC tenant named by XCSH_API_URL in the CURRENT ENVIRONMENT.
+#
+# Consumed by data.external.xc_env_tenant in ../main.tf, which fails the plan when
+# the answer disagrees with var.expected_xc_tenant. See the comment on that data
+# source for why the guard exists (the whole MCN demo was once silently rehomed to
+# another tenant because nothing in the configuration named the intended one).
+#
+# Terraform's `external` data source protocol: a JSON object arrives on stdin (an
+# empty one here, because the data source declares no `query`) and a flat JSON
+# object of string -> string must be written to stdout. Nothing else may go to
+# stdout, and a non-zero exit fails the plan.
+#
+# This reads the environment and NOTHING else — no XC credential, no network call,
+# no Azure. That is what lets `terraform test` and `terraform init -backend=false`
+# keep working in CI, where XCSH_API_URL is simply unset: the tenant comes back
+# empty and the guard abstains rather than failing.
+#
+# Unit-tested by ../../tests/test-xc-env-tenant.sh.
+set -eu
+
+url="${XCSH_API_URL:-}"
+
+# https://f5-sales-demo.console.ves.volterra.io/api -> f5-sales-demo
+#   1. drop the scheme            3. drop any :port
+#   2. drop everything from the   4. keep only the first hostname label
+#      first / ? or #
+tenant=$(
+  printf '%s' "$url" |
+    sed -e 's#^[A-Za-z][A-Za-z0-9+.-]*://##' \
+      -e 's#[/?#].*##' \
+      -e 's#:[0-9]*$##' \
+      -e 's#\..*##'
+)
+
+# Belt and braces: the value is interpolated into JSON, so allow only the
+# characters a DNS label can hold. Anything else would have to be a malformed
+# XCSH_API_URL, and an empty tenant is reported rather than broken JSON emitted.
+case "$tenant" in
+*[!A-Za-z0-9-]*) tenant='' ;;
+esac
+
+# api_url_set distinguishes "no XCSH_API_URL at all" (CI, and the guard abstains)
+# from "XCSH_API_URL set to something unparseable" (a real misconfiguration).
+if [ -n "$url" ]; then
+  api_url_set=true
+else
+  api_url_set=false
+fi
+
+printf '{"tenant":"%s","api_url_set":"%s"}\n' "$tenant" "$api_url_set"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -44,8 +44,21 @@ bastion_subnet_prefix      = "10.0.5.0/26"   # only used when enable_bastion = t
 # Provide the key path (read once at the root) OR paste the material in ssh_public_key.
 ssh_public_key_path = "~/.ssh/id_ed25519.pub"
 
+# --- F5 XC tenant ---
+# The tenant is CONFIG, not something XCSH_API_URL decides. Leave it at the default
+# unless you are deliberately driving a different tenant, in which case give that
+# deployment a state key of its own too — the two belong together (issue #696).
+#
+# Export only the CREDENTIAL: XCSH_API_TOKEN (or the P12/PEM pair). Any
+# XCSH_API_URL naming a different tenant fails the plan with a message saying so,
+# rather than quietly rebuilding the demo somewhere else, which is what happened.
+#
+# expected_xc_tenant = "f5-sales-demo"
+
 # --- F5 XC data-plane ---
-xc_app_namespace = "r-mordasiewicz"
+# A PRE-EXISTING namespace: it is read, never created or destroyed. It must exist
+# in expected_xc_tenant before the first apply.
+xc_app_namespace = "multi-cloud-networking"
 origin_ip        = "20.98.232.135"
 origin_port      = 80
 lb_domain        = "ar-bgp-ecmp.bankexample.com"

--- a/terraform/tests/tenant_guard.tftest.hcl
+++ b/terraform/tests/tenant_guard.tftest.hcl
@@ -1,0 +1,103 @@
+# Tenant guard (issue #696).
+#
+# The F5 XC tenant used to be decided entirely by XCSH_API_URL in the operator's
+# shell. When that value drifted, the whole demo silently rebuilt itself in another
+# tenant and every plan in between was clean. The tenant is now config:
+# var.expected_xc_tenant names it, providers.tf derives the xcsh api_url from it,
+# and data.external.xc_env_tenant fails the plan when the environment disagrees.
+#
+# What is asserted here is the part that is deterministic on any machine: the
+# variable's own validation, and the endpoint derived from it. The mismatch branch
+# of the guard depends on XCSH_API_URL, which a .tftest.hcl cannot set — that
+# branch is unit-tested in ../../tests/test-xc-env-tenant.sh, which drives the
+# program directly with the environment it wants.
+#
+# data.external is NOT mocked: the program reads the environment and makes no
+# network call, so running it for real is what proves the guard is credential-free.
+# With XCSH_API_URL unset (CI) it reports an empty tenant and the guard abstains.
+
+mock_provider "azurerm" {}
+mock_provider "azuread" {}
+mock_provider "xcsh" {}
+
+variables {
+  ce_count       = 1
+  deployer       = "tester"
+  enable_bastion = false
+  ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+}
+
+# The default is the tenant this deployment belongs to, and the API endpoint is
+# derived from it rather than read from the environment. Left at the default
+# deliberately: any other value would trip the guard on a workstation that has the
+# real (f5-sales-demo) credential sourced.
+run "api_url_is_derived_from_the_tenant" {
+  command = plan
+
+  assert {
+    condition     = output.xc_tenant == "f5-sales-demo"
+    error_message = "This deployment belongs to the f5-sales-demo tenant; that must be the default, not something the environment supplies."
+  }
+
+  assert {
+    condition     = output.xc_api_url == "https://f5-sales-demo.console.ves.volterra.io"
+    error_message = "The xcsh endpoint must be derived from expected_xc_tenant, so naming the tenant is the only input needed."
+  }
+
+  # The guard's invariant, stated as an assertion: a plan only gets this far when
+  # the environment either agrees with the configured tenant or says nothing.
+  # Both outcomes are legitimate — "" is CI, where XCSH_API_URL is unset — and any
+  # third value means the postcondition should already have aborted the plan.
+  assert {
+    condition     = contains(["", "f5-sales-demo"], output.xc_env_tenant)
+    error_message = "A plan that reaches its assertions must have agreed with the environment, or found no XCSH_API_URL at all."
+  }
+}
+
+# A URL is the mistake somebody will actually make, because XCSH_API_URL is a URL.
+# Reject it at plan time rather than building https://https://... and failing at
+# the first API call.
+run "rejects_a_url_instead_of_a_tenant" {
+  command = plan
+
+  variables {
+    expected_xc_tenant = "https://f5-sales-demo.console.ves.volterra.io"
+  }
+
+  expect_failures = [var.expected_xc_tenant]
+}
+
+run "rejects_a_hostname_instead_of_a_tenant" {
+  command = plan
+
+  variables {
+    expected_xc_tenant = "f5-sales-demo.console.ves.volterra.io"
+  }
+
+  expect_failures = [var.expected_xc_tenant]
+}
+
+# Hostname labels are case-insensitive but the tenant string is compared verbatim
+# against what the program parses out of XCSH_API_URL, so only one spelling can be
+# correct.
+run "rejects_uppercase" {
+  command = plan
+
+  variables {
+    expected_xc_tenant = "F5-Sales-Demo"
+  }
+
+  expect_failures = [var.expected_xc_tenant]
+}
+
+# An empty tenant would derive https://.console.ves.volterra.io and, worse, make
+# the guard's "" abstain value compare equal to a real mismatch.
+run "rejects_empty" {
+  command = plan
+
+  variables {
+    expected_xc_tenant = ""
+  }
+
+  expect_failures = [var.expected_xc_tenant]
+}

--- a/terraform/variables_xc.tf
+++ b/terraform/variables_xc.tf
@@ -1,9 +1,25 @@
 # ---------------------------------------------------------
+# F5 XC tenant
+# ---------------------------------------------------------
+
+variable "expected_xc_tenant" {
+  description = "F5 XC tenant this deployment belongs to: the first hostname label of the console URL (`f5-sales-demo` for https://f5-sales-demo.console.ves.volterra.io). This is the ONLY place the tenant is named. The xcsh provider's api_url is derived from it, so the configuration — not the ambient environment — decides which tenant is written to, and a plan FAILS when XCSH_API_URL in the environment names a different one."
+  type        = string
+  default     = "f5-sales-demo"
+
+  validation {
+    # A hostname label, not a URL: the scheme and domain are added in locals.tf.
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.expected_xc_tenant))
+    error_message = "expected_xc_tenant must be a bare DNS label (lowercase letters, digits and hyphens) such as f5-sales-demo — not a URL and not a hostname."
+  }
+}
+
+# ---------------------------------------------------------
 # F5 XC data-plane inputs
 # ---------------------------------------------------------
 
 variable "xc_app_namespace" {
-  description = "Name of a PRE-EXISTING F5 XC namespace to place the app-tier objects (origin pool + HTTP load balancer) in. This deployment reads the namespace, it never creates or deletes it: namespace creation is tenant-scoped and 403s for the deploying credential (issue #634)."
+  description = "Name of a PRE-EXISTING F5 XC namespace in expected_xc_tenant to place the app-tier objects (origin pool + HTTP load balancer) in. This deployment READS the namespace; it never creates or deletes it, so a namespace holding unrelated demos can never land on this stack's destroy list."
   type        = string
   default     = "multi-cloud-networking"
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -37,5 +37,12 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 3.0"
     }
+    # Runs scripts/xc-env-tenant.sh at plan time so the tenant guard in main.tf can
+    # see XCSH_API_URL. Terraform cannot read the environment itself, and the guard
+    # has to work with no credentials of any kind, which rules out asking the API.
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
   }
 }

--- a/tests/test-xc-env-tenant.sh
+++ b/tests/test-xc-env-tenant.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Hermetic test for terraform/scripts/xc-env-tenant.sh — the program behind the
+# tenant guard in terraform/main.tf (issue #696).
+#
+# The guard's whole job is to answer one question correctly: which F5 XC tenant
+# does XCSH_API_URL name? Everything downstream is a string comparison, so an
+# extraction bug is a guard that either blocks a correct deployment or waves the
+# incorrect one through — the second being the failure that put the MCN demo in
+# the wrong tenant in the first place.
+#
+# The mismatch branch cannot be exercised from a .tftest.hcl, because a Terraform
+# test cannot set an environment variable. It is exercised here instead: this file
+# owns the environment and can hand the program each case directly.
+#
+# No network, no credentials, no Terraform.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/terraform/scripts/xc-env-tenant.sh"
+
+FAIL=0
+
+# expect <description> <expected-json> [url]
+# Omitting the url argument runs with XCSH_API_URL UNSET, which is not the same
+# case as setting it empty and is what CI actually looks like.
+expect() {
+  local desc="$1" want="$2" got
+  if [ "$#" -ge 3 ]; then
+    got=$(XCSH_API_URL="$3" sh "$SCRIPT")
+  else
+    got=$(env -u XCSH_API_URL sh "$SCRIPT")
+  fi
+
+  if [ "$got" = "$want" ]; then
+    printf 'ok   %s\n' "$desc"
+  else
+    printf 'FAIL %s\n       want: %s\n       got:  %s\n' "$desc" "$want" "$got"
+    FAIL=1
+  fi
+}
+
+# --- The two tenants this repository has actually been pointed at -------------
+
+expect 'the intended tenant' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'https://f5-sales-demo.console.ves.volterra.io'
+
+expect 'the tenant the demo was accidentally rehomed to' \
+  '{"tenant":"f5-amer-ent","api_url_set":"true"}' \
+  'https://f5-amer-ent.console.ves.volterra.io'
+
+# --- URL shapes an operator or a credential file might hold -------------------
+
+expect 'trailing slash' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'https://f5-sales-demo.console.ves.volterra.io/'
+
+expect 'an /api path, as some tooling writes it' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'https://f5-sales-demo.console.ves.volterra.io/api'
+
+expect 'a deep path' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'https://f5-sales-demo.console.ves.volterra.io/api/config/namespaces/system'
+
+expect 'a query string' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'https://f5-sales-demo.console.ves.volterra.io?x=1'
+
+expect 'an explicit port' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'https://f5-sales-demo.console.ves.volterra.io:443'
+
+expect 'plain http' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'http://f5-sales-demo.console.ves.volterra.io'
+
+expect 'no scheme at all' \
+  '{"tenant":"f5-sales-demo","api_url_set":"true"}' \
+  'f5-sales-demo.console.ves.volterra.io'
+
+# --- Abstention: unset means "no opinion", not "mismatch" ---------------------
+#
+# This is the case CI runs in. If it ever reported a tenant, every credential-free
+# `terraform test` and `terraform init -backend=false` would fail the guard.
+
+expect 'XCSH_API_URL unset (CI): abstain' \
+  '{"tenant":"","api_url_set":"false"}'
+
+expect 'XCSH_API_URL set but empty: abstain' \
+  '{"tenant":"","api_url_set":"false"}' \
+  ''
+
+# --- Malformed input must never produce a tenant, or broken JSON --------------
+#
+# The tenant is interpolated into the JSON the data source parses. A value
+# carrying a quote or a brace would corrupt the document and fail the plan with a
+# parse error instead of the guard's message; report no tenant instead.
+
+expect 'not a URL' \
+  '{"tenant":"","api_url_set":"true"}' \
+  'not a url'
+
+expect 'a value containing a double quote' \
+  '{"tenant":"","api_url_set":"true"}' \
+  'https://ev"il.console.ves.volterra.io'
+
+expect 'a value containing JSON punctuation' \
+  '{"tenant":"","api_url_set":"true"}' \
+  'https://a{b}:c.console.ves.volterra.io'
+
+expect 'an underscore, which is not legal in a hostname label' \
+  '{"tenant":"","api_url_set":"true"}' \
+  'https://f5_sales_demo.console.ves.volterra.io'
+
+if [ "$FAIL" -ne 0 ]; then
+  printf '\nxc-env-tenant: FAILURES\n'
+  exit 1
+fi
+
+printf '\nxc-env-tenant: all checks passed\n'


### PR DESCRIPTION
Closes #696

## Problem

Which F5 XC tenant this deployment writes to was decided entirely by `XCSH_API_URL` in the
operator's shell. Nothing in `*.tf`, `terraform.tfvars` or the backend recorded the tenant, and
nothing checked it.

The gap already fired. The MCN CE-HA demo was built in `f5-sales-demo`; the credential file later
began exporting an `f5-amer-ent` `XCSH_API_URL`; subsequent applies minted an `f5-amer-ent`
registration token, the CE VMs re-registered there, and their `f5-sales-demo` registrations were
abandoned. A full parallel copy of the demo ended up in a shared enterprise tenant. Every plan in
between was clean, because the configuration never had an opinion about the tenant.

## Design

Two layers, because they fail differently.

**1. Pin the endpoint (the actual fix).** `var.expected_xc_tenant` names the tenant, defaulting to
`f5-sales-demo`, and `providers.tf` derives the `xcsh` provider's `api_url` from it. The endpoint is
no longer read from the environment at all, so a stray `XCSH_API_URL` can no longer redirect an
apply. The credential (`XCSH_API_TOKEN` / P12 / PEM) still comes from the environment — only the
*destination* moves into version control, next to the state key it belongs with.

**2. Name the mismatch (the diagnostic).** With the endpoint pinned, the residual hazard is a
*token* minted for a different tenant. Its natural symptom is a bare 401 on the first API call,
which reads like an expired credential rather than "you are pointed at the wrong tenant".
`data.external.xc_env_tenant` reads `XCSH_API_URL` and a `postcondition` fails the plan naming both
tenants:

```
Wrong F5 XC tenant. XCSH_API_URL in this environment names tenant 'f5-amer-ent', but this
deployment belongs to 'f5-sales-demo' (state key mcn.tfstate). Source the credential file for
'f5-sales-demo', or — if you really do mean to act on 'f5-amer-ent' — say so explicitly with
-var expected_xc_tenant=f5-amer-ent and a state key of its own.
```

`postcondition`, not `check{}`: a check block only *warns*, and a warning scrolls past in exactly
the situation this exists to stop.

### Why an external program

Terraform cannot read the environment, and the guard has to work with **no credentials of any
kind** — CI runs `terraform init -backend=false` and `terraform test` with no XC or Azure access, so
asking the API is not available either. `terraform/scripts/xc-env-tenant.sh` reads `XCSH_API_URL`
and nothing else: no network, no credential. Where `XCSH_API_URL` is unset the program reports an
empty tenant and the guard **abstains** rather than failing, which is what keeps CI green.

`data.external` is deliberately *not* mocked in the tests, so the tests exercise the real program.

## Also corrects a mis-diagnosis

Issues #634 ("app namespace cannot be recreated, `POST` is 403") and #639 ("defaults to a namespace
that no longer exists") were symptoms of reading the **wrong tenant**, not of a permissions or
lifecycle problem. `multi-cloud-networking` exists in `f5-sales-demo` and always did; the documented
default was correct. `terraform.tfvars.example` goes back to it, and the comments that recorded the
wrong conclusion are fixed. Reading the namespace rather than owning it stays, for the separate #637
reason (it holds other people's demos and must never reach this stack's destroy list).

## Tests

- `terraform/tests/tenant_guard.tftest.hcl` — 5 runs: the derived endpoint and tenant outputs, the
  guard's agreement invariant, and the variable's validation rejecting a URL, a hostname, uppercase,
  and empty.
- `tests/test-xc-env-tenant.sh` — 15 hermetic cases over the extraction itself, including the
  **mismatch branch a `.tftest.hcl` cannot reach** (a Terraform test cannot set an environment
  variable): both real tenants, path/query/port/scheme variants, the unset-and-abstain case, and
  malformed input that must not be able to inject into the JSON the data source parses. Wired into
  `scripts/pre-commit-local.sh`.

## Verification

```
terraform fmt -check -recursive          # clean
terraform validate                       # Success! The configuration is valid.
tflint --recursive                       # no issues
codespell <changed files>                # clean
shfmt -d / shellcheck                    # clean
bash tests/test-xc-env-tenant.sh         # 15/15 pass
terraform test  (XCSH_API_URL unset)     # Success! 30 passed, 0 failed
terraform test  (XCSH_API_URL=f5-sales-demo)  # tenant_guard 5 passed
terraform test  (XCSH_API_URL=f5-amer-ent)    # guard FAILS the plan, as designed
```

The negative case, verified rather than asserted:

```
Error: Resource postcondition failed
  on main.tf line 47, in data "external" "xc_env_tenant":
    │ self.result.tenant is "f5-amer-ent"
    │ var.expected_xc_tenant is "f5-sales-demo"
```

`tflint` initially flagged the data source as unreferenced. Fixed at the source by publishing the
detected value as the `xc_env_tenant` output — a genuinely useful diagnostic (`terraform output
xc_env_tenant` answers "which tenant is my shell sourced for?") rather than a rule suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)