### PR TITLE
feat(terraform): support Canada-only regional network path with virtual sites and CEs

### DIFF
--- a/docs/_includes/terraform/locals.tf
+++ b/docs/_includes/terraform/locals.tf
@@ -60,6 +60,18 @@ locals {
   # `-f5se` matches the convention this tenant's other load balancers already use.
   lb_name = coalesce(var.lb_name, "${var.component}-f5se")
 
+  # --- Derived Canada object names ---
+  ca_region_short        = coalesce(var.ca_region_short, var.ca_location)
+  ca_site_prefix         = coalesce(var.ca_site_prefix, "${var.component}-ca")
+  ca_resource_group_name = coalesce(var.ca_resource_group_name, "rg-${var.component}-ca-${local.deployer}")
+  ca_route_server_name   = coalesce(var.ca_route_server_name, "${var.component}-ca-rs")
+  ca_bastion_name        = coalesce(var.ca_bastion_name, "${var.component}-ca-bastion")
+  ca_client_vm_name      = coalesce(var.ca_client_vm_name, "${var.component}-ca-client")
+  ca_origin_pool_name    = coalesce(var.ca_origin_pool_name, "${var.component}-ca-pool")
+  ca_lb_name             = coalesce(var.ca_lb_name, "${var.component}-ca-f5se")
+  ca_re_vsite_name       = coalesce(var.ca_re_vsite_name, "${var.component}-ca-re-vsite")
+  ca_ce_vsite_name       = coalesce(var.ca_ce_vsite_name, "${var.component}-ca-ce-vsite")
+
   # --- Standard tags (applied to every Azure resource) ---
   standard_tags = {
     component   = var.component
@@ -92,6 +104,15 @@ locals {
       token        = local.ce_registration_token
       # chomp: a key read from a .pub file ends in a newline, which would render a
       # second, empty line into authorized_keys under `content: |`.
+      ssh_public_key = chomp(local.ssh_public_key)
+    })
+  }
+
+  # --- Canada CE cloud-init, rendered once per node ---
+  ca_ce_cloud_init = {
+    for key, node in try(module.ce_topology_ca[0].ce_nodes, {}) : key => templatefile("${path.module}/cloud-init/ce-node.yaml", {
+      cluster_name   = node.site_name
+      token          = local.ce_registration_token
       ssh_public_key = chomp(local.ssh_public_key)
     })
   }

--- a/docs/_includes/terraform/main.tf
+++ b/docs/_includes/terraform/main.tf
@@ -64,6 +64,13 @@ check "vip_outside_vnet_cidrs" {
   }
 }
 
+check "ca_vip_outside_vnet_cidrs" {
+  assert {
+    condition     = !var.enable_canada || cidrhost(var.ca_hub_cidr, 0) != cidrhost("${var.ca_vip}/${split("/", var.ca_hub_cidr)[1]}", 0)
+    error_message = "ca_vip ${var.ca_vip} must be OUTSIDE ca_hub_cidr ${var.ca_hub_cidr}."
+  }
+}
+
 # Tenant-scoped, reusable site registration token. The provider now ships
 # xcsh_token with a Computed `uid` (system_metadata.uid) — the token VALUE a CE
 # feeds to VPM at registration (the resource `id` is the token NAME, not the
