### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   review:
     if: vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@41ef88197c4b7834eb294c798744828c89b90ce5
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@9f85df26bec69406e1872727d1cbd3721c835221
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   translate:
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@41ef88197c4b7834eb294c798744828c89b90ce5
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@9f85df26bec69406e1872727d1cbd3721c835221
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}
@@ -38,5 +38,4 @@ jobs:
     secrets:
       ANTIGRAVITY_TOKEN: ${{ secrets.ANTIGRAVITY_TOKEN }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      AUTOMATION_APP_ID: ${{ secrets.AUTOMATION_APP_ID }}
-      AUTOMATION_APP_PRIVATE_KEY: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+      REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -54,7 +54,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@41ef88197c4b7834eb294c798744828c89b90ce5
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@9f85df26bec69406e1872727d1cbd3721c835221
     permissions:
       contents: write # the reusable completes the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@41ef88197c4b7834eb294c798744828c89b90ce5
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@9f85df26bec69406e1872727d1cbd3721c835221
     with:
       content-ref: ${{ github.sha }}
     permissions:

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -34,4 +34,4 @@ jobs:
     # in a job-level `if:`. An unset variable evaluates false, so this fails safe
     # toward not spending money.
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@41ef88197c4b7834eb294c798744828c89b90ce5
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@9f85df26bec69406e1872727d1cbd3721c835221

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Lifecycle: linked issue → branch → required local `agy` review → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Antigravity CI reviewer and translation-freshness gate remain **suspended** — see CONTRIBUTING.md.
+- Lifecycle: linked issue → branch → required local `agy` review → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The advisory Antigravity CI reviewer and translator run behind organisation switches and are never required merge contexts — see CONTRIBUTING.md.
 
 ## Review routing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,26 +192,24 @@ work but do not review code, specs, plans, pull requests, or CI failures.
 | ----- | --------------- | --------- |
 | **Local document review** | A spec or implementation plan | Antigravity advisory gate |
 | **Local Antigravity review** | The committed branch diff before a PR push | Required workflow step |
-| **CI Antigravity review** | The exact pull-request head | Advisory after the controlled pilot |
+| **CI Antigravity review** | The exact pull-request head | Advisory automation |
 
 ### CI review
 
-The Gemini Antigravity reviewer remains disabled and fail-closed behind
-`ANTIGRAVITY_REVIEW_ENABLED` until docs-control#1016 is resolved.
-It is advisory and must not be added to required status contexts. Automated branches that bypass
-the linked-issue check are reserved for machine-generated work; the authoritative prefix list lives
-in `require-linked-issue.yml` and must never be used for human or agent work.
+The Gemini Antigravity reviewer is fail-closed behind the organisation variable
+`ANTIGRAVITY_REVIEW_ENABLED`. Its immutable runtime, exact-head and workflow receipts, separated
+model and publication credentials, and rejection paths are covered by executable security UAT.
+It is advisory and must not be added to required status contexts. Automated branches that bypass the
+linked-issue check are reserved for machine-generated work; the authoritative prefix list lives in
+`require-linked-issue.yml` and must never be used for human or agent work.
 
-#### Restoring Antigravity review
+#### Operating Antigravity review
 
-Keep the source gate in place. After docs-control#1016 is verified, create the organisation Actions
-variable `ANTIGRAVITY_REVIEW_ENABLED` with value `false`, remove any same-named repository variables,
-and keep the reusable and governed `workflow_dispatch` callers enabled. The scheduled/manual
-docs-control watcher dispatches only exact same-repository heads from trusted default-branch workflow
-definitions. Pilot with selected visibility and the literal value `true`; after a real pull request
-completes safely, expand visibility to every governed repository. Future toggles change only the
-organisation variable, never workflow state. The Antigravity CI review is advisory and must not be
-added to required status contexts.
+Keep the source gate in place, remove any same-named repository variables, and keep the reusable and
+governed `workflow_dispatch` callers enabled. The scheduled/manual docs-control watcher dispatches
+only exact same-repository heads from trusted default-branch workflow definitions. Future toggles
+change only the organisation variable, never workflow state. The Antigravity CI review is advisory
+and must not be added to required status contexts.
 
 ### Local review before a pull-request push
 
@@ -223,7 +221,9 @@ bash scripts/agy-review.sh document --kind plan --file path/to/plan.md
 ```
 
 The command runs independent reviewer and verifier sessions, validates structured output, and fails
-closed. Do not substitute Claude, Codex, a model-invocable review skill, or a PR-diff plugin.
+closed. Each phase emits an immediate start marker, a periodic stderr heartbeat, and a completion
+marker so automation can distinguish a live silent model call from a finished review. Do not
+substitute Claude, Codex, a model-invocable review skill, or a PR-diff plugin.
 
 Branch review is mandatory before every push that opens or updates a pull request:
 
@@ -253,18 +253,19 @@ Local hooks validate translation structure and hashes but do not invoke a model.
 generation belongs to the governed Antigravity workflow so Claude and Codex never generate locale
 content and developer workstations do not duplicate automation work.
 
-GitHub Actions translation remains held until the security boundary in docs-control#1016 is fixed.
-Both the governed caller and reusable workflow fail closed unless the organisation variable
-`TRANSLATIONS_ENABLED` is the literal string `true`. The workflow files must remain enabled once the
-security fix lands; the organisation variable is the only runtime switch. Repository variables with
-the same name are forbidden because they override the organisation value.
+GitHub Actions translation is fail-closed unless the organisation variable `TRANSLATIONS_ENABLED`
+is the literal string `true`. Its immutable runtime, exact-head and workflow receipts, isolated model
+credentials, 12-locale validation, allowlisted patch, and guarded publication are covered by
+executable security UAT. The workflow files remain enabled; the organisation variable is the only
+runtime switch. Repository variables with the same name are forbidden because they override the
+organisation value.
 
 How the translation pipeline operates:
 
 | Part | Where | How it Works |
 | ---- | ----- | ------------ |
 | Local Translation | Pre-commit locale/hash validation | **Deterministic only.** Never invokes a model. |
-| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on a GitHub Actions runner | **Security hold.** After docs-control#1016, the organisation variable controls execution. |
+| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on a GitHub Actions runner | The organisation variable controls execution. |
 | Freshness Audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against English source SHA-256 | **Advisory when enabled.** It shares the Actions switch but is not a required context. |
 | Required Context | `audit / Translation freshness` in branch protection | **Not required.** Requiring a check while its job can skip would deadlock pull requests. |
 
@@ -275,9 +276,12 @@ variables. Unset, `false`, or any other value disables the corresponding automat
 literal string `true` enables it.
 
 The implementation uses GitHub Free features only: scheduled/manual Actions, ordinary organisation
-variables, GitHub App tokens, artifacts, pull-request comments, and classic branch protection. Do
-not add organisation rulesets, merge queues, audit-log streaming, or environment required reviewers.
-The `antigravity-automation` environment on the public docs-control repository is only a secret
+variables, the existing `REPO_SETTINGS_TOKEN` and `REPO_SYNC_TOKEN` governance PATs, artifacts,
+pull-request comments, and classic branch protection. It does not require a GitHub App. Keep
+`REPO_SETTINGS_TOKEN` limited to watcher collection/publication and `REPO_SYNC_TOKEN` limited to
+translation publication; Antigravity model jobs receive neither token. Do not add organisation
+rulesets, merge queues, audit-log streaming, or environment required reviewers. The
+`antigravity-automation` environment on the public docs-control repository is only a secret
 boundary; configure no reviewers, wait timer, or deployment rule on it.
 
 1. Verify docs-control#1016 in the live workflow bytes, not merely by issue state. The installer must
@@ -293,7 +297,8 @@ boundary; configure no reviewers, wait timer, or deployment rule on it.
 
 3. Set selected visibility for a pilot same-repository documentation pull request. Set each desired
    variable to `true`, then require a completed Antigravity review and 12 validated locale outputs.
-   If the pilot fails, set the relevant variable to `false` before cancelling in-flight runs.
+   Verify the exact pilot scope with `--visibility selected --selected-repo <repository>`. If the
+   pilot fails, set the relevant variable to `false` before cancelling in-flight runs.
 
 4. Expand visibility to all governed repositories after the pilot. Future suspension changes only
    the organisation variable value and cancels any already-running jobs; workflow states remain

--- a/scripts/agy-review.sh
+++ b/scripts/agy-review.sh
@@ -98,6 +98,13 @@ done
   echo "[review] output schema is unavailable: $schema" >&2
   exit 1
 }
+heartbeat_seconds=${AGY_REVIEW_HEARTBEAT_SECONDS:-30}
+case "$heartbeat_seconds" in
+'' | 0 | *[!0-9]*)
+  echo "[review] AGY_REVIEW_HEARTBEAT_SECONDS must be a positive integer" >&2
+  exit 2
+  ;;
+esac
 
 target_description=""
 target_instructions=""
@@ -142,8 +149,18 @@ else
 fi
 
 work=$(mktemp -d "$repo_root/.agy-review.XXXXXX")
+agy_pid=""
+heartbeat_pid=""
 # shellcheck disable=SC2329 # invoked through the EXIT trap below
 cleanup() {
+  if [ -n "$heartbeat_pid" ]; then
+    kill "$heartbeat_pid" 2>/dev/null || true
+    wait "$heartbeat_pid" 2>/dev/null || true
+  fi
+  if [ -n "$agy_pid" ]; then
+    kill "$agy_pid" 2>/dev/null || true
+    wait "$agy_pid" 2>/dev/null || true
+  fi
   rm -rf -- "$work"
 }
 trap cleanup EXIT
@@ -162,16 +179,35 @@ if [ "$mode" = code ]; then
 fi
 
 invoke_agy() {
-  local prompt_file=$1 stream_file=$2 result_file=$3
-  if ! env -u GH_TOKEN -u GITHUB_TOKEN -u REPO_SETTINGS_TOKEN -u REPO_SYNC_TOKEN \
+  local phase=$1 prompt_file=$2 stream_file=$3 result_file=$4
+  local agy_status=0 started_at=$SECONDS
+  printf '[review] %s started; waiting for Antigravity (heartbeat every %ss)\n' \
+    "$phase" "$heartbeat_seconds" >&2
+  env -u GH_TOKEN -u GITHUB_TOKEN -u REPO_SETTINGS_TOKEN -u REPO_SYNC_TOKEN \
     -u GATEWAY_TOKEN -u GATEWAY_URL AGY_REVIEW_ACTIVE=1 \
     agy --new-project --sandbox --mode plan --disable-slash-commands \
     --model "Gemini 3.6 Flash (High)" \
     --output-format stream-json --json-schema "$schema" \
-    --print-timeout 25m --print "$(<"$prompt_file")" >"$stream_file"; then
+    --print-timeout 25m --print "$(<"$prompt_file")" >"$stream_file" &
+  agy_pid=$!
+  (
+    while sleep "$heartbeat_seconds"; do
+      kill -0 "$agy_pid" 2>/dev/null || exit 0
+      printf '[review] %s still running (%ss elapsed)\n' \
+        "$phase" "$((SECONDS - started_at))" >&2
+    done
+  ) &
+  heartbeat_pid=$!
+  wait "$agy_pid" || agy_status=$?
+  agy_pid=""
+  kill "$heartbeat_pid" 2>/dev/null || true
+  wait "$heartbeat_pid" 2>/dev/null || true
+  heartbeat_pid=""
+  if [ "$agy_status" -ne 0 ]; then
     echo "[review] Antigravity execution failed" >&2
     return 1
   fi
+  printf '[review] %s completed; validating structured output\n' "$phase" >&2
   if ! jq -s -e '
     [.[] | select(.event == "result")] as $results |
     if ($results | length) != 1 then error("expected one result event")
@@ -197,7 +233,7 @@ Paths in consumer_shell_tests.profiles are resolved under the named downstream r
 
 Review correctness, security, data loss, concurrency, rollback, maintainability, and privacy. Perform a dedicated semantic PII audit over changed inputs, schemas, fixtures, generated files, filenames, media metadata, logs, telemetry, errors, persistence, exports, and deletion. Never repeat a matched personal or infrastructure value; report only category, path, line, and redacted evidence. Classify confirmed PII and reproducible security/correctness defects as high or critical. Report only findings supported by repository evidence. Return only schema-valid JSON.
 EOF
-invoke_agy "$work/reviewer.prompt" "$work/reviewer.stream" "$work/reviewer.json"
+invoke_agy reviewer "$work/reviewer.prompt" "$work/reviewer.stream" "$work/reviewer.json"
 
 cat >"$work/verifier.prompt" <<EOF
 Act as a second independent Antigravity verifier for $target_description.
@@ -209,7 +245,7 @@ Do not execute repository test or lint suites, package builds, network commands,
 
 Paths in consumer_shell_tests.profiles are resolved under the named downstream repository checkout by scripts/run-consumer-shell-tests.sh, not under docs-control. Verify profile ownership and rollout evidence; local absence alone is not a defect.
 EOF
-invoke_agy "$work/verifier.prompt" "$work/verifier.stream" "$work/verifier.json"
+invoke_agy verifier "$work/verifier.prompt" "$work/verifier.stream" "$work/verifier.json"
 
 jq -n --slurpfile reviewer "$work/reviewer.json" --slurpfile verifier "$work/verifier.json" '{
   reviewer: $reviewer[0],

--- a/tests/test-agy-pre-push-review.sh
+++ b/tests/test-agy-pre-push-review.sh
@@ -54,6 +54,9 @@ if [ -n "${FAKE_AGY_BUNDLE_CAPTURE:-}" ]; then
     fi
   done
 fi
+if [ "${FAKE_AGY_DELAY_CALL:-0}" -eq "$count" ]; then
+  sleep "${FAKE_AGY_DELAY_SECONDS:-2}"
+fi
 if [ "${FAKE_AGY_MALFORMED_CALL:-0}" -eq "$count" ]; then
   printf 'not-json\n'
 elif [ "${FAKE_AGY_BLOCK_CALL:-0}" -eq "$count" ]; then
@@ -101,6 +104,19 @@ if run_review "$WORK/bin:$PATH" env GATEWAY_TOKEN=private GITHUB_TOKEN=private \
   pass "two schema-validated Flash passes review a precomputed bundle without inherited credentials"
 else
   fail "clean branch receives two independent Antigravity passes" "$(cat "$WORK/output")"
+fi
+
+setup_repo
+if run_review "$WORK/bin:$PATH" env FAKE_AGY_DELAY_CALL=1 FAKE_AGY_DELAY_SECONDS=2 \
+  AGY_REVIEW_HEARTBEAT_SECONDS=1 &&
+  grep -q '\[review\] reviewer started; waiting for Antigravity' "$WORK/output" &&
+  grep -q '\[review\] reviewer still running (' "$WORK/output" &&
+  grep -q '\[review\] reviewer completed; validating structured output' "$WORK/output" &&
+  grep -q '\[review\] verifier started; waiting for Antigravity' "$WORK/output" &&
+  grep -q '\[review\] verifier completed; validating structured output' "$WORK/output"; then
+  pass "review wrapper emits phase start, heartbeat, and completion progress"
+else
+  fail "review wrapper emits unambiguous progress" "$(cat "$WORK/output")"
 fi
 
 setup_repo


### PR DESCRIPTION
Closes #857

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/github-pages-deploy.yml
- .github/workflows/translation-audit.yml
- .github/workflows/antigravity-review.yml
- .github/workflows/antigravity-translate.yml
- CONTRIBUTING.md
- CLAUDE.md
- .github/workflows/auto-merge.yml
- scripts/agy-review.sh
- tests/test-agy-pre-push-review.sh