### PR TITLE
Fix the MDX parse error that failed the Pages deploy, and add a check that catches it

### DIFF
--- a/docs/zh-cn/customer-edge/access/ssh.mdx
+++ b/docs/zh-cn/customer-edge/access/ssh.mdx
@@ -154,7 +154,7 @@ ssh -tt -o ProxyCommand="ssh -W %h:%p -o UserKnownHostsFile=/dev/null azureuser@
 
 因此 `ssh host 'some-command'` 无法工作：参数被忽略，交互式提示符照常启动。必须作为终端来驱动，否则无从操作。`scripts/sitecli_ssh_harvest.py` 是参考实现。
 
-<Aside type="caution" title="提示"无此设备或地址"的 panic 意味着认证已成功">
+<Aside type="caution" title="提示‘无此设备或地址’的 panic 意味着认证已成功">
 `vpmu` 在登录**之后**找不到可附加的终端时才会发出此错误。将其理解为崩溃时，看起来是最糟糕的结果，而实际上它是距离成功最近的一步报错。添加 `-tt` 后重新连接。
 </Aside>
 

--- a/sitecli/README.md
+++ b/sitecli/README.md
@@ -188,6 +188,15 @@ with `Expected a closing tag`. Backtick it. Related: if `textlint --plugin mdx` 
 page, that is a *true signal* of this and not a plugin defect — the error text invites you to
 report a plugin bug, and doing so wastes your time.
 
