### PR TITLE
fix(docs): stop rejecting TEST-NET-3, and stop judging published PII by fence type

### DIFF
--- a/docs/ar/customer-edge/access/site-console.mdx
+++ b/docs/ar/customer-edge/access/site-console.mdx
@@ -110,7 +110,7 @@ Reader في الخطوة 2 هو متطلب موثّق من Microsoft وليس ش
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/ar/customer-edge/index.mdx
+++ b/docs/ar/customer-edge/index.mdx
@@ -88,7 +88,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 الموقع الذي **لا وجود له** لديه تفسير ثانٍ يسبق «أنه لم يُسجَّل قط»: وهو أنك
 موجَّه إلى المستأجر الخاطئ. يعيش هذا النشر في `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`)، وهو مثبَّت بواسطة `var.expected_xc_tenant` —
+(`https://<XC_TENANT>.console.ves.volterra.io`)، وهو مثبَّت بواسطة `var.expected_xc_tenant` —
 والأمر `cd terraform && terraform output -raw xc_tenant` يوضّح ذلك دون المساس بأي شيء. أما
 بيانات الاعتماد المُصدرة لمستأجر آخر فتعيد `401` مجردًا، وهو ما يُقرأ كرمز منتهي الصلاحية.
 </Aside>

--- a/docs/de/customer-edge/access/site-console.mdx
+++ b/docs/de/customer-edge/access/site-console.mdx
@@ -116,7 +116,7 @@ ist nichts, was man von Hand zusammensetzen sollte.
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/de/customer-edge/index.mdx
+++ b/docs/de/customer-edge/index.mdx
@@ -94,7 +94,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 Für eine Site, die **nicht existiert**, gibt es eine zweite Erklärung noch vor „sie hat sich nie
 registriert“: Sie sind auf den falschen Mandanten ausgerichtet. Diese Bereitstellung liegt in
-`f5-sales-demo` (`https://f5-sales-demo.console.ves.volterra.io`), festgelegt durch
+`f5-sales-demo` (`https://<XC_TENANT>.console.ves.volterra.io`), festgelegt durch
 `var.expected_xc_tenant` — `cd terraform && terraform output -raw xc_tenant` sagt es Ihnen,
 ohne etwas anzufassen. Eine für einen anderen Mandanten ausgestellte Anmeldeinformation gibt ein
 nacktes `401` zurück, was wie ein abgelaufenes Token aussieht.

--- a/docs/en/customer-edge/access/site-console.mdx
+++ b/docs/en/customer-edge/access/site-console.mdx
@@ -101,9 +101,13 @@ something to assemble by hand.
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
+
+   The resource group name ends in the deployer, resolved by
+   `local.deployer`, so yours will differ. It is elided here for the same reason
+   the subscription is.
 
    <Aside type="caution" title="The map is keyed by site, not by VM name">
    `ce_vm_ids` keys are `eastus01`, `eastus02`, `eastus03` — **not** the VM names. A

--- a/docs/en/customer-edge/index.mdx
+++ b/docs/en/customer-edge/index.mdx
@@ -84,9 +84,9 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 `ONLINE` means the debug API will work. Anything else means Site Console or serial console.
 
 A site that **does not exist** has a second explanation before "it never registered": you
-are pointed at the wrong tenant. This deployment lives in `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`), pinned by `var.expected_xc_tenant` —
-`cd terraform && terraform output -raw xc_tenant` says so without touching anything. A
+are pointed at the wrong tenant. The tenant this deployment belongs to is pinned by
+`var.expected_xc_tenant`, and `cd terraform && terraform output -raw xc_tenant` reports it
+without touching anything; its console is `https://<XC_TENANT>.console.ves.volterra.io`. A
 credential minted for another tenant returns a bare `401`, which reads as an expired token.
 </Aside>
 

--- a/docs/es/customer-edge/access/site-console.mdx
+++ b/docs/es/customer-edge/access/site-console.mdx
@@ -112,7 +112,7 @@ convenga componer a mano.
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/es/customer-edge/index.mdx
+++ b/docs/es/customer-edge/index.mdx
@@ -91,7 +91,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 Un sitio que **no existe** tiene una segunda explicación antes de «nunca se registró»: está
 apuntando al tenant equivocado. Este despliegue reside en `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`), fijado por `var.expected_xc_tenant` —
