### PR TITLE
fix(security): sanitize Azure subscription ID PII in terraform variables

### DIFF
--- a/docs/_includes/terraform/variables_azure.tf
+++ b/docs/_includes/terraform/variables_azure.tf
@@ -5,7 +5,7 @@
 variable "subscription_id" {
   description = "Azure subscription ID used by the azurerm provider."
   type        = string
-  # Default = the f5-AZR_4261_SALES_SA_ALL subscription the lab was built in.
+  # Default = the <AZURE_SUBSCRIPTION_ID> subscription the lab was built in.
   default = "00000000-0000-0000-0000-000000000000"
 }
 

--- a/terraform/variables_azure.tf
+++ b/terraform/variables_azure.tf
@@ -5,7 +5,7 @@
 variable "subscription_id" {
   description = "Azure subscription ID used by the azurerm provider."
   type        = string
-  # Default = the f5-AZR_4261_SALES_SA_ALL subscription the lab was built in.
+  # Default = the <AZURE_SUBSCRIPTION_ID> subscription the lab was built in.
   default = "00000000-0000-0000-0000-000000000000"
 }
 


### PR DESCRIPTION
Fixes #871

## Summary
Sanitize leaked Azure subscription ID (`AZR_4261_SALES_SA_ALL`) in `terraform/variables_azure.tf` and `docs/_includes/terraform/variables_azure.tf` by replacing it with `<AZURE_SUBSCRIPTION_ID>`.

## Verification
- `grep_search` confirmed 0 occurrences of `AZR_4261_SALES_SA_ALL` remain across the repo.
- `bash scripts/check-pii.sh --scope head --mode enforce` passed cleanly.
- `bash scripts/agy-pre-push-review.sh` passed cleanly with 0 blockers.