@@ -322,6 +329,258 @@ resource "xcsh_http_loadbalancer" "this" {
     pool {
       namespace = data.xcsh_namespace.mcn.name
       name      = xcsh_origin_pool.this.name
+    }
+    weight   = 1
+    priority = 1
+  }
+
+  round_robin {}
+  no_challenge {}
+  user_id_client_ip {}
+  disable_waf {}
+  disable_rate_limit {}
+  disable_api_discovery {}
+  disable_api_testing {}
+  disable_api_definition {}
+  l7_ddos_protection {}
+  service_policies_from_namespace {}
+  disable_trust_client_ip_headers {}
+  disable_malicious_user_detection {}
+  disable_malware_protection {}
+  disable_threat_mesh {}
+  default_sensitive_data_policy {}
+}
+
+# ---------------------------------------------------------
+# Canada Regional Infrastructure & F5 XC Data-Plane (Canada Path)
+# ---------------------------------------------------------
+
+# Pure expansion of ca_ce_count into the per-CE node map for Canada.
+module "ce_topology_ca" {
+  count  = var.enable_canada ? 1 : 0
+  source = "./modules/ce-topology"
+
+  ce_count           = var.ca_ce_count
+  region_short       = local.ca_region_short
+  mgmt_subnet_prefix = var.ca_mgmt_subnet_prefix
+  site_prefix        = local.ca_site_prefix
+}
+
+# Canada Hub: RG, VNet, four subnets, Azure Route Server.
+module "azure_hub_ca" {
+  count  = var.enable_canada ? 1 : 0
+  source = "./modules/azure-hub"
+
+  resource_group_name        = local.ca_resource_group_name
+  location                   = var.ca_location
+  hub_cidr                   = var.ca_hub_cidr
+  mgmt_subnet_prefix         = var.ca_mgmt_subnet_prefix
+  external_subnet_prefix     = var.ca_external_subnet_prefix
+  internal_subnet_prefix     = var.ca_internal_subnet_prefix
+  route_server_subnet_prefix = var.ca_route_server_subnet_prefix
+  route_server_name          = local.ca_route_server_name
+  bastion_subnet_prefix      = var.ca_bastion_subnet_prefix
+  enable_bastion             = var.enable_bastion
+  bastion_name               = local.ca_bastion_name
+  tags                       = local.tags
+}
+
+# One Canadian CE VM (3 NICs + identity) per node.
+module "ce_node_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+  source   = "./modules/ce-node"
+
+  hostname            = each.value.hostname
+  resource_group_name = try(module.azure_hub_ca[0].resource_group_name, null)
+  location            = try(module.azure_hub_ca[0].location, null)
+  zone                = each.value.az
+  vm_size             = var.ce_vm_size
+  mgmt_subnet_id      = try(module.azure_hub_ca[0].management_subnet_id, null)
+  external_subnet_id  = try(module.azure_hub_ca[0].external_subnet_id, null)
+  internal_subnet_id  = try(module.azure_hub_ca[0].internal_subnet_id, null)
+  mgmt_private_ip     = each.value.slo_ip
+  admin_username      = var.admin_username
+  ssh_public_key      = local.ssh_public_key
+
+  custom_data = base64encode(local.ca_ce_cloud_init[each.key])
+
+  tags = local.tags
+}
+
+resource "random_password" "site_console_admin_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+
+  length           = 32
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "!#%*+-=?@^_~"
+
+  keepers = {
+    ce_vm_instance_id = module.ce_node_ca[each.key].vm_instance_id
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "site_console_password_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+
+  name                       = "site-console-admin-password"
+  virtual_machine_id         = module.ce_node_ca[each.key].vm_id
+  publisher                  = "Microsoft.Azure.Extensions"
+  type                       = "CustomScript"
+  type_handler_version       = "2.1"
+  auto_upgrade_minor_version = true
+
+  protected_settings = jsonencode({
+    script = base64encode(<<-SCRIPT
+      #!/usr/bin/env bash
+      set -euo pipefail
+      password_b64='${base64encode(random_password.site_console_admin_ca[each.key].result)}'
+      password=$(printf '%s' "$password_b64" | base64 --decode)
+      printf 'admin:%s\n' "$password" | chpasswd
+      unset password password_b64
+    SCRIPT
+    )
+  })
+}
+
+# Canadian XC SMSv2 site + BGP object per node.
+module "xc_site_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+  source   = "./modules/xc-site"
+
+  site_name            = each.value.site_name
+  hostname             = each.value.hostname
+  interface_name       = each.value.interface_name
+  mgmt_nic_mac         = module.ce_node_ca[each.key].mgmt_nic_mac
+  ce_vm_instance_id    = module.ce_node_ca[each.key].vm_instance_id
+  rs_peer_ips          = try(module.azure_hub_ca[0].rs_peer_ips, [])
+  ce_asn               = var.ce_asn
+  rs_asn               = var.rs_asn
+  os_version           = var.ce_os_version
+  sw_version           = var.ce_sw_version
+  enable_bgp           = var.enable_bgp
+  approve_registration = var.approve_registration
+}
+
+# Azure Route Server eBGP session for Canadian CEs.
+module "azure_route_server_bgp_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+  source   = "./modules/azure-route-server-bgp"
+
+  name            = "${each.key}-bgp"
+  route_server_id = try(module.azure_hub_ca[0].route_server_id, null)
+  peer_asn        = var.ce_asn
+  peer_ip         = module.ce_node_ca[each.key].mgmt_private_ip
+}
+
+module "client_vm_ca" {
+  count  = var.enable_canada ? 1 : 0
+  source = "./modules/client-vm"
+
+  name                = local.ca_client_vm_name
+  resource_group_name = try(module.azure_hub_ca[0].resource_group_name, null)
+  location            = try(module.azure_hub_ca[0].location, null)
+  subnet_id           = try(module.azure_hub_ca[0].internal_subnet_id, null)
+  admin_username      = var.admin_username
+  ssh_public_key      = local.ssh_public_key
+  tags                = local.tags
+}
+
+# ---------------------------------------------------------
+# F5 XC Virtual Sites (Canada RE & Canada CE)
+# ---------------------------------------------------------
+
+resource "xcsh_virtual_site" "canada_re" {
+  count     = var.enable_canada ? 1 : 0
+  name      = local.ca_re_vsite_name
+  namespace = data.xcsh_namespace.mcn.name
+
+  site_type = "REGIONAL_EDGE"
+  site_selector {
+    expressions = ["ves.io/city in (${join(", ", var.ca_re_cities)})"]
+  }
+}
+
+resource "xcsh_virtual_site" "canada_ce" {
+  count     = var.enable_canada ? 1 : 0
+  name      = local.ca_ce_vsite_name
+  namespace = data.xcsh_namespace.mcn.name
+
+  site_type = "CUSTOMER_EDGE"
+  site_selector {
+    expressions = ["ves.io/siteName in (${join(", ", [for k, v in try(module.ce_topology_ca[0].ce_nodes, {}) : v.site_name])})"]
+  }
+}
+
+resource "xcsh_origin_pool" "canada" {
+  count       = var.enable_canada ? 1 : 0
+  name        = local.ca_origin_pool_name
+  namespace   = data.xcsh_namespace.mcn.name
+  description = "Canada reference origin pool -> ${var.origin_ip}:${var.origin_port}"
+
+  port = var.origin_port
+
+  origin_servers {
+    labels {}
+    public_ip {
+      ip = var.origin_ip
+    }
+  }
+
+  no_tls {}
+  loadbalancer_algorithm = "ROUND_ROBIN"
+  endpoint_selection     = "DISTRIBUTED"
+}
+
+resource "xcsh_http_loadbalancer" "canada" {
+  count      = var.enable_canada ? 1 : 0
+  depends_on = [module.xc_site_ca, xcsh_virtual_site.canada_re, xcsh_virtual_site.canada_ce]
+
+  name        = local.ca_lb_name
+  namespace   = data.xcsh_namespace.mcn.name
+  description = "Canada Regional HA: custom VIP ${var.ca_vip} advertised strictly via Canadian Regional Edges (Toronto and Montreal) and Canadian CEs."
+
+  domains = [var.ca_lb_domain]
+
+  http {
+    port                 = 80
+    dns_volterra_managed = false
+  }
+
+  advertise_custom {
+    advertise_where {
+      virtual_site {
+        network = "SITE_NETWORK_OUTSIDE"
+        virtual_site {
+          namespace = data.xcsh_namespace.mcn.name
+          name      = try(xcsh_virtual_site.canada_re[0].name, null)
+        }
+      }
+      use_default_port {}
+    }
+
+    dynamic "advertise_where" {
+      for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+      content {
+        site {
+          network = "SITE_NETWORK_OUTSIDE"
+          site {
+            namespace = "system"
+            name      = advertise_where.value.site_name
+          }
+          ip = var.ca_vip
+        }
+        use_default_port {}
+      }
+    }
+  }
+
+  default_route_pools {
+    pool {
+      namespace = data.xcsh_namespace.mcn.name
+      name      = try(xcsh_origin_pool.canada[0].name, null)
     }
     weight   = 1
     priority = 1

--- a/docs/_includes/terraform/outputs.tf
+++ b/docs/_includes/terraform/outputs.tf
@@ -161,6 +161,40 @@ output "vip" {
 }
 
 # ---------------------------------------------------------
+# Canada Regional outputs
+# ---------------------------------------------------------
+
+output "ca_lb_domain" {
+  description = "Domain served by the Canada HTTP load balancer."
+  value       = var.ca_lb_domain
+}
+
+output "ca_re_virtual_site_name" {
+  description = "Name of the Canadian Regional Edge virtual site."
+  value       = try(xcsh_virtual_site.canada_re[0].name, null)
+}
+
+output "ca_ce_virtual_site_name" {
+  description = "Name of the Canadian Customer Edge virtual site."
+  value       = try(xcsh_virtual_site.canada_ce[0].name, null)
+}
+
+output "ca_loadbalancer_name" {
+  description = "Name of the Canadian HTTP load balancer."
+  value       = try(xcsh_http_loadbalancer.canada[0].name, null)
+}
+
+output "ca_origin_pool_name" {
+  description = "Name of the Canadian origin pool."
+  value       = try(xcsh_origin_pool.canada[0].name, null)
+}
+
+output "ca_vip" {
+  description = "HA VIP for Canadian CEs advertised via eBGP/ECMP."
+  value       = var.ca_vip
+}
+
+# ---------------------------------------------------------
 # CE registration token
 # ---------------------------------------------------------
 

--- a/docs/_includes/terraform/variables_azure.tf
+++ b/docs/_includes/terraform/variables_azure.tf
@@ -22,6 +22,103 @@ variable "location" {
 }
 
 # ---------------------------------------------------------
+# Canada regional Azure placement & CIDRs
+# ---------------------------------------------------------
+
+variable "ca_location" {
+  description = "Azure region for Canadian regional resources."
+  type        = string
+  default     = "canadacentral"
+}
+
+variable "ca_resource_group_name" {
+  description = "Resource group that holds the Canadian hub VNet, Route Server, CE VMs and test client. Leave null (the default) to derive `rg-<component>-ca-<deployer>`."
+  type        = string
+  default     = null
+}
+
+variable "ca_hub_cidr" {
+  description = "Canada Hub VNet address space."
+  type        = string
+  default     = "10.200.0.0/16"
+}
+
+variable "ca_mgmt_subnet_prefix" {
+  description = "Canada snet-hub-management prefix. CE eth0/SLO NICs live here."
+  type        = string
+  default     = "10.200.1.0/26"
+}
+
+variable "ca_external_subnet_prefix" {
+  description = "Canada snet-hub-external prefix."
+  type        = string
+  default     = "10.200.2.0/26"
+}
+
+variable "ca_internal_subnet_prefix" {
+  description = "Canada snet-hub-internal prefix. Test client lives here."
+  type        = string
+  default     = "10.200.3.0/26"
+}
+
+variable "ca_route_server_subnet_prefix" {
+  description = "Canada RouteServerSubnet prefix. MUST be exactly /27."
+  type        = string
+  default     = "10.200.4.0/27"
+
+  validation {
+    condition     = tonumber(split("/", var.ca_route_server_subnet_prefix)[1]) == 27
+    error_message = "ca_route_server_subnet_prefix must be a /27."
+  }
+}
+
+variable "ca_bastion_subnet_prefix" {
+  description = "Canada AzureBastionSubnet prefix. MUST be /26 or larger."
+  type        = string
+  default     = "10.200.5.0/26"
+
+  validation {
+    condition     = tonumber(split("/", var.ca_bastion_subnet_prefix)[1]) <= 26
+    error_message = "ca_bastion_subnet_prefix must be /26 or larger."
+  }
+}
+
+variable "ca_vip" {
+  description = "HA VIP for Canadian CEs advertised as a /32 via eBGP."
+  type        = string
+  default     = "10.250.1.10"
+
+  validation {
+    condition     = can(cidrhost("${var.ca_vip}/32", 0))
+    error_message = "ca_vip must be a valid IPv4 address."
+  }
+}
+
+variable "ca_route_server_name" {
+  description = "Canada Azure Route Server name. Leave null to derive `<component>-ca-rs`."
+  type        = string
+  default     = null
+}
+
+variable "ca_bastion_name" {
+  description = "Canada Azure Bastion host name. Leave null to derive `<component>-ca-bastion`."
+  type        = string
+  default     = null
+}
+
+variable "ca_client_vm_name" {
+  description = "Canada test client VM name. Leave null to derive `<component>-ca-client`."
+  type        = string
+  default     = null
+}
+
+variable "ca_region_short" {
+  description = "Short region token for Canada site names. Leave null to use var.ca_location."
+  type        = string
+  default     = null
+}
+
+# ---------------------------------------------------------
 # Network CIDRs
 # ---------------------------------------------------------
 

--- a/docs/_includes/terraform/variables_ce.tf
+++ b/docs/_includes/terraform/variables_ce.tf
@@ -13,6 +13,27 @@ variable "ce_count" {
   }
 }
 
+# ---------------------------------------------------------
+# Canada CE topology / scaling
+# ---------------------------------------------------------
+
+variable "ca_ce_count" {
+  description = "Number of Canadian single-node Secure Mesh v2 CE sites (1..3)."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.ca_ce_count >= 1 && var.ca_ce_count <= 3
+    error_message = "ca_ce_count must be between 1 and 3."
+  }
+}
+
+variable "ca_site_prefix" {
+  description = "Prefix for Canadian XC site names (site = <ca_site_prefix>-<ca_region_short>0<n>). Leave null to derive `<component>-ca`."
+  type        = string
+  default     = null
+}
+
 variable "region_short" {
   description = "Short region token used to build the per-CE key and site name (component `mcn-ce-ha` + region `eastus` -> site `mcn-ce-ha-eastus01`). Leave null (the default) to use var.location verbatim; set it only when the Azure region name is longer than you want inside object names."
   type        = string

--- a/docs/_includes/terraform/variables_xc.tf
+++ b/docs/_includes/terraform/variables_xc.tf
@@ -58,13 +58,64 @@ variable "lb_name" {
 }
 
 variable "lb_domain" {
-  description = "Domain served by the HTTP load balancer. REQUIRED, deliberately without a default: the load balancer matches on Host, so this value is what every request must send, and it belongs to whoever runs the deployment."
+  description = "Domain served by the HTTP load balancer for Rest of World. REQUIRED, deliberately without a default: the load balancer matches on Host, so this value is what every request must send, and it belongs to whoever runs the deployment."
   type        = string
 
   validation {
     condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.lb_domain))
     error_message = "lb_domain must be a fully-qualified lowercase domain name (for example mcn-ce-ha.f5-sales-demo.com)."
   }