+(`https://<XC_TENANT>.console.ves.volterra.io`), fijado por `var.expected_xc_tenant` —
 `cd terraform && terraform output -raw xc_tenant` lo indica sin modificar nada. Una
 credencial emitida para otro tenant devuelve un `401` sin más, que se interpreta como un token vencido.
 </Aside>

--- a/docs/fr/customer-edge/access/site-console.mdx
+++ b/docs/fr/customer-edge/access/site-console.mdx
@@ -113,7 +113,7 @@ ressource n'est pas quelque chose à assembler à la main.
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/fr/customer-edge/index.mdx
+++ b/docs/fr/customer-edge/index.mdx
@@ -93,7 +93,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 Un site qui **n'existe pas** a une seconde explication avant « il ne s'est jamais enregistré » :
 vous pointez vers le mauvais tenant. Ce déploiement réside dans `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`), fixé par `var.expected_xc_tenant` —
+(`https://<XC_TENANT>.console.ves.volterra.io`), fixé par `var.expected_xc_tenant` —
 `cd terraform && terraform output -raw xc_tenant` vous le confirme sans rien modifier. Une
 identité générée pour un autre tenant renvoie un simple `401`, ce qui ressemble à un jeton expiré.
 </Aside>

--- a/docs/hi/customer-edge/access/site-console.mdx
+++ b/docs/hi/customer-edge/access/site-console.mdx
@@ -110,7 +110,7 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/hi/customer-edge/index.mdx
+++ b/docs/hi/customer-edge/index.mdx
@@ -91,7 +91,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 एक साइट जो **मौजूद नहीं है**, उसके लिए "यह कभी रजिस्टर नहीं हुई" से पहले एक दूसरा स्पष्टीकरण है: आप
 गलत टेनेंट की ओर संकेत कर रहे हैं। यह डिप्लॉयमेंट `f5-sales-demo` में रहता है
-(`https://f5-sales-demo.console.ves.volterra.io`), जिसे `var.expected_xc_tenant` द्वारा पिन किया गया है —
+(`https://<XC_TENANT>.console.ves.volterra.io`), जिसे `var.expected_xc_tenant` द्वारा पिन किया गया है —
 `cd terraform && terraform output -raw xc_tenant` कुछ भी छुए बिना यह बता देता है। किसी अन्य टेनेंट के लिए
 बनाया गया क्रेडेंशियल एक सादा `401` लौटाता है, जो एक समाप्त हो चुके टोकन जैसा पढ़ा जाता है।
 </Aside>

--- a/docs/it/customer-edge/access/site-console.mdx
+++ b/docs/it/customer-edge/access/site-console.mdx
@@ -117,7 +117,7 @@ qualcosa da comporre a mano.
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/it/customer-edge/index.mdx
+++ b/docs/it/customer-edge/index.mdx
@@ -91,7 +91,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 Un sito che **non esiste** ha una seconda spiegazione prima di «non si è mai registrato»:
 si sta puntando al tenant sbagliato. Questa distribuzione risiede in `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`), fissata da `var.expected_xc_tenant` —
+(`https://<XC_TENANT>.console.ves.volterra.io`), fissata da `var.expected_xc_tenant` —
 `cd terraform && terraform output -raw xc_tenant` lo conferma senza modificare nulla. Una
 credenziale emessa per un altro tenant restituisce un semplice `401`, che appare come un token scaduto.
 </Aside>

--- a/docs/ja/customer-edge/access/site-console.mdx
+++ b/docs/ja/customer-edge/access/site-console.mdx
@@ -108,7 +108,7 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/ja/customer-edge/index.mdx
+++ b/docs/ja/customer-edge/index.mdx
@@ -87,7 +87,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 サイトが**存在しない**場合、「一度も登録されていない」より前に検討すべき説明がもう 1 つあります。
 誤ったテナントを指している可能性です。本デプロイメントは `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`) に存在し、`var.expected_xc_tenant` で固定されています。
