### PR TITLE
fix(terraform): require explicit ce_sw_version and ce_os_version (#726)

### DIFF
--- a/docs/_includes/terraform/variables_ce.tf
+++ b/docs/_includes/terraform/variables_ce.tf
@@ -63,13 +63,21 @@ variable "registration_token" {
 }
 
 variable "ce_os_version" {
-  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). EMPTY IS NOT NEUTRAL: at create the server fills an empty field with the newest ADVERTISED version and installs it, so an empty value makes the result depend on the date rather than on this configuration — pin it deliberately (#714). Terraform cannot change it afterwards: the update is rejected 400 in every direction, including un-pinning. The platform CAN change it in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_os, so a version change is not a rebuild — but the provider cannot drive that yet (xcsh#1390), and using it leaves this value disagreeing with the live site."
+  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). EMPTY IS NOT NEUTRAL: at create the server fills an empty field with the newest ADVERTISED version and installs it, so an empty value makes the result depend on the date rather than on this configuration — pin it deliberately (#714, #726). Terraform cannot change it afterwards: the update is rejected 400 in every direction, including un-pinning. The platform CAN change it in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_os, so a version change is not a rebuild — but the provider cannot drive that yet (xcsh#1390), and using it leaves this value disagreeing with the live site."
   type        = string
-  default     = ""
+
+  validation {
+    condition     = var.ce_os_version != ""
+    error_message = "ce_os_version cannot be empty. Empty is not neutral: at create time F5 XC fills an empty field with the newest advertised version, making installed versions depend on the date of apply rather than on this configuration. Pin a version explicitly (e.g. ce_os_version = \"9.2024.6\")."
+  }
 }
 
 variable "ce_sw_version" {
-  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node installs this on first boot; it chooses the destination, not whether an install happens. Do not assume the image ships something older — image 0.9.2 ships a NEWER build than this fleet pins, and a backwards pin is routine (#714). EMPTY IS NOT NEUTRAL: the server fills an empty field with the newest ADVERTISED version and installs it, which on the image default disk is the combination measured to FAIL — pin it deliberately, and see modules/ce-node for the disk. Terraform cannot change it afterwards (update rejected 400 in every direction), but the platform can in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (xcsh#1390)."
+  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node installs this on first boot; it chooses the destination, not whether an install happens. Do not assume the image ships something older — image 0.9.2 ships a NEWER build than this fleet pins, and a backwards pin is routine (#714, #726). EMPTY IS NOT NEUTRAL: the server fills an empty field with the newest ADVERTISED version and installs it, which on the image default disk is the combination measured to FAIL — pin it deliberately, and see modules/ce-node for the disk. Terraform cannot change it afterwards (update rejected 400 in every direction), but the platform can in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (xcsh#1390)."
   type        = string
-  default     = ""
+
+  validation {
+    condition     = var.ce_sw_version != ""
+    error_message = "ce_sw_version cannot be empty. Empty is not neutral: at create time F5 XC fills an empty field with the newest advertised version, making installed versions depend on the date of apply rather than on this configuration. Pin a version explicitly (e.g. ce_sw_version = \"crt-20250613-3382\")."
+  }
 }

--- a/terraform/tests/ce_versions.tftest.hcl
+++ b/terraform/tests/ce_versions.tftest.hcl
@@ -1,0 +1,44 @@
+# Plan-level test asserting that ce_os_version and ce_sw_version reject empty strings.
+# Empty is not neutral: at create time F5 XC fills an empty field with the newest advertised
+# version, making installed versions depend on the date of apply (#726).
+
+mock_provider "azurerm" {}
+mock_provider "azuread" {}
+mock_provider "xcsh" {}
+
+variables {
+  site_prefix         = null
+  lb_name             = null
+  origin_pool_name    = null
+  route_server_name   = null
+  bastion_name        = null
+  client_vm_name      = null
+  region_short        = null
+  resource_group_name = null
+  deployer            = "tester"
+  lb_domain           = "mcn-ce-ha.f5-sales-demo.com"
+  origin_ip           = "203.0.113.10"
+  ssh_public_key      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+  ce_os_version       = "9.2024.6"
+  ce_sw_version       = "crt-20250613-3382"
+}
+
+run "empty_ce_os_version_is_rejected" {
+  command = plan
+
+  variables {
+    ce_os_version = ""
+  }
+
+  expect_failures = [var.ce_os_version]
+}
+
+run "empty_ce_sw_version_is_rejected" {
+  command = plan
+
+  variables {
+    ce_sw_version = ""
+  }
+
+  expect_failures = [var.ce_sw_version]
+}

--- a/terraform/variables_ce.tf
+++ b/terraform/variables_ce.tf
@@ -63,13 +63,21 @@ variable "registration_token" {
 }
 
 variable "ce_os_version" {
-  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). EMPTY IS NOT NEUTRAL: at create the server fills an empty field with the newest ADVERTISED version and installs it, so an empty value makes the result depend on the date rather than on this configuration — pin it deliberately (#714). Terraform cannot change it afterwards: the update is rejected 400 in every direction, including un-pinning. The platform CAN change it in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_os, so a version change is not a rebuild — but the provider cannot drive that yet (xcsh#1390), and using it leaves this value disagreeing with the live site."
+  description = "CE OS version, set at CREATE time (e.g. 9.2026.14). EMPTY IS NOT NEUTRAL: at create the server fills an empty field with the newest ADVERTISED version and installs it, so an empty value makes the result depend on the date rather than on this configuration — pin it deliberately (#714, #726). Terraform cannot change it afterwards: the update is rejected 400 in every direction, including un-pinning. The platform CAN change it in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_os, so a version change is not a rebuild — but the provider cannot drive that yet (xcsh#1390), and using it leaves this value disagreeing with the live site."
   type        = string
-  default     = ""
+
+  validation {
+    condition     = var.ce_os_version != ""
+    error_message = "ce_os_version cannot be empty. Empty is not neutral: at create time F5 XC fills an empty field with the newest advertised version, making installed versions depend on the date of apply rather than on this configuration. Pin a version explicitly (e.g. ce_os_version = \"9.2024.6\")."
+  }
 }
 
 variable "ce_sw_version" {
-  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node installs this on first boot; it chooses the destination, not whether an install happens. Do not assume the image ships something older — image 0.9.2 ships a NEWER build than this fleet pins, and a backwards pin is routine (#714). EMPTY IS NOT NEUTRAL: the server fills an empty field with the newest ADVERTISED version and installs it, which on the image default disk is the combination measured to FAIL — pin it deliberately, and see modules/ce-node for the disk. Terraform cannot change it afterwards (update rejected 400 in every direction), but the platform can in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (xcsh#1390)."
+  description = "CE F5XC software version, set at CREATE time (e.g. crt-20260201-0179). The node installs this on first boot; it chooses the destination, not whether an install happens. Do not assume the image ships something older — image 0.9.2 ships a NEWER build than this fleet pins, and a backwards pin is routine (#714, #726). EMPTY IS NOT NEUTRAL: the server fills an empty field with the newest ADVERTISED version and installs it, which on the image default disk is the combination measured to FAIL — pin it deliberately, and see modules/ce-node for the disk. Terraform cannot change it afterwards (update rejected 400 in every direction), but the platform can in place via POST /api/config/namespaces/{ns}/sites/{name}/upgrade_sw (xcsh#1390)."
   type        = string
-  default     = ""
+
+  validation {
+    condition     = var.ce_sw_version != ""
+    error_message = "ce_sw_version cannot be empty. Empty is not neutral: at create time F5 XC fills an empty field with the newest advertised version, making installed versions depend on the date of apply rather than on this configuration. Pin a version explicitly (e.g. ce_sw_version = \"crt-20250613-3382\")."
+  }
 }


### PR DESCRIPTION
Removes `default = ""` from `ce_os_version` and `ce_sw_version` in `terraform/variables_ce.tf` and adds validation blocks rejecting empty strings. Adds plan-level tests in `terraform/tests/ce_versions.tftest.hcl` and re-syncs `docs/_includes/terraform/`.

Closes #726