+}
+
+# ---------------------------------------------------------
+# Canada Regional F5 XC inputs
+# ---------------------------------------------------------
+
+variable "enable_canada" {
+  description = "Enable parallel Canada-only regional infrastructure, Canadian virtual sites, and f5-sales-demo.ca load balancer."
+  type        = bool
+  default     = true
+}
+
+variable "ca_lb_domain" {
+  description = "Domain served by the Canada HTTP load balancer. Defaults to mcn-ce-ha.f5-sales-demo.ca."
+  type        = string
+  default     = "mcn-ce-ha.f5-sales-demo.ca"
+
+  validation {
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.ca_lb_domain))
+    error_message = "ca_lb_domain must be a fully-qualified lowercase domain name (for example mcn-ce-ha.f5-sales-demo.ca)."
+  }
+}
+
+variable "ca_re_cities" {
+  description = "List of cities for the Canadian Regional Edge Virtual Site selector. Defaults to Toronto and Montreal."
+  type        = list(string)
+  default     = ["toronto", "montreal"]
+}
+
+variable "ca_lb_name" {
+  description = "Name of the Canada HTTP load balancer. Leave null (the default) to derive `<component>-ca-f5se`."
+  type        = string
+  default     = null
+}
+
+variable "ca_origin_pool_name" {
+  description = "Name of the Canada origin pool. Leave null (the default) to derive `<component>-ca-pool`."
+  type        = string
+  default     = null
+}
+
+variable "ca_re_vsite_name" {
+  description = "Name of the Canadian Regional Edge virtual site. Leave null (the default) to derive `<component>-ca-re-vsite`."
+  type        = string
+  default     = null
+}
+
+variable "ca_ce_vsite_name" {
+  description = "Name of the Canadian Customer Edge virtual site. Leave null (the default) to derive `<component>-ca-ce-vsite`."
+  type        = string
+  default     = null
 }
 
 variable "vip" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -60,6 +60,18 @@ locals {
   # `-f5se` matches the convention this tenant's other load balancers already use.
   lb_name = coalesce(var.lb_name, "${var.component}-f5se")
 
+  # --- Derived Canada object names ---
+  ca_region_short        = coalesce(var.ca_region_short, var.ca_location)
+  ca_site_prefix         = coalesce(var.ca_site_prefix, "${var.component}-ca")
+  ca_resource_group_name = coalesce(var.ca_resource_group_name, "rg-${var.component}-ca-${local.deployer}")
+  ca_route_server_name   = coalesce(var.ca_route_server_name, "${var.component}-ca-rs")
+  ca_bastion_name        = coalesce(var.ca_bastion_name, "${var.component}-ca-bastion")
+  ca_client_vm_name      = coalesce(var.ca_client_vm_name, "${var.component}-ca-client")
+  ca_origin_pool_name    = coalesce(var.ca_origin_pool_name, "${var.component}-ca-pool")
+  ca_lb_name             = coalesce(var.ca_lb_name, "${var.component}-ca-f5se")
+  ca_re_vsite_name       = coalesce(var.ca_re_vsite_name, "${var.component}-ca-re-vsite")
+  ca_ce_vsite_name       = coalesce(var.ca_ce_vsite_name, "${var.component}-ca-ce-vsite")
+
   # --- Standard tags (applied to every Azure resource) ---
   standard_tags = {
     component   = var.component
@@ -92,6 +104,15 @@ locals {
       token        = local.ce_registration_token
       # chomp: a key read from a .pub file ends in a newline, which would render a
       # second, empty line into authorized_keys under `content: |`.
+      ssh_public_key = chomp(local.ssh_public_key)
+    })
+  }
+
+  # --- Canada CE cloud-init, rendered once per node ---
+  ca_ce_cloud_init = {
+    for key, node in try(module.ce_topology_ca[0].ce_nodes, {}) : key => templatefile("${path.module}/cloud-init/ce-node.yaml", {
+      cluster_name   = node.site_name
+      token          = local.ce_registration_token
       ssh_public_key = chomp(local.ssh_public_key)
     })
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,6 +64,13 @@ check "vip_outside_vnet_cidrs" {
   }
 }
 