+(`https://<XC_TENANT>.console.ves.volterra.io`) に存在し、`var.expected_xc_tenant` で固定されています。
 `cd terraform && terraform output -raw xc_tenant` を実行すれば、何も変更せずに確認できます。
 別のテナント向けに発行された資格情報は素の `401` を返すため、トークンの期限切れのように見えます。
 </Aside>

--- a/docs/ko/customer-edge/access/site-console.mdx
+++ b/docs/ko/customer-edge/access/site-console.mdx
@@ -107,7 +107,7 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/ko/customer-edge/index.mdx
+++ b/docs/ko/customer-edge/index.mdx
@@ -89,7 +89,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 **존재하지 않는** 사이트에는 "등록된 적이 없다"보다 먼저 검토할 두 번째 설명이 있습니다.
 잘못된 테넌트를 가리키고 있는 경우입니다. 이 배포는 `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`)에 있으며, `var.expected_xc_tenant`로 고정됩니다 —
+(`https://<XC_TENANT>.console.ves.volterra.io`)에 있으며, `var.expected_xc_tenant`로 고정됩니다 —
 `cd terraform && terraform output -raw xc_tenant`를 실행하면 아무것도 변경하지 않고 확인할 수 있습니다.
 다른 테넌트용으로 발급된 자격 증명은 만료된 토큰처럼 보이는 단순한 `401`을 반환합니다.
 </Aside>

--- a/docs/pt-br/customer-edge/access/site-console.mdx
+++ b/docs/pt-br/customer-edge/access/site-console.mdx
@@ -111,7 +111,7 @@ algo para montar à mão.
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/pt-br/customer-edge/index.mdx
+++ b/docs/pt-br/customer-edge/index.mdx
@@ -90,7 +90,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 Um site que **não existe** tem uma segunda explicação antes de "ele nunca se registrou": você
 está apontando para o tenant errado. Este deployment vive em `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`), fixado por `var.expected_xc_tenant` —
+(`https://<XC_TENANT>.console.ves.volterra.io`), fixado por `var.expected_xc_tenant` —
 `cd terraform && terraform output -raw xc_tenant` informa isso sem tocar em nada. Uma
 credencial emitida para outro tenant retorna um `401` puro, que se parece com um token expirado.
 </Aside>

--- a/docs/th/customer-edge/access/site-console.mdx
+++ b/docs/th/customer-edge/access/site-console.mdx
@@ -109,7 +109,7 @@ Reader ในขั้นตอนที่ 2 เป็นข้อกำหน�
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/th/customer-edge/index.mdx
+++ b/docs/th/customer-edge/index.mdx
@@ -91,7 +91,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 ไซต์ที่ **ไม่มีอยู่** มีคำอธิบายที่สองก่อนจะสรุปว่า "มันไม่เคยลงทะเบียน": คุณ
 ชี้ไปที่เทแนนต์ผิด การดีพลอยนี้อยู่ใน `f5-sales-demo`
-(`https://f5-sales-demo.console.ves.volterra.io`) ซึ่งตรึงไว้ด้วย `var.expected_xc_tenant` —
+(`https://<XC_TENANT>.console.ves.volterra.io`) ซึ่งตรึงไว้ด้วย `var.expected_xc_tenant` —
 `cd terraform && terraform output -raw xc_tenant` จะบอกได้โดยไม่ต้องแตะต้องอะไรเลย
 เครดิเชียลที่สร้างขึ้นสำหรับเทแนนต์อื่นจะคืนค่า `401` เปล่า ๆ ซึ่งอ่านได้เหมือนโทเคนหมดอายุ
 </Aside>

--- a/docs/zh-cn/customer-edge/access/site-console.mdx
+++ b/docs/zh-cn/customer-edge/access/site-console.mdx
@@ -98,7 +98,7 @@ Azure Bastion 弥合了这一差距，且不会在网络上放置任何其他东
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/zh-cn/customer-edge/index.mdx
+++ b/docs/zh-cn/customer-edge/index.mdx
@@ -83,7 +83,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 对于**不存在**的站点，在"它从未注册"之前还有另一种解释：
 你指向了错误的租户。本部署位于 `f5-sales-demo`