+**Quote a phrase inside an `<Aside title="...">` with single quotes, never double.** A second
+`"` ends the attribute, and MDX then reads the rest as an attribute name:
+``Unexpected character `"` (U+0022) in attribute name``. This is mainly a translation hazard — the
+English pages use single quotes, but a translator may render them as typographic or straight
+doubles, and it broke a Pages deploy after the fact (#712). Nothing else catches it: parity
+compares fence and component counts, the `sourceHash` audit only proves freshness, and CI's
+prose linters pass. `tests/test-mdx-attribute-quotes.sh` is the check, and it scans every locale
+because MDX aborts on the first parse error and hides the rest.
+
 **Do not duplicate configuration that has to stay identical across locales.** Fenced code is
 preserved — command names and captured output come through unchanged in all twelve locales,
 verified. Frontmatter and prose are translated, so a `description` or heading carrying a

--- a/tests/test-mdx-attribute-quotes.sh
+++ b/tests/test-mdx-attribute-quotes.sh
@@ -61,13 +61,13 @@ printf '2. the check itself catches a planted violation\n'
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-cat > "${TMP}/bad.mdx" <<'BAD'
+cat >"${TMP}/bad.mdx" <<'BAD'
 <Aside type="caution" title="a phrase "quoted" inside the attribute">
 body
 </Aside>
 BAD
 
-cat > "${TMP}/good.mdx" <<'GOOD'
+cat >"${TMP}/good.mdx" <<'GOOD'
 <Aside type="caution" title="a phrase 'quoted' with single quotes">
 body
 </Aside>

--- a/tests/test-mdx-attribute-quotes.sh
+++ b/tests/test-mdx-attribute-quotes.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# A double-quoted JSX attribute cannot contain a straight double quote. MDX stops
+# parsing the attribute at the second `"`, treats what follows as another attribute
+# name, and fails the build:
+#
+#   <Aside type="caution" title="提示"无此设备或地址"的 panic 意味着认证已成功">
+#                                    ^ attribute ends here
+#
+#   Unexpected character `"` (U+0022) in attribute name ...
+#
+# This broke the Pages deploy on main after PR #711 merged (issue #712). Nothing
+# else in the pipeline catches it:
+#
+#   * translation parity compares fence and component COUNTS, which still matched;
+#   * the i18n.sourceHash audit proves freshness, not that the file parses;
+#   * docs-translate reported success for the file;
+#   * CI's MARKDOWN and NATURAL_LANGUAGE linters both passed.
+#
+# The English pages avoid this by using single quotes inside an attribute, but a
+# translator will not necessarily preserve that, so the risk is highest in the
+# twelve generated locales — which is exactly where a human is least likely to look.
+#
+# MDX aborts on the FIRST parse error, so one bad attribute hides every one behind
+# it. This scans all files and reports all of them.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+CONTENT="${ROOT}/docs"
+
+VIOLATIONS=0
+
+# A double-quoted attribute value that itself contains a double quote. Anchored on
+# `attr="` so prose containing quotes is untouched — only attribute values match.
+PATTERN='<[A-Z][A-Za-z]*[^>]*[a-zA-Z-]+="[^"]*"[^=">]*"'
+
+scan() {
+  local dir="$1" label="$2" found=0
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    printf '  [FAIL] %s\n' "$hit"
+    found=$((found + 1))
+  done < <(grep -rnoE "$PATTERN" "$dir" --include='*.mdx' 2>/dev/null || true)
+  if [ "$found" -gt 0 ]; then
+    printf '%s: %d nested-quote attribute(s)\n' "$label" "$found" >&2
+    VIOLATIONS=$((VIOLATIONS + found))
+  else
+    printf '  ok   — %s\n' "$label"
+  fi
+}
+
+printf '1. no .mdx nests a straight quote inside a JSX attribute\n'
+scan "$CONTENT" "every locale under docs/"
+
+# --- the check must be able to fail -------------------------------------------
+#
+# A scan that reports nothing is worthless if it cannot report anything. Plant a
+# violation in a temporary tree and require the pattern to catch it, and a safe
+# variant to pass, so a regex that silently stops matching fails this script
+# instead of blessing the repository.
+printf '2. the check itself catches a planted violation\n'
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "${TMP}/bad.mdx" <<'BAD'
+<Aside type="caution" title="a phrase "quoted" inside the attribute">
+body
+</Aside>
+BAD
+
+cat > "${TMP}/good.mdx" <<'GOOD'
+<Aside type="caution" title="a phrase 'quoted' with single quotes">
+body
+</Aside>
+
+Prose may contain "double quotes" freely, and <Aside type="note" title="plain"> is fine.
+GOOD
+
+if grep -rqE "$PATTERN" "${TMP}/bad.mdx"; then
+  printf '  ok   — caught the planted nested quote\n'
+else
+  printf '  [FAIL] the pattern did not catch a known-bad attribute\n' >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+fi
+
+if grep -rqE "$PATTERN" "${TMP}/good.mdx"; then
+  printf '  [FAIL] the pattern flagged a file that is legitimate\n' >&2
+  grep -rnoE "$PATTERN" "${TMP}/good.mdx" >&2 || true
+  VIOLATIONS=$((VIOLATIONS + 1))
+else
+  printf '  ok   — left single quotes and prose quotes alone\n'
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  printf 'FAIL: %d problem(s). A double-quoted JSX attribute must not contain a double quote — use single quotes inside it.\n' "$VIOLATIONS" >&2
+  exit 1
+fi
+
+printf 'PASS: every JSX attribute in every locale parses as MDX\n'


### PR DESCRIPTION
Closes #712

## The break

The Pages deploy failed on `main` at `2ec1b68` and the site did not update:

```
Unexpected character `"` (U+0022) in attribute name ...
  [plugin @mdx-js/rolldown] src/content/docs/zh-cn/customer-edge/access/ssh.mdx:157:40
```

The Chinese translation of an `<Aside>` title nested straight double quotes inside a
double-quoted JSX attribute, ending the attribute early. The English source uses single
quotes there; the translator rendered them as doubles. Fixed with Chinese single quotation
marks, which keeps the typography correct for the language.

## Why nothing caught it, and what now does

Every existing gate passed on the broken tree:

| Gate | Result on the broken tree | Why it missed this |
| --- | --- | --- |
| `test-translation-parity.sh` | pass | compares fence and component **counts**, which matched |
| `i18n.sourceHash` audit | pass | proves freshness, not that the file parses |
| `docs-translate` | reported `✓` for the file | no MDX validation |
| CI `MARKDOWN`, `NATURAL_LANGUAGE` | pass | neither parses JSX attributes |

So the first signal was the deploy failing **after merge**. `tests/test-mdx-attribute-quotes.sh`
closes that: it scans every locale — MDX aborts on the first parse error and hides the rest —
and it plants a violation in a temp tree to prove it can still fail, in the manner of
`tests/test-docs-no-literals.sh`.

Demonstrated **red** against the broken tree, flagging exactly `zh-cn ssh.mdx:157`, and green
after the one-character-class fix. The self-check confirms it leaves single quotes and ordinary
prose quotes alone.

## Verification

- `tests/test-mdx-attribute-quotes.sh` — red before, green after; self-check passes both ways.
- All nine shell test scripts and `scripts/check-sitecli-docs.sh` — exit 0.
- `pre-commit run --all-files` — exit 0, after fixing a nested-backtick MD038 the README note
  introduced.
- The remaining work is the deploy itself: this cannot be called done until the Pages run
  succeeds and the pages are fetched from the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)