+check "ca_vip_outside_vnet_cidrs" {
+  assert {
+    condition     = !var.enable_canada || cidrhost(var.ca_hub_cidr, 0) != cidrhost("${var.ca_vip}/${split("/", var.ca_hub_cidr)[1]}", 0)
+    error_message = "ca_vip ${var.ca_vip} must be OUTSIDE ca_hub_cidr ${var.ca_hub_cidr}."
+  }
+}
+
 # Tenant-scoped, reusable site registration token. The provider now ships
 # xcsh_token with a Computed `uid` (system_metadata.uid) — the token VALUE a CE
 # feeds to VPM at registration (the resource `id` is the token NAME, not the
@@ -322,6 +329,258 @@ resource "xcsh_http_loadbalancer" "this" {
     pool {
       namespace = data.xcsh_namespace.mcn.name
       name      = xcsh_origin_pool.this.name
+    }
+    weight   = 1
+    priority = 1
+  }
+
+  round_robin {}
+  no_challenge {}
+  user_id_client_ip {}
+  disable_waf {}
+  disable_rate_limit {}
+  disable_api_discovery {}
+  disable_api_testing {}
+  disable_api_definition {}
+  l7_ddos_protection {}
+  service_policies_from_namespace {}
+  disable_trust_client_ip_headers {}
+  disable_malicious_user_detection {}
+  disable_malware_protection {}
+  disable_threat_mesh {}
+  default_sensitive_data_policy {}
+}
+
+# ---------------------------------------------------------
+# Canada Regional Infrastructure & F5 XC Data-Plane (Canada Path)
+# ---------------------------------------------------------
+
+# Pure expansion of ca_ce_count into the per-CE node map for Canada.
+module "ce_topology_ca" {
+  count  = var.enable_canada ? 1 : 0
+  source = "./modules/ce-topology"
+
+  ce_count           = var.ca_ce_count
+  region_short       = local.ca_region_short
+  mgmt_subnet_prefix = var.ca_mgmt_subnet_prefix
+  site_prefix        = local.ca_site_prefix
+}
+
+# Canada Hub: RG, VNet, four subnets, Azure Route Server.
+module "azure_hub_ca" {
+  count  = var.enable_canada ? 1 : 0
+  source = "./modules/azure-hub"
+
+  resource_group_name        = local.ca_resource_group_name
+  location                   = var.ca_location
+  hub_cidr                   = var.ca_hub_cidr
+  mgmt_subnet_prefix         = var.ca_mgmt_subnet_prefix
+  external_subnet_prefix     = var.ca_external_subnet_prefix
+  internal_subnet_prefix     = var.ca_internal_subnet_prefix
+  route_server_subnet_prefix = var.ca_route_server_subnet_prefix
+  route_server_name          = local.ca_route_server_name
+  bastion_subnet_prefix      = var.ca_bastion_subnet_prefix
+  enable_bastion             = var.enable_bastion
+  bastion_name               = local.ca_bastion_name
+  tags                       = local.tags
+}
+
+# One Canadian CE VM (3 NICs + identity) per node.
+module "ce_node_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+  source   = "./modules/ce-node"
+
+  hostname            = each.value.hostname
+  resource_group_name = try(module.azure_hub_ca[0].resource_group_name, null)
+  location            = try(module.azure_hub_ca[0].location, null)
+  zone                = each.value.az
+  vm_size             = var.ce_vm_size
+  mgmt_subnet_id      = try(module.azure_hub_ca[0].management_subnet_id, null)
+  external_subnet_id  = try(module.azure_hub_ca[0].external_subnet_id, null)
+  internal_subnet_id  = try(module.azure_hub_ca[0].internal_subnet_id, null)
+  mgmt_private_ip     = each.value.slo_ip
+  admin_username      = var.admin_username
+  ssh_public_key      = local.ssh_public_key
+
+  custom_data = base64encode(local.ca_ce_cloud_init[each.key])
+
+  tags = local.tags
+}
+
+resource "random_password" "site_console_admin_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+
+  length           = 32
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  override_special = "!#%*+-=?@^_~"
+
+  keepers = {
+    ce_vm_instance_id = module.ce_node_ca[each.key].vm_instance_id
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "site_console_password_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+
+  name                       = "site-console-admin-password"
+  virtual_machine_id         = module.ce_node_ca[each.key].vm_id
+  publisher                  = "Microsoft.Azure.Extensions"
+  type                       = "CustomScript"
+  type_handler_version       = "2.1"
+  auto_upgrade_minor_version = true
+
+  protected_settings = jsonencode({
+    script = base64encode(<<-SCRIPT
+      #!/usr/bin/env bash
+      set -euo pipefail
+      password_b64='${base64encode(random_password.site_console_admin_ca[each.key].result)}'
+      password=$(printf '%s' "$password_b64" | base64 --decode)
+      printf 'admin:%s\n' "$password" | chpasswd
+      unset password password_b64
+    SCRIPT
+    )
+  })
+}
+
+# Canadian XC SMSv2 site + BGP object per node.
+module "xc_site_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+  source   = "./modules/xc-site"
+
+  site_name            = each.value.site_name
+  hostname             = each.value.hostname
+  interface_name       = each.value.interface_name
+  mgmt_nic_mac         = module.ce_node_ca[each.key].mgmt_nic_mac
+  ce_vm_instance_id    = module.ce_node_ca[each.key].vm_instance_id
+  rs_peer_ips          = try(module.azure_hub_ca[0].rs_peer_ips, [])
+  ce_asn               = var.ce_asn
+  rs_asn               = var.rs_asn
+  os_version           = var.ce_os_version
+  sw_version           = var.ce_sw_version
+  enable_bgp           = var.enable_bgp
+  approve_registration = var.approve_registration
+}
+
+# Azure Route Server eBGP session for Canadian CEs.
+module "azure_route_server_bgp_ca" {
+  for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+  source   = "./modules/azure-route-server-bgp"
+
+  name            = "${each.key}-bgp"
+  route_server_id = try(module.azure_hub_ca[0].route_server_id, null)
+  peer_asn        = var.ce_asn
+  peer_ip         = module.ce_node_ca[each.key].mgmt_private_ip
+}
+
+module "client_vm_ca" {
+  count  = var.enable_canada ? 1 : 0
+  source = "./modules/client-vm"
+
+  name                = local.ca_client_vm_name
+  resource_group_name = try(module.azure_hub_ca[0].resource_group_name, null)
+  location            = try(module.azure_hub_ca[0].location, null)
+  subnet_id           = try(module.azure_hub_ca[0].internal_subnet_id, null)
+  admin_username      = var.admin_username
+  ssh_public_key      = local.ssh_public_key
+  tags                = local.tags
+}
+
+# ---------------------------------------------------------
+# F5 XC Virtual Sites (Canada RE & Canada CE)
+# ---------------------------------------------------------
+
+resource "xcsh_virtual_site" "canada_re" {
+  count     = var.enable_canada ? 1 : 0
+  name      = local.ca_re_vsite_name
+  namespace = data.xcsh_namespace.mcn.name
+
+  site_type = "REGIONAL_EDGE"
+  site_selector {
+    expressions = ["ves.io/city in (${join(", ", var.ca_re_cities)})"]
+  }
+}
+
+resource "xcsh_virtual_site" "canada_ce" {
+  count     = var.enable_canada ? 1 : 0
+  name      = local.ca_ce_vsite_name
+  namespace = data.xcsh_namespace.mcn.name
+
+  site_type = "CUSTOMER_EDGE"
+  site_selector {
+    expressions = ["ves.io/siteName in (${join(", ", [for k, v in try(module.ce_topology_ca[0].ce_nodes, {}) : v.site_name])})"]
+  }
+}
+
+resource "xcsh_origin_pool" "canada" {
+  count       = var.enable_canada ? 1 : 0
+  name        = local.ca_origin_pool_name
+  namespace   = data.xcsh_namespace.mcn.name
+  description = "Canada reference origin pool -> ${var.origin_ip}:${var.origin_port}"
+
+  port = var.origin_port
+
+  origin_servers {
+    labels {}
+    public_ip {
+      ip = var.origin_ip
+    }
+  }
+
+  no_tls {}
+  loadbalancer_algorithm = "ROUND_ROBIN"
+  endpoint_selection     = "DISTRIBUTED"
+}
+
+resource "xcsh_http_loadbalancer" "canada" {
+  count      = var.enable_canada ? 1 : 0
+  depends_on = [module.xc_site_ca, xcsh_virtual_site.canada_re, xcsh_virtual_site.canada_ce]
+
+  name        = local.ca_lb_name
+  namespace   = data.xcsh_namespace.mcn.name
+  description = "Canada Regional HA: custom VIP ${var.ca_vip} advertised strictly via Canadian Regional Edges (Toronto and Montreal) and Canadian CEs."
+
+  domains = [var.ca_lb_domain]
+
+  http {
+    port                 = 80
+    dns_volterra_managed = false
+  }
+
+  advertise_custom {
+    advertise_where {
+      virtual_site {
+        network = "SITE_NETWORK_OUTSIDE"
+        virtual_site {
+          namespace = data.xcsh_namespace.mcn.name
+          name      = try(xcsh_virtual_site.canada_re[0].name, null)
+        }
+      }
+      use_default_port {}
+    }
+
+    dynamic "advertise_where" {
+      for_each = try(module.ce_topology_ca[0].ce_nodes, {})
+      content {
+        site {
+          network = "SITE_NETWORK_OUTSIDE"
+          site {
+            namespace = "system"
+            name      = advertise_where.value.site_name
+          }
+          ip = var.ca_vip
+        }
+        use_default_port {}
+      }
+    }
+  }
+
+  default_route_pools {
+    pool {
+      namespace = data.xcsh_namespace.mcn.name
+      name      = try(xcsh_origin_pool.canada[0].name, null)
     }
     weight   = 1
     priority = 1

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -161,6 +161,40 @@ output "vip" {
 }
 
 # ---------------------------------------------------------
+# Canada Regional outputs
+# ---------------------------------------------------------
+
+output "ca_lb_domain" {
+  description = "Domain served by the Canada HTTP load balancer."
+  value       = var.ca_lb_domain
+}
+
+output "ca_re_virtual_site_name" {
+  description = "Name of the Canadian Regional Edge virtual site."
+  value       = try(xcsh_virtual_site.canada_re[0].name, null)
+}
+
+output "ca_ce_virtual_site_name" {
+  description = "Name of the Canadian Customer Edge virtual site."
+  value       = try(xcsh_virtual_site.canada_ce[0].name, null)
+}
+
+output "ca_loadbalancer_name" {
+  description = "Name of the Canadian HTTP load balancer."
+  value       = try(xcsh_http_loadbalancer.canada[0].name, null)
+}
+
+output "ca_origin_pool_name" {
+  description = "Name of the Canadian origin pool."
+  value       = try(xcsh_origin_pool.canada[0].name, null)
+}
+
+output "ca_vip" {
+  description = "HA VIP for Canadian CEs advertised via eBGP/ECMP."
+  value       = var.ca_vip
+}
+
+# ---------------------------------------------------------
 # CE registration token
 # ---------------------------------------------------------
 

--- a/terraform/tests/canada_regional.tftest.hcl
+++ b/terraform/tests/canada_regional.tftest.hcl
@@ -1,0 +1,93 @@
+# Test suite for Canada Regional infrastructure, Virtual Sites, and HTTP Load Balancer.
+
+mock_provider "azurerm" {}
+mock_provider "azuread" {}
+mock_provider "xcsh" {}
+
+variables {
+  site_prefix            = null
+  ca_site_prefix         = null
+  lb_name                = null
+  ca_lb_name             = null
+  origin_pool_name       = null
+  ca_origin_pool_name    = null
+  route_server_name      = null
+  ca_route_server_name   = null
+  bastion_name           = null
+  ca_bastion_name        = null
+  client_vm_name         = null
+  ca_client_vm_name      = null
+  region_short           = null
+  ca_region_short        = null
+  resource_group_name    = null
+  ca_resource_group_name = null
+  lb_domain              = "mcn-ce-ha.f5-sales-demo.com"
+  ca_lb_domain           = "mcn-ce-ha.f5-sales-demo.ca"
+  origin_ip              = "203.0.113.10"
+  deployer               = "tester"
+  ssh_public_key         = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzwDqvgRGHaZqbo57o/AxuuqRNPT9MqeYNYsK1Owh8l plan-test-only"
+  xc_app_namespace       = "multi-cloud-networking"
+  enable_canada          = true
+}
+
+run "canada_regional_virtual_sites_and_lb" {
+  command = plan
+
+  variables {
+    ce_count    = 2
+    ca_ce_count = 3
+  }
+
+  assert {
+    condition     = output.ca_re_virtual_site_name == "mcn-ce-ha-ca-re-vsite"
+    error_message = "Canada RE Virtual Site name should be mcn-ce-ha-ca-re-vsite."
+  }
+
+  assert {
+    condition     = output.ca_ce_virtual_site_name == "mcn-ce-ha-ca-ce-vsite"
+    error_message = "Canada CE Virtual Site name should be mcn-ce-ha-ca-ce-vsite."
+  }
+
+  assert {
+    condition     = output.ca_lb_domain == "mcn-ce-ha.f5-sales-demo.ca"
+    error_message = "Canada HTTP Load Balancer domain should be mcn-ce-ha.f5-sales-demo.ca."
+  }
+
+  assert {
+    condition     = output.ca_loadbalancer_name == "mcn-ce-ha-ca-f5se"
+    error_message = "Canada HTTP Load Balancer name should be mcn-ce-ha-ca-f5se."
+  }
+
+  assert {
+    condition     = output.ca_origin_pool_name == "mcn-ce-ha-ca-pool"
+    error_message = "Canada Origin Pool name should be mcn-ce-ha-ca-pool."
+  }
+
+  assert {
+    condition     = output.ca_vip == "10.250.1.10"
+    error_message = "Canada VIP should be 10.250.1.10."
+  }
+}
+
+run "canada_disabled_plans_no_canada_resources" {
+  command = plan
+
+  variables {
+    enable_canada = false
+  }
+
+  assert {
+    condition     = length(xcsh_virtual_site.canada_re) == 0
+    error_message = "With enable_canada = false, no Canada RE virtual site should be created."
+  }
+
+  assert {
+    condition     = length(xcsh_http_loadbalancer.canada) == 0
+    error_message = "With enable_canada = false, no Canada HTTP load balancer should be created."
+  }
+
+  assert {
+    condition     = output.ca_re_virtual_site_name == null
+    error_message = "With enable_canada = false, ca_re_virtual_site_name output must be null."
+  }
+}

--- a/terraform/variables_azure.tf
+++ b/terraform/variables_azure.tf
@@ -22,6 +22,103 @@ variable "location" {
 }
 
 # ---------------------------------------------------------
+# Canada regional Azure placement & CIDRs
+# ---------------------------------------------------------
+
+variable "ca_location" {
+  description = "Azure region for Canadian regional resources."
+  type        = string
+  default     = "canadacentral"
+}
+
+variable "ca_resource_group_name" {
+  description = "Resource group that holds the Canadian hub VNet, Route Server, CE VMs and test client. Leave null (the default) to derive `rg-<component>-ca-<deployer>`."
+  type        = string
+  default     = null
+}
+
+variable "ca_hub_cidr" {
+  description = "Canada Hub VNet address space."
+  type        = string
+  default     = "10.200.0.0/16"
+}
+
+variable "ca_mgmt_subnet_prefix" {
+  description = "Canada snet-hub-management prefix. CE eth0/SLO NICs live here."
+  type        = string
+  default     = "10.200.1.0/26"
+}
+
+variable "ca_external_subnet_prefix" {
+  description = "Canada snet-hub-external prefix."
+  type        = string
+  default     = "10.200.2.0/26"
+}
+
+variable "ca_internal_subnet_prefix" {
+  description = "Canada snet-hub-internal prefix. Test client lives here."
+  type        = string
+  default     = "10.200.3.0/26"
+}
+
+variable "ca_route_server_subnet_prefix" {
+  description = "Canada RouteServerSubnet prefix. MUST be exactly /27."
+  type        = string
+  default     = "10.200.4.0/27"
+
+  validation {
+    condition     = tonumber(split("/", var.ca_route_server_subnet_prefix)[1]) == 27
+    error_message = "ca_route_server_subnet_prefix must be a /27."
+  }
+}
+
+variable "ca_bastion_subnet_prefix" {
+  description = "Canada AzureBastionSubnet prefix. MUST be /26 or larger."
+  type        = string
+  default     = "10.200.5.0/26"
+
+  validation {
+    condition     = tonumber(split("/", var.ca_bastion_subnet_prefix)[1]) <= 26
+    error_message = "ca_bastion_subnet_prefix must be /26 or larger."
+  }
+}
+
+variable "ca_vip" {
+  description = "HA VIP for Canadian CEs advertised as a /32 via eBGP."
+  type        = string
+  default     = "10.250.1.10"
+
+  validation {
+    condition     = can(cidrhost("${var.ca_vip}/32", 0))
+    error_message = "ca_vip must be a valid IPv4 address."
+  }
+}
+
+variable "ca_route_server_name" {
+  description = "Canada Azure Route Server name. Leave null to derive `<component>-ca-rs`."
+  type        = string
+  default     = null
+}
+
+variable "ca_bastion_name" {
+  description = "Canada Azure Bastion host name. Leave null to derive `<component>-ca-bastion`."
+  type        = string
+  default     = null
+}
+
+variable "ca_client_vm_name" {
+  description = "Canada test client VM name. Leave null to derive `<component>-ca-client`."
+  type        = string
+  default     = null
+}
+
+variable "ca_region_short" {
+  description = "Short region token for Canada site names. Leave null to use var.ca_location."
+  type        = string
+  default     = null
+}
+
+# ---------------------------------------------------------
 # Network CIDRs
 # ---------------------------------------------------------
 

--- a/terraform/variables_ce.tf
+++ b/terraform/variables_ce.tf
@@ -13,6 +13,27 @@ variable "ce_count" {
   }
 }
 
+# ---------------------------------------------------------
+# Canada CE topology / scaling
+# ---------------------------------------------------------
+
+variable "ca_ce_count" {
+  description = "Number of Canadian single-node Secure Mesh v2 CE sites (1..3)."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.ca_ce_count >= 1 && var.ca_ce_count <= 3
+    error_message = "ca_ce_count must be between 1 and 3."
+  }
+}
+
+variable "ca_site_prefix" {
+  description = "Prefix for Canadian XC site names (site = <ca_site_prefix>-<ca_region_short>0<n>). Leave null to derive `<component>-ca`."
+  type        = string
+  default     = null
+}
+
 variable "region_short" {
   description = "Short region token used to build the per-CE key and site name (component `mcn-ce-ha` + region `eastus` -> site `mcn-ce-ha-eastus01`). Leave null (the default) to use var.location verbatim; set it only when the Azure region name is longer than you want inside object names."
   type        = string

--- a/terraform/variables_xc.tf
+++ b/terraform/variables_xc.tf
@@ -58,13 +58,64 @@ variable "lb_name" {
 }
 
 variable "lb_domain" {
-  description = "Domain served by the HTTP load balancer. REQUIRED, deliberately without a default: the load balancer matches on Host, so this value is what every request must send, and it belongs to whoever runs the deployment."
+  description = "Domain served by the HTTP load balancer for Rest of World. REQUIRED, deliberately without a default: the load balancer matches on Host, so this value is what every request must send, and it belongs to whoever runs the deployment."
   type        = string
 
   validation {
     condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.lb_domain))
     error_message = "lb_domain must be a fully-qualified lowercase domain name (for example mcn-ce-ha.f5-sales-demo.com)."
   }