-（`https://f5-sales-demo.console.ves.volterra.io`），由 `var.expected_xc_tenant` 固定 ——
+（`https://<XC_TENANT>.console.ves.volterra.io`），由 `var.expected_xc_tenant` 固定 ——
 `cd terraform && terraform output -raw xc_tenant` 可以在不改动任何东西的情况下告诉你答案。
 为其他租户签发的凭据会返回一个裸的 `401`，看起来像是令牌过期。
 </Aside>

--- a/docs/zh-tw/customer-edge/access/site-console.mdx
+++ b/docs/zh-tw/customer-edge/access/site-console.mdx
@@ -100,7 +100,7 @@ Reader 需求是 Microsoft 文件所述的需求，而非在此實際量測所�
 
    ```text
    mcn-ce-ha-bastion
-   rg-mcn-ce-ha-rmordasiewicz
+   rg-mcn-ce-ha-<deployer>
    /subscriptions/…/providers/Microsoft.Compute/virtualMachines/f5-xc-ce-vm-01
    ```
 

--- a/docs/zh-tw/customer-edge/index.mdx
+++ b/docs/zh-tw/customer-edge/index.mdx
@@ -82,7 +82,7 @@ curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
 
 當站台**不存在**時，在「它從未註冊」之前還有另一種解釋：你指向了錯誤的租戶。
 本部署位於 `f5-sales-demo`
-（`https://f5-sales-demo.console.ves.volterra.io`），由 `var.expected_xc_tenant` 鎖定 ——
+（`https://<XC_TENANT>.console.ves.volterra.io`），由 `var.expected_xc_tenant` 鎖定 ——
 執行 `cd terraform && terraform output -raw xc_tenant` 即可確認，且不會變更任何內容。
 為其他租戶簽發的憑證會回傳單純的 `401`，看起來就像權杖過期一樣。
 </Aside>

--- a/tests/test-docs-no-literals.sh
+++ b/tests/test-docs-no-literals.sh
@@ -62,7 +62,26 @@ done
 #
 # The retired names are kept so a stale value cannot come back unnoticed — a copied
 # snippet or a reverted edit reintroducing `wsp-demo-pool` should fail here.
-PATTERNS='mcn-ce-ha-|rmordasiewicz|bankexample|wsp-demo|ce-ha-lab-|ar-ecmp-|ar-bgp-|f5-xc-ce-vm-0[0-9]|10\.0\.[0-9]+\.[0-9]+|10\.250\.0\.10|20\.98\.232\.135|203\.0\.113\.'
+#
+# 203.0.113. is deliberately NOT here. STYLE_GUIDE.md §"Assign ranges by role"
+# tells authors to use TEST-NET-3 for published service addresses, so rejecting it
+# would have the gate and the guide contradict each other.
+PATTERNS='mcn-ce-ha-|rmordasiewicz|bankexample|wsp-demo|ce-ha-lab-|ar-ecmp-|ar-bgp-|f5-xc-ce-vm-0[0-9]|10\.0\.[0-9]+\.[0-9]+|10\.250\.0\.10|20\.98\.232\.135'
+
+# Identity, not deployment values — and the instruction/evidence distinction does
+# not apply to it. A deployment value inside an output fence is evidence: it shows
+# what the system did, and nobody copies it. An account name or a tenant identifier
+# inside an output fence is still an account name and a tenant identifier, published
+# in a public repository. STYLE_GUIDE §"Personally identifiable information" lists
+# user names and party-specific identifiers with no fence-type exemption.
+#
+# This is how `rg-mcn-ce-ha-rmordasiewicz` reached a `text` fence in
+# docs/en/customer-edge/access/site-console.mdx and passed every gate.
+#
+# The tenant is matched by its console host rather than by name: the bare string
+# `f5-sales-demo` is also the npm scope and the GitHub organisation, both of which
+# are legitimate in prose and imports.
+IDENTITY_PATTERNS='rmordasiewicz|[a-z0-9-]+\.console\.ves\.volterra\.io'
 
 scan() {
   # Emits "path:line:text" for every offending line: a match that is NOT inside a
@@ -89,6 +108,16 @@ scan() {
         if ($0 ~ pat) printf "%s:%d:%s\n", file, NR, $0
       }
     ' "$f"
+  done
+}
+
+scan_identity() {
+  # Emits "path:line:text" for every identity match, wherever it appears. No fence
+  # logic on purpose: there is no context in a published page that makes an account
+  # name or a customer's tenant acceptable.
+  local dir="$1"
+  find "$dir" -name '*.mdx' -type f | sort | while IFS= read -r f; do
+    grep -nE "$IDENTITY_PATTERNS" "$f" | sed "s|^|${f}:|"
   done
 }
 
