### PR TITLE
Size the CE OS disk, and correct four version claims the matrix disproved

### DIFF
--- a/terraform/modules/ce-node/main.tf
+++ b/terraform/modules/ce-node/main.tf
@@ -101,6 +101,10 @@ resource "azurerm_linux_virtual_machine" "this" {
     name                 = "${var.hostname}-osdisk"
     caching              = "ReadWrite"
     storage_account_type = "StandardSSD_LRS"
+
+    # Explicit, because the image default is the one size measured to fail the
+    # advertised version pair (#714). See variables.tf for the measurements.
+    disk_size_gb = var.os_disk_size_gb
   }
 
   source_image_reference {

--- a/terraform/modules/ce-node/variables.tf
+++ b/terraform/modules/ce-node/variables.tf
@@ -65,3 +65,31 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# Sized from measurement, not from a rule of thumb. Issue #714 ran one disposable
+# single-node Azure Secure Mesh v2 site per size, all from marketplace image 0.9.2,
+# installing the pair the tenant advertises (crt-20260201-0179 + OS 9.2026.14):
+#
+#     31 GiB (the image default)   FAIL — voucher DaemonSet 0/1, site stuck
+#                                  PROVISIONING with nothing installed
+#     33 GB                        PASS
+#     36 / 40 / 48 / 64 GB         PASS
+#
+# The default below is deliberately NOT the measured 33 GB floor. 33 works for that
+# pair on that image today; a build with a marginally larger payload would fail there
+# with no configuration change and no obvious cause — exactly the position the image
+# default is in now.
+#
+# Do NOT size this from F5's documented "20 GB plus 15% of capacity" pre-upgrade
+# figure. That check gates Console UI upgrades only and does not apply to the API
+# path; applied here it predicts 48 GB would fail, and 48 GB installs cleanly.
+variable "os_disk_size_gb" {
+  description = "CE OS disk size in GB. The marketplace image default of 31 GiB is measured to FAIL the version pair F5 advertises (#714); 33 GB is the smallest size that works and this default carries headroom above it."
+  type        = number
+  default     = 64
+
+  validation {
+    condition     = var.os_disk_size_gb >= 40
+    error_message = "os_disk_size_gb must be at least 40 GB. The image default of 31 GiB fails the advertised version pair, and 33 GB — the measured minimum — leaves no margin for a larger future payload (#714)."
+  }
+}

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -112,31 +112,48 @@ resource "xcsh_securemesh_site_v2" "this" {
     geo_proximity {}
   }
 
-  # CE software/OS version. Re-validated live 2026-07-28, and three things previously
-  # believed about this block are wrong:
+  # CE software/OS version. Measured by the matrix in issue #714 (2026-07-29), which
+  # disproved three things this comment previously asserted. What holds:
   #
-  # 1. PINNING DOES NOT AVOID AN UPGRADE. The marketplace image is always `latest`
-  #    (see modules/ce-node), it ships an older XC build, and the node upgrades on
-  #    first boot either way — `volterra_software_status.deployment_state.phase` reads
-  #    UPGRADE_COMPLETED with `last_installed_version` equal to the pin. The pin
-  #    chooses the DESTINATION of that upgrade, nothing more.
+  # 1. THE NODE ALWAYS INSTALLS SOMETHING ON FIRST BOOT. modules/ce-node deploys the
+  #    marketplace image at `latest`, so the build a node arrives with is whatever that
+  #    image currently ships. The pin chooses the DESTINATION, not whether an install
+  #    happens.
   #
-  # 2. EMPTY VARS DO NOT MEAN "LATEST". They emit the default_* marker arms, which the
-  #    API interprets as "no preference" — and XC then advertises
-  #    `available_version` and waits rather than upgrading. A tenant site left
-  #    unpinned sat on a build nine months older than the version it advertised as
-  #    available. Unpinned means "whatever the node came up with", not "newest".
+  #    Corrected: the image does NOT necessarily ship something older. Image 0.9.2
+  #    ships a build stamped 20260703-e2c462a — newer than this fleet's pin and newer
+  #    than the version the tenant advertises. A backwards pin is routine: this fleet
+  #    was created from that image with a pin thirteen months older and is running.
   #
-  # 3. software_settings IS EFFECTIVELY CREATE-ONLY. Any PUT touching it is rejected
-  #    with `[BAD_REQUEST] Invalid request parameters` — verified in BOTH directions,
-  #    un-pinning and pinning forward, on all three sites. Worse, the first rejected
-  #    request still cleared the field server-side while the provider's Read does not
-  #    surface it, so Terraform's state disagrees with the live object and re-proposes
-  #    the same failing change forever (xcsh#1387).
+  # 2. AN EMPTY VAR MEANS "GIVE ME THE NEWEST", NOT "LEAVE IT ALONE". The default_*
+  #    marker arms below are filled in by the server at CREATE with the newest
+  #    ADVERTISED version, and it installs that. A site created with both vars empty
+  #    came back pinned to crt-20260201-0179 / 9.2026.14 and the install then failed.
   #
-  # CONSEQUENCE FOR OPERATORS: moving a CE to a different version means RECREATING the
-  # site and its CE VM with the new value, not editing it. That is a fleet rebuild.
-  # Choose the version deliberately at deploy time.
+  #    So empty is the RISKIEST setting, not the neutral one, and it makes the outcome
+  #    depend on the date rather than on this configuration. Pin both deliberately.
+  #    ("Advertises and waits" is real, but it applies AFTER first boot, not during it.)
+  #
+  # 3. software_settings IS CREATE-ONLY — for Terraform. Any PUT touching it is
+  #    rejected with `[BAD_REQUEST] Invalid request parameters`, verified in all three
+  #    directions: pinning forward, pinning backward, and un-pinning.
+  #
+  #    Corrected: a version change is NOT a rebuild. The platform performs it in place
+  #    via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (and upgrade_os)
+  #    with {"version": "..."} — verified end to end, the site reached ONLINE with
+  #    last_installed_version equal to the requested build. The provider cannot do this
+  #    yet (xcsh#1390), so an API upgrade leaves these vars disagreeing with the live
+  #    object and Terraform unable to reconcile.
+  #
+  #    Also corrected: the claim that a rejected PUT "still cleared the field
+  #    server-side" was NOT reproduced — after each of the three rejections the spec was
+  #    unchanged and the site stayed ONLINE. The divergence in xcsh#1387 was seen on a
+  #    site that had already auto-upgraded past its pin, so it may need that starting
+  #    state; that case was not tested and is not claimed either way.
+  #
+  # CONSEQUENCE FOR OPERATORS: pin both versions explicitly, and size the CE disk for
+  # them — the image default fails the advertised pair (see modules/ce-node). To move a
+  # running site, use the upgrade API rather than editing these values.
   software_settings {
     os {
       dynamic "default_os_version" {

--- a/terraform/tests/ce_node.tftest.hcl
+++ b/terraform/tests/ce_node.tftest.hcl
@@ -167,3 +167,60 @@ run "vm_instance_id_is_the_instance_id_not_the_arm_resource_id" {
     error_message = "vm_instance_id must expose virtual_machine_id (regenerated per instance), not the name-derived ARM resource id."
   }
 }
+
+# The CE OS disk must be sized explicitly, and large enough that the versions F5
+# advertises can actually install.
+#
+# Measured 2026-07-29 (issue #714), one disposable single-node Azure Secure Mesh v2
+# site per size, all from marketplace image 0.9.2, installing the pair the tenant
+# advertises (crt-20260201-0179 + OS 9.2026.14):
+#
+#     31 GiB (the image default, i.e. no disk_size_gb)  FAIL — voucher DaemonSet
+#                                                       0/1, site stuck
+#                                                       PROVISIONING, nothing
+#                                                       installed
+#     33 GB                                             PASS
+#     36 / 40 / 48 / 64 GB                              PASS
+#
+# So an unset disk_size_gb is not a neutral default: it is the one size on which the
+# advertised pair fails. It matters even while the fleet pins an older build,
+# because leaving the version variables EMPTY makes the server choose the newest
+# advertised pair — so an unpinned deployment lands exactly on the failing case.
+#
+# The floor asserted here is deliberately above the measured 33 GB minimum. 33 works
+# for this pair on this image today; a build with a marginally larger payload would
+# fail there with no configuration change and no obvious cause, which is precisely
+# the position the 31 GiB default is in now.
+run "ce_os_disk_is_sized_for_the_advertised_versions" {
+  command = plan
+
+  module {
+    source = "./modules/ce-node"
+  }
+
+  variables {
+    hostname            = "f5-xc-ce-vm-01"
+    resource_group_name = "rg-mcn-ce-ha-testdeployer"
+    location            = "eastus"
+    zone                = "1"
+    vm_size             = "Standard_D8_v4"
+    mgmt_subnet_id      = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/snet-hub-management"
+    external_subnet_id  = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/snet-hub-external"
+    internal_subnet_id  = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/hub-vnet/subnets/snet-hub-internal"
+    mgmt_private_ip     = "10.0.1.4"
+    admin_username      = "azureuser"
+    ssh_public_key      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+    custom_data         = "IyNjbG91ZC1jb25maWcK"
+    tags                = {}
+  }
+
+  assert {
+    condition     = azurerm_linux_virtual_machine.this.os_disk[0].disk_size_gb > 0
+    error_message = "The CE OS disk size must be set explicitly. Left unset the VM inherits the marketplace image default of 31 GiB, which is the one size measured to fail the version pair F5 advertises (#714). Note the check is > 0, not != null: an unset attribute renders as 0 in a mocked plan, so a null check would pass on exactly the case it exists to catch."
+  }
+
+  assert {
+    condition     = azurerm_linux_virtual_machine.this.os_disk[0].disk_size_gb >= 40
+    error_message = "The CE OS disk must be at least 40 GB. 33 GB is the smallest size measured to work, so this floor is deliberate headroom: a build with a slightly larger payload would fail at the minimum with no configuration change (#714)."
+  }
+}

--- a/terraform/variables_ce.tf
+++ b/terraform/variables_ce.tf
@@ -63,13 +63,13 @@ variable "registration_token" {
 }
 
 variable "ce_os_version" {
-  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). Empty leaves it to the server, which means whatever the node boots with — NOT the newest: XC advertises an available version and waits. This cannot be changed on a running site (any update is rejected 400, xcsh#1387), so changing it recreates the site and its CE VM."
+  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). EMPTY IS NOT NEUTRAL: at create the server fills an empty field with the newest ADVERTISED version and installs it, so an empty value makes the result depend on the date rather than on this configuration — pin it deliberately (#714). Terraform cannot change it afterwards: the update is rejected 400 in every direction, including un-pinning. The platform CAN change it in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_os, so a version change is not a rebuild — but the provider cannot drive that yet (xcsh#1390), and using it leaves this value disagreeing with the live site."
   type        = string
   default     = ""
 }
 
 variable "ce_sw_version" {
-  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node upgrades to this on first boot; the marketplace image is always latest and ships something older, so an upgrade happens either way and this only chooses its destination. Empty is NOT latest, and this cannot be changed on a running site (xcsh#1387) — changing it recreates the site and its CE VM."
+  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node installs this on first boot; it chooses the destination, not whether an install happens. Do not assume the image ships something older — image 0.9.2 ships a NEWER build than this fleet pins, and a backwards pin is routine (#714). EMPTY IS NOT NEUTRAL: the server fills an empty field with the newest ADVERTISED version and installs it, which on the image default disk is the combination measured to FAIL — pin it deliberately, and see modules/ce-node for the disk. Terraform cannot change it afterwards (update rejected 400 in every direction), but the platform can in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (xcsh#1390)."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Closes #717
Closes #718

Both halves come from the same measurements in #714, so they land together — the disk change is what
makes the corrected claims actionable.

## The CE disk was never sized

`modules/ce-node` declared `os_disk` with no `disk_size_gb`, so every Customer Edge inherited the
marketplace image's **31 GiB** — the one size measured to *fail* the version pair the tenant
advertises. One disposable single-node Azure Secure Mesh v2 site per size, all from image `0.9.2`,
installing `crt-20260201-0179` + OS `9.2026.14`:

| OS disk | outcome |
| --- | --- |
| 31 GiB (image default, what we shipped) | **FAIL** — voucher DaemonSet 0/1, stuck `PROVISIONING`, nothing installed |
| 33 GB | PASS |
| 36 / 40 / 48 / 64 GB | PASS |

Default is now **64 GB**, with a validation floor of **40** — deliberately above the measured 33 GB
minimum. 33 works for that pair on that image today; a build with a marginally larger payload would
fail there with no configuration change, which is exactly where the 31 GiB default sits now.

**This matters even though the fleet pins an older build**, because an empty version variable makes
the server choose the newest advertised pair — so an unpinned deployment lands precisely on the
failing case.

## Four claims in the terraform were wrong

`variables_ce.tf` and the `xc-site` comment block are what an engineer reads before the docs site,
and they contradicted it after #715/#716. Now aligned with what was measured:

| Claim | Correction |
| --- | --- |
| "Empty means whatever the node boots with, NOT the newest" | At create the server fills an empty field with the newest **advertised** version and installs it. Empty is the riskiest setting and makes the outcome date-dependent. |
| "The marketplace image ships something older" | Image `0.9.2` ships **newer** than this fleet's pin. A backwards pin is routine — this fleet was built that way and is running. |
| "Changing it recreates the site and its CE VM" | Terraform cannot change it (rejected in all three directions), but the platform does it **in place** via `POST .../sites/{name}/upgrade_sw`. Not a rebuild. Provider support is xcsh#1390. |
| "A rejected PUT still cleared the field server-side" | **Not reproduced** — spec unchanged after each rejection, site stayed `ONLINE`. Narrowed to the divergent-state case xcsh#1387 describes, and marked untested rather than deleted. |

The `replace_triggered_by` rationale is **retained**: #714's D2 cell confirmed that replacing the VM
alone leaves the site `FAILED`, so that coupling is still right — only the "a version change requires
it" framing was wrong.

## Verification

- `terraform test` — **31 passed, 0 failed**.
- The new test was **red before** the change (`disk_size_gb is 0`), green after, and **red again**
  when the `disk_size_gb` line is deleted — so the guard cannot rot silently.
- One assertion was tightened mid-work and the reason is recorded in the test: `!= null` **passed**
  on the unset value, because a mocked plan renders it as `0`. It would have held on the exact case
  it existed to catch.
- `terraform fmt -check -recursive` clean; `terraform validate` clean; `pre-commit run --all-files`
  exit 0.
- Grep confirms no disproved claim remains as an assertion under `terraform/`. Two strings still
  match, both inside explicit withdrawals ("Do **not** assume the image ships something older", and
  "the claim … **was NOT reproduced**") — a plain grep cannot distinguish an assertion from a
  retraction.

## Not included

`ce_sw_version` / `ce_os_version` still default to `""`. Making a pin mandatory is the sharper
determinism fix and is tracked separately, because it changes behaviour for any caller relying on the
empty default rather than only correcting a description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)