+}
+
+# ---------------------------------------------------------
+# Canada Regional F5 XC inputs
+# ---------------------------------------------------------
+
+variable "enable_canada" {
+  description = "Enable parallel Canada-only regional infrastructure, Canadian virtual sites, and f5-sales-demo.ca load balancer."
+  type        = bool
+  default     = true
+}
+
+variable "ca_lb_domain" {
+  description = "Domain served by the Canada HTTP load balancer. Defaults to mcn-ce-ha.f5-sales-demo.ca."
+  type        = string
+  default     = "mcn-ce-ha.f5-sales-demo.ca"
+
+  validation {
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.ca_lb_domain))
+    error_message = "ca_lb_domain must be a fully-qualified lowercase domain name (for example mcn-ce-ha.f5-sales-demo.ca)."
+  }
+}
+
+variable "ca_re_cities" {
+  description = "List of cities for the Canadian Regional Edge Virtual Site selector. Defaults to Toronto and Montreal."
+  type        = list(string)
+  default     = ["toronto", "montreal"]
+}
+
+variable "ca_lb_name" {
+  description = "Name of the Canada HTTP load balancer. Leave null (the default) to derive `<component>-ca-f5se`."
+  type        = string
+  default     = null
+}
+
+variable "ca_origin_pool_name" {
+  description = "Name of the Canada origin pool. Leave null (the default) to derive `<component>-ca-pool`."
+  type        = string
+  default     = null
+}
+
+variable "ca_re_vsite_name" {
+  description = "Name of the Canadian Regional Edge virtual site. Leave null (the default) to derive `<component>-ca-re-vsite`."
+  type        = string
+  default     = null
+}
+
+variable "ca_ce_vsite_name" {
+  description = "Name of the Canadian Customer Edge virtual site. Leave null (the default) to derive `<component>-ca-ce-vsite`."
+  type        = string
+  default     = null
 }
 
 variable "vip" {


### PR DESCRIPTION
## Summary

Support Canada-only regional network path with virtual sites and customer edges (CEs).

Fixes #850

## Test plan

- [x] CI checks pass
- [x] Terraform validation