@@ -119,10 +148,24 @@ else
   FAIL=1
 fi
 
+# Scanned across every locale, not just docs/en. Rules 1 and 2 are about what a
+# reader copies and are checked on the English source the translations derive from.
+# Identity is different: a machine translation copies an account name through
+# verbatim, so a single leak in English becomes thirteen published copies.
+echo "3. no account name or tenant identifier anywhere on a page, in any locale"
+IDENTITY_HITS=$(scan_identity "${ROOT}/docs" || true)
+if [ -z "$IDENTITY_HITS" ]; then
+  echo "  ok   — no page names a person or a tenant"
+else
+  echo "  FAIL — these identify a person or a customer; use a placeholder or an output:"
+  printf '%s\n' "$IDENTITY_HITS" | sed 's/^/         /'
+  FAIL=1
+fi
+
 # A checker that cannot fail is worse than no checker, because it reads as a passing
 # gate. Plant one violation of each kind and require both to be caught.
 if [ "$SELFTEST" -eq 1 ]; then
-  echo "3. the check itself catches a planted violation"
+  echo "4. the check itself catches a planted violation"
   WORK=$(mktemp -d)
   trap 'rm -rf "$WORK"' EXIT
   mkdir -p "${WORK}/docs/en"
@@ -136,6 +179,23 @@ if [ "$SELFTEST" -eq 1 ]; then
   printf '%s\n' \
     '---' 'title: t' '---' '' 'Observed 2026-07-28:' '' '```text' 'site ar-bgp-eastus01 -> ONLINE' '```' \
     >"${WORK}/docs/en/output.mdx"
+  # A person's account name is PII wherever it appears. The output/instruction
+  # distinction is right for deployment values and wrong for identity: a reader
+  # is not going to copy this, but it is still published either way. This is the
+  # exact shape that reached docs/en/customer-edge/access/site-console.mdx:104.
+  printf '%s\n' \
+    '---' 'title: t' '---' '' 'Observed 2026-07-28:' '' '```text' 'rg-mcn-ce-ha-rmordasiewicz' '```' \
+    >"${WORK}/docs/en/identity-in-output.mdx"
+  # The tenant's own console host names the customer. STYLE_GUIDE requires a
+  # placeholder for a tenant identifier.
+  printf '%s\n' \
+    '---' 'title: t' '---' '' 'Observed 2026-07-28:' '' '```text' 'https://example-corp.console.ves.volterra.io' '```' \
+    >"${WORK}/docs/en/tenant-in-output.mdx"
+  # TEST-NET-3 is what STYLE_GUIDE tells authors to use for a published service
+  # address, so the gate must not reject it.
+  printf '%s\n' \
+    '---' 'title: t' '---' '' '```bash' 'curl http://203.0.113.10/' '```' \
+    >"${WORK}/docs/en/reserved.mdx"
 
   PLANTED=$(scan "${WORK}/docs/en" || true)
   if printf '%s' "$PLANTED" | grep -q 'prose.mdx'; then
@@ -155,6 +215,32 @@ if [ "$SELFTEST" -eq 1 ]; then
     FAIL=1
   else
     echo "  ok   — left captured output alone"
