### PR TITLE
Re-sync the terraform includes that #719 left stale, and file the protection gap that let it merge

### DIFF
--- a/docs/_includes/terraform/modules/ce-node/main.tf
+++ b/docs/_includes/terraform/modules/ce-node/main.tf
@@ -101,6 +101,10 @@ resource "azurerm_linux_virtual_machine" "this" {
     name                 = "${var.hostname}-osdisk"
     caching              = "ReadWrite"
     storage_account_type = "StandardSSD_LRS"
+
+    # Explicit, because the image default is the one size measured to fail the
+    # advertised version pair (#714). See variables.tf for the measurements.
+    disk_size_gb = var.os_disk_size_gb
   }
 
   source_image_reference {

--- a/docs/_includes/terraform/modules/ce-node/variables.tf
+++ b/docs/_includes/terraform/modules/ce-node/variables.tf
@@ -65,3 +65,31 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# Sized from measurement, not from a rule of thumb. Issue #714 ran one disposable
+# single-node Azure Secure Mesh v2 site per size, all from marketplace image 0.9.2,
+# installing the pair the tenant advertises (crt-20260201-0179 + OS 9.2026.14):
+#
+#     31 GiB (the image default)   FAIL — voucher DaemonSet 0/1, site stuck
+#                                  PROVISIONING with nothing installed
+#     33 GB                        PASS
+#     36 / 40 / 48 / 64 GB         PASS
+#
+# The default below is deliberately NOT the measured 33 GB floor. 33 works for that
+# pair on that image today; a build with a marginally larger payload would fail there
+# with no configuration change and no obvious cause — exactly the position the image
+# default is in now.
+#
+# Do NOT size this from F5's documented "20 GB plus 15% of capacity" pre-upgrade
+# figure. That check gates Console UI upgrades only and does not apply to the API
+# path; applied here it predicts 48 GB would fail, and 48 GB installs cleanly.
+variable "os_disk_size_gb" {
+  description = "CE OS disk size in GB. The marketplace image default of 31 GiB is measured to FAIL the version pair F5 advertises (#714); 33 GB is the smallest size that works and this default carries headroom above it."
+  type        = number
+  default     = 64
+
+  validation {
+    condition     = var.os_disk_size_gb >= 40
+    error_message = "os_disk_size_gb must be at least 40 GB. The image default of 31 GiB fails the advertised version pair, and 33 GB — the measured minimum — leaves no margin for a larger future payload (#714)."
+  }
+}

--- a/docs/_includes/terraform/modules/xc-site/main.tf
+++ b/docs/_includes/terraform/modules/xc-site/main.tf
@@ -112,31 +112,48 @@ resource "xcsh_securemesh_site_v2" "this" {
     geo_proximity {}
   }
 
-  # CE software/OS version. Re-validated live 2026-07-28, and three things previously
-  # believed about this block are wrong:
+  # CE software/OS version. Measured by the matrix in issue #714 (2026-07-29), which
+  # disproved three things this comment previously asserted. What holds:
   #
-  # 1. PINNING DOES NOT AVOID AN UPGRADE. The marketplace image is always `latest`
-  #    (see modules/ce-node), it ships an older XC build, and the node upgrades on
-  #    first boot either way — `volterra_software_status.deployment_state.phase` reads
-  #    UPGRADE_COMPLETED with `last_installed_version` equal to the pin. The pin
-  #    chooses the DESTINATION of that upgrade, nothing more.
+  # 1. THE NODE ALWAYS INSTALLS SOMETHING ON FIRST BOOT. modules/ce-node deploys the
+  #    marketplace image at `latest`, so the build a node arrives with is whatever that
+  #    image currently ships. The pin chooses the DESTINATION, not whether an install
+  #    happens.
   #
-  # 2. EMPTY VARS DO NOT MEAN "LATEST". They emit the default_* marker arms, which the
-  #    API interprets as "no preference" — and XC then advertises
-  #    `available_version` and waits rather than upgrading. A tenant site left
-  #    unpinned sat on a build nine months older than the version it advertised as
-  #    available. Unpinned means "whatever the node came up with", not "newest".
+  #    Corrected: the image does NOT necessarily ship something older. Image 0.9.2
+  #    ships a build stamped 20260703-e2c462a — newer than this fleet's pin and newer
+  #    than the version the tenant advertises. A backwards pin is routine: this fleet
+  #    was created from that image with a pin thirteen months older and is running.
   #
-  # 3. software_settings IS EFFECTIVELY CREATE-ONLY. Any PUT touching it is rejected
-  #    with `[BAD_REQUEST] Invalid request parameters` — verified in BOTH directions,
-  #    un-pinning and pinning forward, on all three sites. Worse, the first rejected
-  #    request still cleared the field server-side while the provider's Read does not
-  #    surface it, so Terraform's state disagrees with the live object and re-proposes
-  #    the same failing change forever (xcsh#1387).
+  # 2. AN EMPTY VAR MEANS "GIVE ME THE NEWEST", NOT "LEAVE IT ALONE". The default_*
+  #    marker arms below are filled in by the server at CREATE with the newest
+  #    ADVERTISED version, and it installs that. A site created with both vars empty
+  #    came back pinned to crt-20260201-0179 / 9.2026.14 and the install then failed.
   #
-  # CONSEQUENCE FOR OPERATORS: moving a CE to a different version means RECREATING the
-  # site and its CE VM with the new value, not editing it. That is a fleet rebuild.
-  # Choose the version deliberately at deploy time.
+  #    So empty is the RISKIEST setting, not the neutral one, and it makes the outcome
+  #    depend on the date rather than on this configuration. Pin both deliberately.
+  #    ("Advertises and waits" is real, but it applies AFTER first boot, not during it.)
+  #
+  # 3. software_settings IS CREATE-ONLY — for Terraform. Any PUT touching it is
+  #    rejected with `[BAD_REQUEST] Invalid request parameters`, verified in all three
+  #    directions: pinning forward, pinning backward, and un-pinning.
+  #
+  #    Corrected: a version change is NOT a rebuild. The platform performs it in place
+  #    via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (and upgrade_os)
+  #    with {"version": "..."} — verified end to end, the site reached ONLINE with
+  #    last_installed_version equal to the requested build. The provider cannot do this
+  #    yet (xcsh#1390), so an API upgrade leaves these vars disagreeing with the live
+  #    object and Terraform unable to reconcile.
+  #
+  #    Also corrected: the claim that a rejected PUT "still cleared the field
+  #    server-side" was NOT reproduced — after each of the three rejections the spec was
+  #    unchanged and the site stayed ONLINE. The divergence in xcsh#1387 was seen on a
+  #    site that had already auto-upgraded past its pin, so it may need that starting
+  #    state; that case was not tested and is not claimed either way.
+  #
+  # CONSEQUENCE FOR OPERATORS: pin both versions explicitly, and size the CE disk for
+  # them — the image default fails the advertised pair (see modules/ce-node). To move a
+  # running site, use the upgrade API rather than editing these values.
   software_settings {
     os {
       dynamic "default_os_version" {

--- a/docs/_includes/terraform/variables_ce.tf
+++ b/docs/_includes/terraform/variables_ce.tf
@@ -63,13 +63,13 @@ variable "registration_token" {
 }
 
 variable "ce_os_version" {
-  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). Empty leaves it to the server, which means whatever the node boots with — NOT the newest: XC advertises an available version and waits. This cannot be changed on a running site (any update is rejected 400, xcsh#1387), so changing it recreates the site and its CE VM."
+  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). EMPTY IS NOT NEUTRAL: at create the server fills an empty field with the newest ADVERTISED version and installs it, so an empty value makes the result depend on the date rather than on this configuration — pin it deliberately (#714). Terraform cannot change it afterwards: the update is rejected 400 in every direction, including un-pinning. The platform CAN change it in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_os, so a version change is not a rebuild — but the provider cannot drive that yet (xcsh#1390), and using it leaves this value disagreeing with the live site."
   type        = string
   default     = ""
 }
 
 variable "ce_sw_version" {
-  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node upgrades to this on first boot; the marketplace image is always latest and ships something older, so an upgrade happens either way and this only chooses its destination. Empty is NOT latest, and this cannot be changed on a running site (xcsh#1387) — changing it recreates the site and its CE VM."
+  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node installs this on first boot; it chooses the destination, not whether an install happens. Do not assume the image ships something older — image 0.9.2 ships a NEWER build than this fleet pins, and a backwards pin is routine (#714). EMPTY IS NOT NEUTRAL: the server fills an empty field with the newest ADVERTISED version and installs it, which on the image default disk is the combination measured to FAIL — pin it deliberately, and see modules/ce-node for the disk. Terraform cannot change it afterwards (update rejected 400 in every direction), but the platform can in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (xcsh#1390)."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Closes #722

## What broke

#719 edited `terraform/` without re-running `scripts/sync-terraform-includes.sh`, so
`docs/_includes/terraform/` kept the previous copies. Two consequences:

1. `tests/test-terraform-includes.sh` fails on `main`.
2. **The published site still showed the version claims #719 had just disproved.**
   `docs/_includes/terraform/variables_ce.tf` carried two of them — readers were being served text
   the repository had already corrected.

## Why it reached main

`lint / Shell Unit Tests` **failed on #719 and reported exactly this defect**. It is not among
`main`'s required status checks — only `Check linked issues`, `Lint Code Base` and
`Translation freshness` are — so auto-merge landed the branch with a red test.

That protection gap is filed as #722 and closed by this PR's link, but the fix there is a settings
change rather than a code change, so it needs doing separately from this content fix.

## Verification

- `scripts/sync-terraform-includes.sh` → 29 files synced.
- `tests/test-terraform-includes.sh` — exit 0 (was exit 1 on `main`).
- Disproved claims in the includes: `NOT the newest` 0, `Empty is NOT latest` 0,
  `recreates the site` 0. Control pattern `upgrade_sw` returns 2, proving the scan works rather than
  matching nothing.
- The includes now carry `os_disk_size_gb`, so the published Terraform shows the sized disk.

## Note on the follow-up

The remaining work in #722 is to make `Shell Unit Tests` required, and to decide deliberately about
`validate` and `coverage-smsv2`, which are also advisory today. Both reported on #719 and neither
would have blocked it either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)