### PR TITLE
fix(docs): put README heading first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Multi-Cloud Networking
+
 🌐 English |
 [日本語](https://f5-sales-demo.github.io/mcn/ja/) |
 [한국어](https://f5-sales-demo.github.io/mcn/ko/) |
@@ -11,8 +13,6 @@
 [العربية](https://f5-sales-demo.github.io/mcn/ar/) |
 [हिन्दी](https://f5-sales-demo.github.io/mcn/hi/) |
 [ไทย](https://f5-sales-demo.github.io/mcn/th/)
-
-# Multi-Cloud Networking
 
 [![GitHub Pages Deploy](https://github.com/f5-sales-demo/mcn/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5-sales-demo/mcn/actions/workflows/github-pages-deploy.yml)
 [![Repository Settings](https://github.com/f5-sales-demo/mcn/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/mcn/actions/workflows/enforce-repo-settings.yml)


### PR DESCRIPTION
## Summary

Move the existing README H1 ahead of the locale selector so full-tree Markdown lint satisfies MD041 without disabling or excluding the rule.

## Related issue

Closes #789

## Verification

- `npx --yes markdownlint-cli@0.49.1 README.md` — pass.
- `git diff --check` — pass.
- Full-tree Markdown lint exposed only five stale managed-file findings; their authoritative docs-control fixes are already merged and the governed rollout is active.

## Checklist

- [x] Linked to a GitHub issue
- [x] Focused source fix
- [x] No lint rule disabled or excluded
- [x] Verified locally