+  fi
+  if printf '%s' "$PLANTED" | grep -q 'reserved.mdx'; then
+    echo "  FAIL — rejected a reserved documentation address; STYLE_GUIDE requires TEST-NET-3 here"
+    FAIL=1
+  else
+    echo "  ok   — allowed a reserved documentation address in a command"
+  fi
+
+  IDENTITY=$(scan_identity "${WORK}/docs/en" || true)
+  if printf '%s' "$IDENTITY" | grep -q 'identity-in-output.mdx'; then
+    echo "  ok   — caught an account name inside captured output"
+  else
+    echo "  FAIL — missed an account name inside captured output; PII is not evidence"
+    FAIL=1
+  fi
+  if printf '%s' "$IDENTITY" | grep -q 'tenant-in-output.mdx'; then
+    echo "  ok   — caught a tenant console host inside captured output"
+  else
+    echo "  FAIL — missed a tenant console host; a tenant identifier names a customer"
+    FAIL=1
+  fi
+  if printf '%s' "$IDENTITY" | grep -q '/output\.mdx:'; then
+    echo "  FAIL — identity scan flagged an ordinary deployment value"
+    FAIL=1
+  else
+    echo "  ok   — identity scan left ordinary deployment values to rule 1"
   fi
 fi
 


### PR DESCRIPTION
Closes #766

## Why

**The gate rejected the range STYLE_GUIDE mandates.** `tests/test-docs-no-literals.sh:65`
denylisted `203\.0\.113\.`, which §"Assign ranges by role" tells authors to use for
published service addresses. Symptom: TEST-NET-3 appears **zero times** in `docs/en`.

**Identity was judged by fence type.** The gate's instruction-versus-evidence distinction is
right for deployment values and wrong for identity. A resource group name in an output fence
is evidence. A person's account name in an output fence is still an account name, published
in a public repository — and nobody copies either one.

That is exactly how these survived every gate:

| Location | Leak |
|---|---|
| `access/site-console.mdx:104` | a real engineer's account name in a `text` fence |
| `customer-edge/index.mdx:88` | the tenant's console URL |
| **24 locale files** | both strings, copied verbatim by machine translation |

The gate only ever scanned `docs/en`, so one leak in English was thirteen published copies.

## What changed

- `203\.0\.113\.` removed from the denylist.
- New identity class, matched **anywhere on a page with no fence exemption**, and scanned
  across **every locale**. The tenant is matched by its console host rather than its bare
  name — `f5-sales-demo` is also the npm scope and the GitHub organisation and is legitimate
  in imports and issue links.
- The two English violations and all 24 locale copies fixed. `<deployer>` and `<XC_TENANT>`
  replace them, consistent with the subscription already elided two lines below.

## Verification

```text
1. no deployment-specific literal inside a command          ok
2. every page carrying such a literal dates it              ok
3. no account name or tenant identifier, in any locale      ok
4. the check itself catches a planted violation
     caught a literal in an ssh command                     ok
     caught a literal in a bash fence                       ok
     left captured output alone                             ok
     allowed a reserved documentation address in a command  ok
     caught an account name inside captured output          ok
     caught a tenant console host inside captured output    ok
     identity scan left ordinary deployment values to rule 1 ok
```

Each of the four new self-test cases was written first and observed failing before its fix.
`grep -rE 'rmordasiewicz|[a-z0-9-]+\.console\.ves\.volterra\.io' docs` returns **0**.

Unaffected gates re-run: `test-translation-parity.sh` passes (540 files across 12 locales, 0
missing), `test-mdx-attribute-quotes.sh` passes, `check-sitecli-docs.sh` still consistent at
build `crt-20250613-3382` / 34 commands. `shellcheck` and `shfmt -d` clean.

## Deliberately not in scope

Rule 2 still inspects `.mdx` text only, so the **14 pages** embedding captured output via
`file=…/_data/sitecli-*.txt` render undated evidence and go undetected. Enforcing it now
would require inventing capture dates — `sitecli/capture-manifest.json` records none — and
fabricating an evidence date is precisely the defect the dating rule exists to prevent. It
lands with the re-capture after the next rebuild, when the dates are real.