### PR TITLE
fix(terraform): refine xc-site module for auto-provisioned sites

### DIFF
--- a/docs/_includes/terraform/main.tf
+++ b/docs/_includes/terraform/main.tf
@@ -450,6 +450,7 @@ module "xc_site_ca" {
   for_each = try(module.ce_topology_ca[0].ce_nodes, {})
   source   = "./modules/xc-site"
 
+  create_site          = false
   site_name            = each.value.site_name
   hostname             = each.value.hostname
   interface_name       = each.value.interface_name
@@ -550,17 +551,6 @@ resource "xcsh_http_loadbalancer" "canada" {
   }
 
   advertise_custom {
-    advertise_where {
-      virtual_site {
-        network = "SITE_NETWORK_OUTSIDE"
-        virtual_site {
-          namespace = data.xcsh_namespace.mcn.name
-          name      = try(xcsh_virtual_site.canada_re[0].name, null)
-        }
-      }
-      use_default_port {}
-    }
-
     dynamic "advertise_where" {
       for_each = try(module.ce_topology_ca[0].ce_nodes, {})
       content {

--- a/docs/_includes/terraform/modules/xc-site/main.tf
+++ b/docs/_includes/terraform/modules/xc-site/main.tf
@@ -28,6 +28,7 @@ resource "terraform_data" "ce_vm" {
 # (var.interface_name) that the BGP peer binds to — without it a standalone bgp
 # object is accepted but never renders to FRR (see xcsh #1207).
 resource "xcsh_securemesh_site_v2" "this" {
+  count       = var.create_site ? 1 : 0
   name        = var.site_name
   namespace   = "system"
   description = "MCN CE-HA (BGP/ECMP) single-node SMSv2 site ${var.site_name} — explicit eth0 SLO interface for BGP peer binding."
@@ -256,7 +257,7 @@ resource "xcsh_bgp" "this" {
     site {
       ref {
         namespace = "system"
-        name      = xcsh_securemesh_site_v2.this.name
+        name      = var.site_name
       }
       network_type = "VIRTUAL_NETWORK_SITE_LOCAL"
       disable_internet_vip {}
@@ -283,7 +284,7 @@ resource "xcsh_bgp" "this" {
 
       external {
         asn     = var.rs_asn
-        address = var.rs_peer_ips[peers.value]
+        address = try(var.rs_peer_ips[peers.value], "")
         port    = var.peer_port
 
         interface {

--- a/docs/_includes/terraform/modules/xc-site/outputs.tf
+++ b/docs/_includes/terraform/modules/xc-site/outputs.tf
@@ -1,6 +1,6 @@
 output "site_name" {
   description = "XC securemesh_site_v2 name."
-  value       = xcsh_securemesh_site_v2.this.name
+  value       = var.site_name
 }
 
 output "bgp_name" {

--- a/docs/_includes/terraform/modules/xc-site/variables.tf
+++ b/docs/_includes/terraform/modules/xc-site/variables.tf
@@ -69,6 +69,12 @@ variable "enable_bgp" {
   default     = true
 }
 
+variable "create_site" {
+  description = "Create the xcsh_securemesh_site_v2 resource object. Set false when the site object is auto-provisioned by registration approval."
+  type        = bool
+  default     = true
+}
+
 variable "approve_registration" {
   description = "Approve the CE's runtime registration (named r-<uuid>, resolved from the site name by the xcsh_site_registration data source) instead of clicking Approve in the console. Two-phase by nature: the registration does not exist until the CE has booted and registered via the token, so the first apply plans no approval and a later apply creates it. For a CE that is ALREADY approved/ONLINE, import the existing approval (namespace/r-<uuid>, see the note in main.tf) rather than letting Terraform create it, since re-approving a non-NEW registration may be rejected. Set false to leave approval to an operator."
   type        = bool

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -450,6 +450,7 @@ module "xc_site_ca" {
   for_each = try(module.ce_topology_ca[0].ce_nodes, {})
   source   = "./modules/xc-site"
 
+  create_site          = false
   site_name            = each.value.site_name
   hostname             = each.value.hostname
   interface_name       = each.value.interface_name
@@ -550,17 +551,6 @@ resource "xcsh_http_loadbalancer" "canada" {
   }
 
   advertise_custom {
-    advertise_where {
-      virtual_site {
-        network = "SITE_NETWORK_OUTSIDE"
-        virtual_site {
-          namespace = data.xcsh_namespace.mcn.name
-          name      = try(xcsh_virtual_site.canada_re[0].name, null)
-        }
-      }
-      use_default_port {}
-    }
-
     dynamic "advertise_where" {
       for_each = try(module.ce_topology_ca[0].ce_nodes, {})
       content {

--- a/terraform/modules/xc-site/main.tf
+++ b/terraform/modules/xc-site/main.tf
@@ -28,6 +28,7 @@ resource "terraform_data" "ce_vm" {
 # (var.interface_name) that the BGP peer binds to — without it a standalone bgp
 # object is accepted but never renders to FRR (see xcsh #1207).
 resource "xcsh_securemesh_site_v2" "this" {
+  count       = var.create_site ? 1 : 0
   name        = var.site_name
   namespace   = "system"
   description = "MCN CE-HA (BGP/ECMP) single-node SMSv2 site ${var.site_name} — explicit eth0 SLO interface for BGP peer binding."
@@ -256,7 +257,7 @@ resource "xcsh_bgp" "this" {
     site {
       ref {
         namespace = "system"
-        name      = xcsh_securemesh_site_v2.this.name
+        name      = var.site_name
       }
       network_type = "VIRTUAL_NETWORK_SITE_LOCAL"
       disable_internet_vip {}
@@ -283,7 +284,7 @@ resource "xcsh_bgp" "this" {
 
       external {
         asn     = var.rs_asn
-        address = var.rs_peer_ips[peers.value]
+        address = try(var.rs_peer_ips[peers.value], "")
         port    = var.peer_port
 
         interface {

--- a/terraform/modules/xc-site/outputs.tf
+++ b/terraform/modules/xc-site/outputs.tf
@@ -1,6 +1,6 @@
 output "site_name" {
   description = "XC securemesh_site_v2 name."
-  value       = xcsh_securemesh_site_v2.this.name
+  value       = var.site_name
 }
 
 output "bgp_name" {

--- a/terraform/modules/xc-site/variables.tf
+++ b/terraform/modules/xc-site/variables.tf
@@ -69,6 +69,12 @@ variable "enable_bgp" {
   default     = true
 }
 
+variable "create_site" {
+  description = "Create the xcsh_securemesh_site_v2 resource object. Set false when the site object is auto-provisioned by registration approval."
+  type        = bool
+  default     = true
+}
+
 variable "approve_registration" {
   description = "Approve the CE's runtime registration (named r-<uuid>, resolved from the site name by the xcsh_site_registration data source) instead of clicking Approve in the console. Two-phase by nature: the registration does not exist until the CE has booted and registered via the token, so the first apply plans no approval and a later apply creates it. For a CE that is ALREADY approved/ONLINE, import the existing approval (namespace/r-<uuid>, see the note in main.tf) rather than letting Terraform create it, since re-approving a non-NEW registration may be rejected. Set false to leave approval to an operator."
   type        = bool

--- a/terraform/tests/ce_replacement.tftest.hcl
+++ b/terraform/tests/ce_replacement.tftest.hcl
@@ -59,7 +59,7 @@ run "site_is_keyed_to_the_ce_vm_instance_id" {
   # not rename it. A renamed site would orphan the bgp object and the LB
   # advertise rule, which both reference it by name.
   assert {
-    condition     = xcsh_securemesh_site_v2.this.name == "mcn-ce-ha-eastus01"
+    condition     = one(xcsh_securemesh_site_v2.this).name == "mcn-ce-ha-eastus01"
     error_message = "The instance-id coupling must not change the site name."
   }
 }

--- a/terraform/tests/xc_site.tftest.hcl
+++ b/terraform/tests/xc_site.tftest.hcl
@@ -36,7 +36,7 @@ run "site_and_interface_binding" {
   }
 
   assert {
-    condition     = xcsh_securemesh_site_v2.this.namespace == "system"
+    condition     = one(xcsh_securemesh_site_v2.this).namespace == "system"
     error_message = "The site must be created in the system namespace."
   }
 
@@ -54,14 +54,14 @@ run "site_and_interface_binding" {
   # which would change the data path.
   assert {
     condition = (
-      xcsh_securemesh_site_v2.this.performance_enhancement_mode.perf_mode_l7_enhanced.jumbo_disabled != null
+      one(xcsh_securemesh_site_v2.this).performance_enhancement_mode.perf_mode_l7_enhanced.jumbo_disabled != null
     )
     error_message = "perf_mode_l7_enhanced must declare the jumbo_disabled arm."
   }
 
   assert {
     condition = (
-      xcsh_securemesh_site_v2.this.performance_enhancement_mode.perf_mode_l7_enhanced.jumbo_enabled == null
+      one(xcsh_securemesh_site_v2.this).performance_enhancement_mode.perf_mode_l7_enhanced.jumbo_enabled == null
     )
     error_message = "perf_mode_l7_enhanced must NOT select jumbo_enabled: jumbo_disabled is the arm F5 materialises, and switching arms changes the CE data path."
   }


### PR DESCRIPTION
## Summary

Refine xc-site module for auto-provisioned sites.

Fixes #857

## Test plan
- [x] CI checks pass