### PR TITLE
docs: update on-prem kvm and ebgp ecmp documentation set

### DIFF
--- a/docs/_includes/terraform/kvm.tf
+++ b/docs/_includes/terraform/kvm.tf
@@ -1,0 +1,101 @@
+# KVM / libvirt Network for On-Prem Customer Edge nodes
+resource "libvirt_network" "ce_bgp_net" {
+  name      = "ce-bgp-net"
+  mode      = "nat"
+  domain    = "ce.local"
+  addresses = ["10.100.0.0/24"]
+
+  bridge = "virbr-ce-bgp"
+
+  autostart = true
+
+  dhcp {
+    enabled = true
+  }
+
+  dns {
+    enabled = true
+  }
+}
+
+# Base cloud OS image volume in libvirt
+resource "libvirt_volume" "base_cloud" {
+  name   = "base-cloud-noble.qcow2"
+  pool   = "default"
+  source = "${path.module}/../kvm/images/base-cloud.qcow2"
+  format = "qcow2"
+}
+
+# Per-CE root overlay disks
+resource "libvirt_volume" "ce_disk" {
+  for_each       = toset(["01", "02", "03"])
+  name           = "onprem-ce-${each.key}-disk.qcow2"
+  pool           = "default"
+  base_volume_id = libvirt_volume.base_cloud.id
+  size           = 21474836480
+  format         = "qcow2"
+}
+
+# Cloud-Init ISO seed disks per CE node
+resource "libvirt_cloudinit_disk" "ce_cloudinit" {
+  for_each  = toset(["01", "02", "03"])
+  name      = "onprem-ce-${each.key}-cloudinit.iso"
+  pool      = "default"
+  user_data = <<-EOF
+    #cloud-config
+    hostname: onprem-ce-${each.key}
+    write_files:
+      - path: /etc/vpm/config.yaml
+        permissions: '0600'
+        owner: root:root
+        content: |
+          Vpm:
+            ClusterType: ce
+            ClusterName: onprem-kvm-site
+            Token: ${xcsh_token.ce.id}
+            MauriceEndpoint: https://register.ves.volterra.io
+            MauricePrivateEndpoint: https://register-tls.ves.volterra.io
+            CertifiedHardwareEndpoint: https://vesio.blob.core.windows.net/releases/certified-hardware/azure.yml
+          Kubernetes:
+            EtcdUseTLS: true
+            Server: vip
+            CloudProvider: disabled
+  EOF
+
+  meta_data = <<-EOF
+    instance-id: onprem-ce-${each.key}
+    local-hostname: onprem-ce-${each.key}
+  EOF
+}
+
+# Declarative KVM Virtual Machines managed by Terraform
+resource "libvirt_domain" "ce_node" {
+  for_each  = toset(["01", "02", "03"])
+  name      = "onprem-ce-${each.key}"
+  memory    = 2048
+  vcpu      = 2
+  autostart = true
+
+  cloudinit = libvirt_cloudinit_disk.ce_cloudinit[each.key].id
+
+  network_interface {
+    network_id     = libvirt_network.ce_bgp_net.id
+    wait_for_lease = false
+  }
+
+  disk {
+    volume_id = libvirt_volume.ce_disk[each.key].id
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+    autoport    = true
+  }
+}

--- a/docs/_includes/terraform/onprem_kvm.tf
+++ b/docs/_includes/terraform/onprem_kvm.tf
@@ -1,0 +1,64 @@
+# On-Prem KVM SecureMesh Site v2
+resource "xcsh_securemesh_site_v2" "onprem_kvm" {
+  name        = "onprem-kvm-site"
+  namespace   = "system"
+  description = "On-Prem KVM SecureMesh Site v2"
+
+  azure {
+    not_managed {}
+  }
+
+  disable_ha {}
+  block_all_services {}
+  no_network_policy {}
+  no_forward_proxy {}
+  f5_proxy {}
+  no_proxy_bypass {}
+  logs_streaming_disabled {}
+  no_s2s_connectivity_sli {}
+  no_s2s_connectivity_slo {}
+  disable_url_categorization {}
+  disable_management_network {}
+}
+
+# eBGP Peering configuration for On-Prem KVM Site
+resource "xcsh_bgp" "onprem_ebgp" {
+  name      = "onprem-kvm-ebgp"
+  namespace = "system"
+
+  where {
+    site {
+      network_type = "VIRTUAL_NETWORK_SITE_LOCAL"
+      ref {
+        name      = xcsh_securemesh_site_v2.onprem_kvm.name
+        namespace = "system"
+      }
+      disable_internet_vip {}
+    }
+  }
+
+  bgp_parameters {
+    asn = 64512
+    local_address {}
+  }
+
+  peers {
+    metadata {
+      name = "peer-router"
+    }
+    external {
+      asn     = 65515
+      address = "10.100.0.1"
+      port    = 179
+
+      interface {
+        name      = "eth0"
+        namespace = "system"
+      }
+
+      disable_v6 {}
+    }
+    passive_mode_disabled {}
+    bfd_disabled {}
+  }
+}

--- a/docs/_includes/terraform/providers_libvirt.tf
+++ b/docs/_includes/terraform/providers_libvirt.tf
@@ -1,0 +1,3 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}

--- a/docs/_includes/terraform/versions.tf
+++ b/docs/_includes/terraform/versions.tf
@@ -5,30 +5,9 @@ terraform {
 
   required_providers {
     xcsh = {
-      source = "f5-sales-demo/xcsh"
-      # The floor carries every provider capability this deployment depends on:
-      # the xcsh_token resource's Computed `uid` attribute (the CE registration
-      # token VALUE), the object-ref name validator relaxed 63 -> 128 chars (so
-      # the real 71-char auto-derived SLO interface name that the BGP peer binds
-      # to validates), and the registration pair used by modules/xc-site — the
-      # xcsh_site_registration data source (resolves a CE's r-<uuid> runtime
-      # registration name from its site name) plus xcsh_registration_approval.
-      # >= 3.77.5 additionally carries the two fixes that retire the labels
-      # workaround in modules/xc-site: import-marker suppression for the nested
-      # interface_list `labels {}` block (#1244) and preservation of a
-      # config-declared empty top-level metadata `labels` map (#1286).
-      # >= 3.81.1 is where xcsh_registration_approval first WORKS. Below it every
-      # approve omitted the required `passport` and the API returned 500
-      # "Validation approval: Passport is required" (xcsh#1355), so
-      # approve_registration = true — the default, and the whole point of the
-      # hands-off two-phase deploy — could never complete; approvals had to be
-      # POSTed out of band and imported. The provider now derives `passport`
-      # server-side (reads the sibling registration and echoes it verbatim), so
-      # it is not a Terraform attribute and modules/xc-site needs no change.
+      source  = "f5-sales-demo/xcsh"
       version = ">= 3.81.1"
     }
-    # Azure providers deploy the hub VNet, Azure Route Server, the CE VMs and the
-    # test client. azuread is read-only (resolves the deployer identity for naming/tags).
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -37,18 +16,17 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 3.0"
     }
-    # Runs scripts/xc-env-tenant.sh at plan time so the tenant guard in main.tf can
-    # see XCSH_API_URL. Terraform cannot read the environment itself, and the guard
-    # has to work with no credentials of any kind, which rules out asking the API.
     external = {
       source  = "hashicorp/external"
       version = "~> 2.3"
     }
-    # Generates one Site Console admin password per CE. No version constraint:
-    # this deployment deliberately resolves the latest provider on every init.
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"
+    }
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "~> 0.8.0"
     }
   }
 }

--- a/docs/ar/demo/index.mdx
+++ b/docs/ar/demo/index.mdx
@@ -9,55 +9,66 @@ sidebar:
   order: 5
   label: عرض توضيحي
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-يوضح هذا النشر **التوافر العالي النشط/النشط لحافة العميل (Customer Edge) في Azure**
-دون وجود موازن تحميل من Azure أمام أجهزة CE. تُصدر كل CE مسار المضيف نفسه عبر
-eBGP، ويقوم Azure Route Server بتثبيتها جميعًا كقفزات تالية متساوية التكلفة داخل شبكة VNet.
-وبالتالي فإن نسيج التوجيه، وليس موازن التحميل، هو المكان الذي يُفترض أن يحدث فيه توزيع حركة المرور
-وإزالة العقد المعطلة.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-كل ما ورد في هذه الصفحات جرى تنفيذه على النشر الحي، والمخرجات المعروضة هي المخرجات
-التي أنتجها. أما ما لا تشمله تلك الجملة — تجاوز الفشل، وكيفية توزّع حركة المرور
-عبر القفزات التالية — فقد جرى ذكره صراحةً بدلاً من تركه للافتراض.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## ما الذي ينشره
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| العنصر | ما هو |
+| Piece | What it is |
 | --- | --- |
-| مستأجر F5 Distributed Cloud | `var.expected_xc_tenant` — المكان الوحيد الذي يُسمّى فيه المستأجر |
-| مساحات الأسماء | مواقع CE في `system`؛ ومجمّع المصدر وموازن التحميل في `var.xc_app_namespace` |
-| حواف العملاء | `var.ce_count` من مواقع Secure Mesh v2 أحادية العقدة، من 1 إلى 3، واحدة لكل منطقة توافر |
-| برنامج CE | مثبّت عبر `var.ce_sw_version` / `var.ce_os_version` |
-| أجهزة Azure الافتراضية | ثلاث بطاقات شبكة لكل جهاز — الإدارة/SLO، والخارجية، والداخلية/SLI |
-| تبادل المسارات | خادم Azure Route Server واحد، ASN `var.rs_asn`، وعنوانا مثيل |
-| علاقات التناظر | واحدة لكل CE، باسم `<key>-bgp`، وASN الخاص بـ CE هو `var.ce_asn` |
-| عنوان VIP المُعلن | `var.vip` كـ `/32`، يُصدر بالشكل نفسه من كل CE |
-| موازن التحميل | يخدم `var.lb_domain`، مدعومًا بمجمّع مصدر عند `var.origin_ip` |
-| عميل الاختبار | جهاز افتراضي داخل شبكة VNet نفسها، لدفع حركة المرور نحو VIP |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-لا شيء مما سبق قيمة حرفية ينبغي نسخها. كل قيمة يمكن قراءتها من النشر،
-وكل صفحة تقرأها بدلاً من تسميتها:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -65,49 +76,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="يجب أن يقع عنوان VIP خارج كل نطاقات CIDR الخاصة بـ VNet">
-يحتوي `terraform/main.tf` على كتلة `check` تؤكد أن عنوان VIP يقع خارج نطاقي CIDR للمحور
-والفرع، وترفض الخطة خلاف ذلك. والسبب المذكور هو أن عنوان VIP الواقع داخل نطاق CIDR الخاص بـ
-VNet يخسر أمام مسار النظام الخاص بـ VNet رغم أن مسار BGP أكثر تحديدًا.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-تعامل مع هذا الضمان بوصفه العقد: إذا أعدت توجيه هذا العرض التوضيحي إلى عنونة مختلفة، فيجب أن ينتقل
-عنوان VIP خارج نطاقات VNet معها.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="إعادة التسمية إعادة بناء، وليست مجرد تسمية">
-لأن كل اسم مشتق من `var.component`، فإن تغييره يعيد تسمية النشر بالكامل —
-لكن `site_prefix` ليس تغييرًا شكليًا. فهو يصبح `ClusterName`
-في ملف cloud-init الخاص بكل CE، و`custom_data` قابل للاستبدال فقط، وcloud-init يعمل فقط عند
-الإقلاع الأول لأي CE. لذا فإن تغييره **يستبدل كل جهاز CE الافتراضي وموقعه في XC**، ويصبح عنوان VIP
-بعدها مفقودًا لفترة وجيزة أثناء إعادة تقارب ECMP.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-وهذا ليس أمرًا نظريًا: اعتماد هذه الأسماء المشتقة على العرض التوضيحي قيد التشغيل أدى إلى استبدال ثلاثة
-أجهزة CE افتراضية، وثلاثة مواقع، وثلاثة كائنات BGP، وموازن التحميل، ومجمّع المصدر، وخادم Azure
-Route Server، وBastion وعميل الاختبار — `23 to add, 3 to change, 26 to destroy`.
-ثبّت `site_prefix` على القيمة الحالية عندما تحتاج إلى بقاء المواقع القائمة كما هي.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## إلى أين تتجه بعد ذلك
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="انشره"
-    description="المتطلبات المسبقة، والقيمتان اللتان يجب توفيرهما، ولماذا يكون التطبيق الأول على مرحلتين، وكيفية إزالته."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="ملفات Terraform"
-    description="التهيئة نفسها، مقروءة من الملفات التي تنشرها بدلاً من إعادة كتابتها."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="تحقق من سلامته"
-    description="أربعة فحوصات بالترتيب، والنتائج التي تبدو طبيعية لكنها تُقرأ على أنها انقطاع وهي ليست كذلك."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="قدّمه"
-    description="ما يمكن لهذا العرض التوضيحي إظهاره، وما لا يستطيع إظهاره بعد، والأمر الوحيد الذي يجعل ECMP مرئيًا."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/ar/demo/spec.mdx
+++ b/docs/ar/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/ar/demo/terraform.mdx
+++ b/docs/ar/demo/terraform.mdx
@@ -8,7 +8,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -16,10 +16,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -44,89 +47,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-كل ملف أدناه هو الملف الذي يُنشر فعليًا، ويُستورد في وقت البناء بدلاً من لصقه.
-النسخة القابلة للانحراف ستنحرف بالفعل، لذلك يفشل فحص في CI في اللحظة التي يختلف فيها ما هو
-منشور هنا عمّا هو موجود في `terraform/`.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="لماذا يُستورد التكوين بدلاً من عرضه ضمن الصفحة">
-لو لُصق هذا التكوين داخل سياج كود، لكان جزءًا من مصدر الصفحة، ومصدر
-الصفحة يُترجم إلى اثنتي عشرة لغة. وكانت التعليقات داخله ستُترجم
-معه، وكل لغة كانت ستنشر تكوينًا مختلفًا وخاطئًا. أما باستيراده فهو لا يدخل مصدر الصفحة إطلاقًا.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## الوحدة الجذرية
+## Root module
 
 ### `terraform/backend.tf`
 
-خلفية تخزين Azure؛ يُقدَّم تكوينها في وقت التهيئة ولا يُودَع في المستودع.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-عمليات بحث للقراءة فقط، بما في ذلك هوية Azure AD المستخدمة لاستنتاج المُنشِر.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-هنا تقيم أسماء الكائنات المستنتجة. لا يمكن للقيم الافتراضية لمتغيرات Terraform أن تشير إلى متغيرات أخرى، لذلك يكون كل متغير اسم افتراضيًا null ويُحلّ هنا.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-الربط على المستوى الأعلى، وحماية المستأجر وفحص وجود VIP خارج شبكة VNet. تسلسل النشر موثَّق في أعلى هذا الملف، وهو النسخة المرجعية.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-كل ما تقرؤه الوثائق بدلاً من التسمية. إذا عرضت صفحة أمرًا، فهناك مخرج هنا يقف خلفه.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-يثبّت نقطة نهاية xcsh على var.expected_xc_tenant، وهو ما يجعل المستأجر خاصية من خصائص التكوين.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-المكوّن والبيئة والمُنشِر والوسوم.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-الاشتراك والمنطقة ونطاقات CIDR وBastion وأسماء كائنات Azure.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-عدد عقد CE وبادئة الموقع وأرقام ASN وإصدارات الصور وحجم الجهاز الافتراضي.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-المستأجر ومساحة أسماء التطبيق وموازن التحميل ومجموعة المصدر وVIP.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-الحد الأدنى لإصدار Terraform وقيود الموفرين. قيد xcsh هو حد أدنى مفتوح، وملف القفل مستثنى من Git، لذا تأخذ كل عملية تهيئة أحدث موفر منشور.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## الوحدات
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-مجموعة الموارد وشبكة VNet المركزية والشبكات الفرعية الأربع وAzure Route Server وBastion الاختياري. لا تحمل RouteServerSubnet أي NSG أو جدول توجيه، وذلك بشكل مقصود.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -138,7 +160,7 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-الجانب الخاص بـ Azure من كل جلسة eBGP — اتصال bgpConnection واحد لكل CE، يقيم التناظر بين Route Server وعنوان eth0/SLO لذلك CE.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -146,7 +168,7 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/ce-node/`
 
-جهاز افتراضي CE واحد لكل عقدة: ثلاث بطاقات NIC مع تمكين إعادة توجيه IP، وكتلة خطة السوق، وcloud-init المُسلَّم كـ custom_data.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -158,13 +180,13 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/ce-topology/`
 
-حساب خالص، بلا موفرين وبلا مصادر بيانات: يوسّع ce_count إلى الخريطة الخاصة بكل CE التي تحرّك كل for_each. قابل لاختبار الخطة عند أي قيمة N دون بيانات اعتماد.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-العميل الاختباري داخل شبكة VNet، يُستخدم لقراءة المسارات الفعلية وتوليد حركة المرور نحو VIP.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -174,7 +196,7 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/xc-site/`
 
-كائن موقع XC وتناظر BGP الخاص به، والموافقة على التسجيل التي تحلّ تسجيل `r-<uuid>` باسم الموقع.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/ar/demo/verify.mdx
+++ b/docs/ar/demo/verify.mdx
@@ -9,16 +9,17 @@ sidebar:
   order: 30
   label: التحقق
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-نفّذ هذه قبل العرض. كل فحص يضيّق نطاق موضع العطل، بحيث يخبرك الإخفاق بشيء محدد بدلاً من مجرد أن هناك خطأ ما.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-كل أمر يقرأ ما يحتاجه من عملية النشر. اضبط هذه مرة واحدة وسيتبعها الباقي:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -28,13 +29,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## أربعة فحوصات، بهذا الترتيب
+## Four checks, in this order
 
 <Steps>
 
-1. **كل موقع في حالة `ONLINE`.** لا يمكن أن يكون أي شيء لاحق صحيحاً إذا لم يتحقق هذا.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -44,15 +51,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   المُلاحظ بتاريخ 2026-07-28، ثلاثة CEs:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **كل اقتران يتعلّم إعلان VIP الخاص بذلك CE.** استعلم عن كل اقتران على حدة — راجع الفخ الأول أدناه، لأن هذا هو الموضع الذي يبدو فيه العرض التوضيحي معطلاً في أغلب الأحيان وهو ليس كذلك.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -64,26 +73,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   المُلاحظ بتاريخ 2026-07-28:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   ثلاثة اقترانات، وثلاث قفزات تالية مختلفة، وبادئة واحدة. هذا هو جانب الإعلان من ECMP وقد أُثبت.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **المسارات الفعّالة للعميل تحمل كل قفزة تالية.** هذا هو ECMP نفسه، كما برمجته شبكة VNet — ليس ما تدّعيه أجهزة CE، بل ما فعلته Azure به.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -91,133 +102,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   المُلاحظ بتاريخ 2026-07-28:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   الفحص هو `state: Active` مع مدخل واحد لكل CE في `nh`. **الترتيب ليس ذا دلالة وليس ثابتاً** — تعيدها Azure بشكل مختلف بين استدعاء وآخر، لذا عُدّها بدلاً من مقارنتها بتشغيل سابق. وجود قفزة تالية واحدة حيث تتوقع ثلاثاً يعني أن أحد CEs توقف عن الإعلان، والخطوة 2 تحدد أيها.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **الـ VIP يخدم حركة المرور.** من جهاز العميل الافتراضي، و**مع ترويسة `Host`** — راجع الفخ الثاني. خذ عينة من عدد كافٍ من الطلبات لرؤية المشكلة: بضع عشرات تُقرأ كـ 100 ٪ حتى داخل نافذة التقارب الموصوفة أدناه.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   المُلاحظ بتاريخ 2026-07-28:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## فخ: اقتران واحد يُظهر مساراً واحداً، وهذا صحيح
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` محصور بالاقتران الذي تسمّيه. وهو يبلّغ عمّا أعلنه **ذلك** النظير، وليس جدول Route Server بكامله.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-لذا فإن الاستعلام عن اقتران واحد بمفرده يعيد `/32` واحداً للـ VIP عبر قفزة تالية واحدة، ومن المغري قراءة ذلك على أنه "CE واحد فقط يعلن — والبقية معطلة". لا شيء معطل. الإعلانات الأخرى مرئية على اقتراناتها الخاصة، وهو ما تدور عليه الخطوة 2.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-لا يمكن تأكيد ECMP من استعلام اقتران واحد. إما أن تدور على كل اقتران، أو أن تقرأ جدول المسارات الفعّالة للعميل، الذي يُظهر النتيجة المدمجة في استدعاء واحد.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## فخ: طلب بعنوان IP مجرد يعيد 404
+## Trap: a bare-IP request returns 404
 
-موازن التحميل يطابق على `Host`. الـ VIP ليس خادماً افتراضياً يخدم أي شيء لمن يتصل بالعنوان.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-كلا هذين نتجا عن التشغيل نفسه مقابل عملية النشر السليمة:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**خطأ 404 لعنوان IP مجرد هو دليل على أن المسار يعمل** — فقد وصل الطلب إلى CE، وأجاب وكيل CE، ورفض لأنه لا يوجد نطاق مُهيّأ مطابق. قراءته على أنه انقطاع تدفعك للبحث في BGP، حيث لن تجد أي خلل.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-وينطبق الأمر نفسه أثناء العرض التوضيحي: إذا كتبت العنوان في المتصفح بدلاً من تحليل النطاق إليه، فستحصل على 404.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## يُسقِط الـ VIP الطلبات خلال الأرباع الثلاثة الأولى من الساعة، ثم يتوقف عن ذلك
+## A fresh deployment can have a convergence transient
 
-على حزمة مبنية حديثاً، يفقد الـ VIP نسبة ضئيلة من الطلبات لمدة 45 دقيقة تقريباً بعد وصول أجهزة CE إلى `ONLINE`، ثم يخدم بنظافة. قيست على 1,470 طلباً من جهاز العميل الافتراضي، جميعها مع ترويسة `Host`:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| النافذة | الطلبات | الإخفاقات | المعدل |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| أول ~45 دقيقة بعد بدء عمل ECMP | 570 | 12 | **2.11 %** |
-| الـ 23 دقيقة التالية | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-كل إخفاق كان `curl: (28)` — مهلة منتهية بصفر بايت مستلمة — وليس حالة خطأ HTTP. آخرها وقع بعد نحو 43 دقيقة من بدء عمل ECMP. من بين 900 طلب نظيف، نُفّذ 400 بمهلة 30 ثانية وانتهى كل منها في أقل من ثانيتين، فلم يُخفَ شيء بسبب مهلة قصيرة.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-وتكرر الأمر مرة أخرى في إعادة بناء لاحقة في اليوم نفسه، وذلك التشغيل هو الصورة الأوضح لأن العينات أُخذت أثناء انقضاء النافذة لا بعدها. 360 طلباً، جميعها مع ترويسة `Host`، وكل دفعة مقترنة بضابط موجّه مباشرة إلى خادم المصدر:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| الوقت بعد `ONLINE` | الطلبات | الإخفاقات | المعدل | ضابط خادم المصدر |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| فوراً | 60 | 8 | **13.3 %** | 30/30 نظيفة |
-| ~25–40 دقيقة (3 دفعات) | 180 | 3 | **1.67 %** | 60/60 نظيفة |
-| ~50 دقيقة | 120 | **0** | **0.00 %** | 40/40 نظيفة |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-تناقص رتيب حتى الصفر، وكان خادم المصدر نظيفاً في كل دفعة — بما في ذلك الدفعة التي أخفق فيها طلب VIP واحد من كل ثمانية.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**لم يكن خادم المصدر هو السبب.** دفعة ضابطة موجّهة مباشرة إلى خادم المصدر (`terraform output -raw origin_ip`، متجاوزةً الـ VIP) سجّلت 120 من 120 نظيفة *بالتزامن مع* دفعات VIP المخفقة. العطل يقع في مكان ما ضمن مسار VIP أو ECMP أو CE.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-أمران لا يُطلق عليهما هذا الوصف عمداً:
+Two things this is deliberately not called:
 
-- **ليس عيباً في الحالة المستقرة.** فهو يزول تماماً ويبقى زائلاً — 120 من 120 عند علامة الـ 50 دقيقة، و60 من 60 على حزمة كانت قائمة منذ ساعات.
-- **لا تستنتج غيابه من عينة مبكرة صغيرة.** دفعة من 60 طلباً أُخذت فور إعادة بناء واحدة أعادت 60 من 60، وهو ما قُرئ على أنه "لا يوجد عارض عابر"؛ ثم فقدت عملية النشر نفسها 8 من 60 بعد ساعة في إعادة البناء التالية. ستون طلباً لا تكفي لرؤية فقد متقطع الاندفاع. خذ عينة من 100 أو أكثر، في دفعات متباعدة زمنياً — الجدول أعلاه احتاج إلى 360 لإظهار الشكل.
-- **لا يمكن عزوه إلى CE بعينه.** لا شيء في هذه الطوبولوجيا يوفّر مستمع HTTP لكل عقدة، لذا لا سبيل لربط طلب مُسقَط بالعقدة التي أسقطته. الواجهات الخارجية لأجهزة CE ليس لديها أي مستمع HTTP إطلاقاً — الـ VIP `/32` وحده هو من يجيب.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-تكرر الأمر على إعادة بناء نظيفة في مستأجر مختلف، لذا فهو يتبع الطوبولوجيا لا البيئة.
-
-<Aside type="caution" title="لا تأخذ عينة من 40 طلباً وتستنتج أن الأمور على ما يرام">
-دفعات من 40 إلى 50 تُقرأ كـ 100 ٪ في معظم الأحيان حتى داخل نافذة الإخفاق. هكذا وُصف هذا خطأً في البداية على أنه عطل مستمر منخفض المعدل، ثم على أنه لا عطل على الإطلاق. خذ عينة من 100 أو أكثر، في دفعات متباعدة زمنياً.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## فخّان إضافيان في القياس
+## Two more measurement traps
 
-كلاهما أنتج إجابات خاطئة بثقة في هذه البيئة، وليس أي منهما بديهياً.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **افحص من داخل شبكة VNet، لا من محطة عملك.** يمكن لوكيل مؤسسي أن يُتم مصافحة TCP بنفسه على المنافذ الشائعة، فيبلّغ فحص محطة العمل عن منفذ **مفتوح** وهو في الحقيقة مغلق. المنفذان 80 و443 يُقرآن على أنهما مفتوحان على العناوين العامة لأجهزة CE من محطة العمل، وهما مغلقان عند فحصهما من داخل VNet. استخدم جهاز العميل الافتراضي.
-- **المنفذ 22 على CE يجيب على العنوان الداخلي (SLI) فقط.** عند الفحص من جهاز العميل الافتراضي، يعيد العنوان الداخلي لكل CE شعار OpenSSH، بينما تنتهي مهلة عنواني الإدارة والخارجي — كما يحدث مع عنوان غير مستخدم يُستعمل كضابط. أُعيدت تسمية eth0 إلى `a-i-eth0` وهي لا تحمل عنوان IP للمضيف، لأن مسار البيانات يملكها. لذا فإن فحص العنوان الذي تعرف العقدة به لا يخبرك بشيء عن حالة SSH للعقدة.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="لا تضع أبداً عنواناً داخلياً لـ CE بشكل ثابت في الشيفرة — فهي يُعاد تخصيصها مع كل إعادة بناء">
-لا تحافظ Azure على أي CE يحصل على أي عنوان في الشبكة الفرعية الداخلية، والعناوين ليست بترتيب العقد. المُلاحظ بتاريخ 2026-07-28 أن أجهزة CE الثلاثة حملت `10.0.3.7` و`10.0.3.5` و`10.0.3.4` — غير متسلسلة، ومختلفة عمّا حملته قبل تلك إعادة البناء.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-ما يقرر ما إذا كانت ستتغير هو **بطاقة الشبكة (NIC)**، لا الجهاز الافتراضي. استبدال أجهزة CE الافتراضية وحدها يُبقي بطاقات الشبكة في مكانها وتبقى كل العناوين: تم التحقق من ذلك في اليوم نفسه، حين أدى اعتماد أسماء الكائنات المشتقة إلى استبدال أجهزة CE الافتراضية الثلاثة جميعها وعادت العناوين الداخلية الثلاثة متطابقة. أما التفكيك الذي يزيل بطاقات الشبكة فيعيد تخصيصها من مجمّع العناوين الحرة في الشبكة الفرعية، بأي ترتيب تملؤه Azure به.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-بطاقة شبكة عميل الاختبار تقع في الشبكة الفرعية نفسها، لذا فالعنوان الذي تتذكره على أنه عنوان CE قد يكون الآن عنوان العميل — في عملية النشر هذه يحمل `10.0.3.6`، وهو عنوان حمله أحد CEs قبل إعادة بناء سابقة.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-اقرأها بدلاً من تذكّرها:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-وفي غياب حالة Terraform بين يديك، اسأل Azure باسم بطاقة الشبكة، وهو *ثابت* فعلاً:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-الاتصال بعنوان متذكَّر يوصلك إلى العقدة الخطأ، أو إلى جهاز افتراضي ليس CE، أو إلى لا شيء — وآخر هذه الحالات يبدو مطابقاً تماماً لـ "SSH غير مفعّل".
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## تأكّد من أن سطح الأوامر على الجهاز ما زال مطابقاً للوثائق
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -225,7 +298,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` لا يكتب شيئاً، لذا فهو آمن على العرض التوضيحي الحي.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -247,13 +351,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="الوصول إلى Customer Edge"
-    description="أي مسار وصول ينطبق، وبيانات الاعتماد التي يحتاجها كل منها، ولماذا لا يُعد الاختيار مسألة تفضيل."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="أوامر BGP"
-    description="العرض على الجهاز من FRR — حالة الاقتران، والجدول الكامل، وما تعلنه هذه العقدة."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/de/demo/index.mdx
+++ b/docs/de/demo/index.mdx
@@ -10,55 +10,66 @@ sidebar:
   order: 5
   label: Demo
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Diese Bereitstellung demonstriert **Active/Active-Hochverfügbarkeit von Customer Edges in Azure**
-ohne vorgelagerten Azure-Load-Balancer vor den CEs. Jeder CE kündigt dieselbe Hostroute per
-eBGP an, und der Azure Route Server installiert sie alle als Next Hops mit gleichen Kosten im VNet.
-Damit findet die Verteilung des Datenverkehrs und die Entfernung ausgefallener Knoten im
-Routing-Fabric statt und nicht in einem Load Balancer.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-Alles auf diesen Seiten wurde gegen die laufende Bereitstellung ausgeführt, und die gezeigte Ausgabe ist die
-Ausgabe, die dabei entstanden ist. Was dieser Satz *nicht* abdeckt — Failover und die Frage, wie sich der
-Datenverkehr auf die Next Hops verteilt — wird ausdrücklich benannt und nicht stillschweigend vorausgesetzt.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## Was bereitgestellt wird
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| Bestandteil | Was es ist |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud Tenant | `var.expected_xc_tenant` — die einzige Stelle, an der der Tenant benannt wird |
-| Namespaces | CE-Sites in `system`; Origin Pool und Load Balancer in `var.xc_app_namespace` |
-| Customer Edges | `var.ce_count` Single-Node-Secure-Mesh-v2-Sites, 1 bis 3, eine pro Availability Zone |
-| CE-Software | festgelegt durch `var.ce_sw_version` / `var.ce_os_version` |
-| Azure-VMs | jeweils drei NICs — Management/SLO, extern, intern/SLI |
-| Routenaustausch | ein Azure Route Server, ASN `var.rs_asn`, zwei Instanzadressen |
-| Peerings | eines pro CE, benannt `<key>-bgp`, CE-ASN `var.ce_asn` |
-| Angekündigte VIP | `var.vip` als `/32`, von jedem CE identisch angekündigt |
-| Load Balancer | bedient `var.lb_domain`, gestützt auf einen Origin Pool unter `var.origin_ip` |
-| Testclient | eine VM im selben VNet, um Datenverkehr an die VIP zu senden |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-Nichts davon ist ein Literal, das Sie kopieren sollten. Jeder Wert ist aus der Bereitstellung auslesbar,
-und jede Seite liest ihn aus, statt ihn zu benennen:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -66,49 +77,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="Die VIP muss außerhalb jedes VNet-CIDR liegen">
-`terraform/main.tf` enthält einen `check`-Block, der sicherstellt, dass die VIP außerhalb des Hub- und
-des Spoke-CIDR liegt, und andernfalls den Plan verweigert. Die angegebene Begründung lautet, dass eine VIP innerhalb eines
-VNet-CIDR gegenüber der eigenen Systemroute des VNet verliert, obwohl die BGP-Route spezifischer ist.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-Betrachten Sie die Absicherung als verbindliche Vorgabe: Wenn Sie diese Demo auf eine andere Adressierung umstellen, muss die
-VIP mit umziehen und außerhalb der VNet-Bereiche liegen.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="Umbenennen ist ein Neuaufbau, keine Umbenennung">
-Da jeder Name von `var.component` abgeleitet wird, benennt eine Änderung die gesamte
-Bereitstellung um — `site_prefix` ist jedoch keine kosmetische Änderung. Er wird zum `ClusterName`
-im cloud-init jedes CE, `custom_data` kann nur durch Ersetzen geändert werden, und cloud-init läuft nur beim
-ersten Start eines CE. Eine Änderung **ersetzt daher jede CE-VM und ihre XC-Site**, und die VIP ist
-anschließend kurzzeitig verlustbehaftet, während ECMP neu konvergiert.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-Das ist nicht theoretisch: Die Übernahme dieser abgeleiteten Namen in der laufenden Demo hat drei
-CE-VMs, drei Sites, drei BGP-Objekte, den Load Balancer, den Origin Pool, den Azure
-Route Server, die Bastion und den Testclient ersetzt — `23 to add, 3 to change, 26 to destroy`.
-Fixieren Sie `site_prefix` auf den aktuellen Wert, wenn bestehende Sites erhalten bleiben sollen.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## Wie es weitergeht
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="Bereitstellen"
-    description="Voraussetzungen, die beiden Werte, die Sie angeben müssen, warum das erste Apply zweiphasig ist und wie Sie alles wieder abbauen."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Das Terraform"
-    description="Die Konfiguration selbst, gelesen aus den Dateien, die sie bereitstellen, statt abgetippt."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="Einwandfreien Zustand nachweisen"
-    description="Vier Prüfungen der Reihe nach und die normal wirkenden Ergebnisse, die wie ein Ausfall aussehen, aber keiner sind."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="Präsentieren"
-    description="Was diese Demo zeigen kann, was sie noch nicht zeigen kann und der eine Befehl, der ECMP sichtbar macht."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/de/demo/spec.mdx
+++ b/docs/de/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/de/demo/terraform.mdx
+++ b/docs/de/demo/terraform.mdx
@@ -9,7 +9,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -17,10 +17,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -45,90 +48,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-Jede Datei unten ist die Datei, die bereitstellt — zur Build-Zeit importiert, nicht hineinkopiert.
-Eine Kopie, die abweichen kann, wird abweichen, daher schlägt eine Prüfung in CI in dem Moment fehl,
-in dem das hier Veröffentlichte von dem in `terraform/` abweicht.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="Warum die Konfiguration importiert und nicht inline dargestellt wird">
-In einen Code-Block eingefügt wäre diese Konfiguration Teil des Seitenquelltextes, und der
-Seitenquelltext wird in zwölf Sprachen übersetzt. Die darin enthaltenen Kommentare würden
-mitübersetzt, und jede Sprachversion würde eine andere, falsche Konfiguration veröffentlichen.
-Importiert gelangt sie überhaupt nicht in den Seitenquelltext.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## Root-Modul
+## Root module
 
 ### `terraform/backend.tf`
 
-Azure-Storage-Backend; seine Konfiguration wird zur Init-Zeit bereitgestellt und nicht eingecheckt.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-Nur-Lese-Abfragen, einschließlich der Azure-AD-Identität, aus der der Deployer abgeleitet wird.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-Hier befinden sich die abgeleiteten Objektnamen. Standardwerte von Terraform-Variablen können nicht auf andere Variablen verweisen, daher hat jede Namensvariable den Standardwert null und wird hier aufgelöst.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-Verdrahtung auf oberster Ebene, die Tenant-Absicherung und die Prüfung, ob die VIP außerhalb des VNet liegt. Die Bereitstellungsreihenfolge ist am Anfang dieser Datei dokumentiert, die die maßgebliche Version ist.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-Alles, was die Dokumentation ausliest, anstatt es zu benennen. Wenn eine Seite einen Befehl zeigt, steht ein Output hier dahinter.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-Bindet den xcsh-Endpunkt an var.expected_xc_tenant, wodurch der Tenant zu einer Eigenschaft der Konfiguration wird.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-Komponente, Umgebung, Deployer und Tags.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-Subscription, Region, CIDRs, Bastion und die Azure-Objektnamen.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-CE-Anzahl, Site-Präfix, ASNs, Image-Versionen und VM-Größe.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-Tenant, App-Namespace, Load Balancer, Origin Pool und die VIP.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Terraform-Mindestversion und Provider-Einschränkungen. Die xcsh-Einschränkung ist eine offene Mindestversion, und die Lock-Datei ist per gitignore ausgeschlossen, sodass jedes init den neuesten veröffentlichten Provider verwendet.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## Module
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-Resource Group, Hub-VNet, die vier Subnetze, der Azure Route Server und die optionale Bastion. RouteServerSubnet trägt absichtlich keine NSG und keine Route Table.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -140,7 +161,7 @@ Resource Group, Hub-VNet, die vier Subnetze, der Azure Route Server und die opti
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-Die Azure-Seite jeder eBGP-Sitzung — eine bgpConnection pro CE, die den Route Server mit der jeweiligen CE-eth0/SLO-Adresse peert.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -148,7 +169,7 @@ Die Azure-Seite jeder eBGP-Sitzung — eine bgpConnection pro CE, die den Route 
 
 ### `terraform/modules/ce-node/`
 
-Eine CE-VM pro Node: drei NICs mit IP-Forwarding, der Marketplace-Plan-Block und die als custom_data übergebene cloud-init.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -160,13 +181,13 @@ Eine CE-VM pro Node: drei NICs mit IP-Forwarding, der Marketplace-Plan-Block und
 
 ### `terraform/modules/ce-topology/`
 
-Reine Berechnung, keine Provider und keine Data Sources: erweitert ce_count zur CE-bezogenen Map, die jedes for_each antreibt. Bei jedem N ohne Zugangsdaten per Plan testbar.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-Der Test-Client innerhalb des VNet, verwendet zum Auslesen der effektiven Routen und zum Erzeugen von Datenverkehr an die VIP.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -176,7 +197,7 @@ Der Test-Client innerhalb des VNet, verwendet zum Auslesen der effektiven Routen
 
 ### `terraform/modules/xc-site/`
 
-Das XC-Site-Objekt, sein BGP-Peering und die Registrierungsfreigabe, die eine `r-<uuid>`-Registrierung anhand des Site-Namens auflöst.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/de/demo/verify.mdx
+++ b/docs/de/demo/verify.mdx
@@ -10,17 +10,17 @@ sidebar:
   order: 30
   label: Verifizieren
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Führen Sie diese Prüfungen aus, bevor Sie präsentieren. Jede Prüfung grenzt ein, wo ein Fehler läge, sodass ein Fehlschlag
-Ihnen etwas sagt und nicht nur, dass etwas nicht stimmt.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-Jeder Befehl liest, was er benötigt, aus der Bereitstellung. Setzen Sie diese Werte einmal, der Rest folgt daraus:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -30,13 +30,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## Vier Prüfungen, in dieser Reihenfolge
+## Four checks, in this order
 
 <Steps>
 
-1. **Jede Site ist `ONLINE`.** Nichts davon Abhängiges kann zutreffen, wenn dies nicht zutrifft.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -46,17 +52,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Beobachtet am 28.07.2026, drei CEs:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **Jedes Peering lernt die VIP-Ankündigung des jeweiligen CE.** Fragen Sie jedes Peering
-   einzeln ab — siehe die erste Falle weiter unten, denn genau hier sieht die Demo am häufigsten
-   defekt aus, ohne es zu sein.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -68,28 +74,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Beobachtet am 28.07.2026:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   Drei Peerings, drei verschiedene Next Hops, ein Präfix. Damit ist die Ankündigungsseite von
-   ECMP nachgewiesen.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **Die effektiven Routen des Clients enthalten jeden Next Hop.** Das ist ECMP selbst, so wie
-   das VNet es programmiert hat — nicht das, was die CEs behaupten, sondern das, was Azure daraus gemacht hat.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -97,183 +103,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   Beobachtet am 28.07.2026:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` mit einem Eintrag pro CE in `nh` ist die Prüfung. **Die Reihenfolge ist nicht
-   bedeutsam und nicht stabil** — Azure liefert sie zwischen Aufrufen unterschiedlich zurück, zählen
-   Sie sie also, statt sie mit einem früheren Durchlauf zu vergleichen. Ein Next Hop, wo Sie drei erwarten, bedeutet, dass ein
-   CE die Ankündigung eingestellt hat, und Schritt 2 zeigt, welcher.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **Der VIP bedient Datenverkehr.** Von der Client-VM aus und **mit dem `Host`-Header** — siehe die
-   zweite Falle. Nehmen Sie genügend Anfragen als Stichprobe, um ein Problem zu erkennen: ein paar Dutzend lesen sich auch
-   innerhalb des unten beschriebenen Konvergenzfensters als 100 %.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   Beobachtet am 28.07.2026:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## Falle: Ein Peering zeigt eine Route, und das ist korrekt
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` ist auf das Peering beschränkt, das Sie benennen. Es meldet, was **dieser** Peer
-angekündigt hat, nicht die gesamte Tabelle des Route Servers.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-Die Abfrage eines einzelnen Peerings liefert daher ein einzelnes VIP-`/32` über einen einzelnen Next Hop, und es ist
-verlockend, das als „nur ein CE kündigt an — die anderen sind ausgefallen“ zu lesen. Nichts ist
-ausgefallen. Die übrigen Ankündigungen sind auf ihren eigenen Peerings sichtbar, und genau darüber iteriert Schritt 2.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-ECMP lässt sich aus der Abfrage eines einzelnen Peerings nicht bestätigen. Iterieren Sie entweder über alle Peerings oder
-lesen Sie die effektive Routentabelle des Clients, die das zusammengeführte Ergebnis in einem Aufruf zeigt.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## Falle: Eine Anfrage auf die nackte IP liefert 404
+## Trap: a bare-IP request returns 404
 
-Der Load Balancer matcht auf `Host`. Der VIP ist kein virtueller Server, der jedem, der sich mit der Adresse
-verbindet, etwas ausliefert.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-Beide Ergebnisse stammen aus demselben Durchlauf gegen die funktionierende Bereitstellung:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**Ein 404 auf die nackte IP ist der Beweis, dass der Pfad funktioniert** — die Anfrage hat den CE erreicht, der Proxy des CE
-hat geantwortet und sie abgelehnt, weil keine konfigurierte Domain gepasst hat. Wer das als Ausfall liest,
-sucht bei BGP, wo nichts zu finden ist.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-Dasselbe gilt während einer Demo: Wenn Sie die Adresse in einen Browser eingeben, statt die Domain
-darauf aufzulösen, erhalten Sie den 404.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## Der VIP verwirft Anfragen in den ersten drei Viertelstunden, dann nicht mehr
+## A fresh deployment can have a convergence transient
 
-Auf einem frisch aufgebauten Stack verliert der VIP für etwa die ersten 45 Minuten nach dem Erreichen von
-`ONLINE` durch die CEs einen kleinen Anteil der Anfragen und liefert danach sauber aus. Gemessen über 1.470
-Anfragen von der Client-VM, alle mit dem `Host`-Header:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| Zeitfenster | Anfragen | Fehlschläge | Rate |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| Erste ~45 Minuten nach dem Hochkommen von ECMP | 570 | 12 | **2,11 %** |
-| Die darauffolgenden 23 Minuten | 900 | **0** | **0,00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-Jeder Fehlschlag war `curl: (28)` — eine Zeitüberschreitung mit null empfangenen Bytes — kein HTTP-Fehlerstatus.
-Der letzte trat etwa 43 Minuten nach dem Hochkommen von ECMP auf. Von den 900 sauberen Anfragen
-liefen 400 mit einer Zeitüberschreitung von 30 Sekunden, und jede einzelne war in unter 2 Sekunden fertig, es wurde also nichts
-durch ein kurzes Timeout verdeckt.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-Es trat am selben Tag bei einem späteren Neuaufbau erneut auf, und dieser Durchlauf ist das klarere Bild,
-weil er während des Ablaufs des Fensters und nicht danach beprobt wurde. 360 Anfragen, alle mit
-dem `Host`-Header, jede Charge gepaart mit einer Kontrolle direkt gegen den Ursprungsserver:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| Zeit nach `ONLINE` | Anfragen | Fehlschläge | Rate | Ursprungs-Kontrolle |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| sofort | 60 | 8 | **13,3 %** | 30/30 sauber |
-| ~25–40 Min. (3 Chargen) | 180 | 3 | **1,67 %** | 60/60 sauber |
-| ~50 Min. | 120 | **0** | **0,00 %** | 40/40 sauber |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-Monoton fallend bis null, und der Ursprungsserver war in jeder Charge sauber — auch in jener,
-in der jede achte VIP-Anfrage fehlschlug.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**Der Ursprungsserver war nicht die Ursache.** Eine Kontrollcharge direkt gegen den Ursprungsserver
-(`terraform output -raw origin_ip`, unter Umgehung des VIP) lief 120 von 120 sauber durch, *gleichzeitig
-mit* fehlschlagenden VIP-Chargen. Der Fehler liegt irgendwo im Pfad aus VIP, ECMP oder CE.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-Zwei Dinge, die hier bewusst nicht behauptet werden:
+Two things this is deliberately not called:
 
-- **Es ist kein Dauerzustandsdefekt.** Er verschwindet vollständig und bleibt verschwunden — 120 von 120 zum
-  50-Minuten-Zeitpunkt und 60 von 60 auf einem Stack, der bereits Stunden lief.
-- **Schließen Sie aus einer kleinen frühen Stichprobe nicht auf Abwesenheit.** Eine Charge mit 60 Anfragen, unmittelbar
-  nach einem Neuaufbau erhoben, ergab 60 von 60, was sich als „kein transienter Fehler“ las; dieselbe
-  Bereitstellung verlor eine Stunde später beim nächsten Neuaufbau 8 von 60. Sechzig Anfragen reichen nicht aus,
-  um einen stoßweisen Verlust zu erkennen. Nehmen Sie 100 oder mehr als Stichprobe, in zeitlich getrennten Chargen — die Tabelle oben
-  benötigte 360, um das Muster zu zeigen.
-- **Es lässt sich keinem bestimmten CE zuordnen.** Nichts in dieser Topologie stellt einen HTTP-Listener pro Knoten
-  bereit, es gibt also keine Möglichkeit, eine verworfene Anfrage an den Knoten zu binden, der sie verworfen hat.
-  Die äußeren Schnittstellen der CEs haben überhaupt keinen HTTP-Listener — nur das VIP-`/32` antwortet.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-Es trat bei einem sauberen Neuaufbau in einem anderen Mandanten erneut auf, es folgt also der Topologie und nicht
-der Umgebung.
-
-<Aside type="caution" title="Nehmen Sie nicht 40 Anfragen als Stichprobe und schließen Sie daraus, dass alles in Ordnung ist">
-Chargen von 40 bis 50 lesen sich auch innerhalb des fehlerhaften Fensters meist als 100 %. Genau so
-wurde dies zunächst als anhaltender Fehler mit niedriger Rate und anschließend als gar kein Fehler
-falsch charakterisiert. Nehmen Sie 100 oder mehr als Stichprobe, in zeitlich getrennten Chargen.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## Zwei weitere Messfallen
+## Two more measurement traps
 
-Beide haben in dieser Umgebung selbstsichere Fehlschlüsse erzeugt, und keine davon ist offensichtlich.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **Prüfen Sie aus dem VNet heraus, nicht von Ihrem Arbeitsplatzrechner.** Ein Unternehmens-Proxy kann den
-  TCP-Handshake auf gängigen Ports selbst abschließen, sodass eine Prüfung vom Arbeitsplatzrechner einen Port als **offen** meldet,
-  der tatsächlich geschlossen ist. Die Ports 80 und 443 lesen sich vom Arbeitsplatzrechner aus auf den öffentlichen CE-Adressen als offen
-  und sind geschlossen, wenn sie aus dem VNet heraus geprüft werden. Verwenden Sie die Client-VM.
-- **Port 22 auf einem CE antwortet nur auf der internen (SLI-)Adresse.** Von der Client-VM aus geprüft,
-  liefert die interne Adresse jedes CE ein OpenSSH-Banner, während seine Management- und externen
-  Adressen in eine Zeitüberschreitung laufen — ebenso wie eine unbenutzte Adresse, die als Kontrolle dient. eth0 ist in
-  `a-i-eth0` umbenannt und trägt keine Host-IP, weil der Datenpfad sie besitzt. Die Prüfung der Adresse,
-  unter der Sie den Knoten kennen, sagt Ihnen also nichts über den SSH-Zustand des Knotens.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="Kodieren Sie niemals eine interne CE-Adresse fest — sie werden bei jedem Neuaufbau neu vergeben">
-Azure bewahrt nicht, welcher CE welche Adresse im internen Subnetz erhält, und die
-Adressen liegen nicht in Knotenreihenfolge vor. Beobachtet am 28.07.2026 hielten die drei CEs `10.0.3.7`,
-`10.0.3.5` und `10.0.3.4` — nicht fortlaufend und anders als das, was sie vor diesem
-Neuaufbau hielten.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-Darüber, ob sie sich ändern, entscheidet die **NIC**, nicht die VM. Werden nur die CE-VMs ersetzt,
-bleiben die NICs bestehen und jede Adresse überlebt: am selben Tag verifiziert, als die Übernahme
-der abgeleiteten Objektnamen alle drei CE-VMs ersetzte und die drei internen Adressen identisch
-zurückkamen. Ein Abbau, der die NICs entfernt, vergibt sie neu aus dem freien Pool des Subnetzes,
-in welcher Reihenfolge auch immer Azure ihn befüllt.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-Die NIC des Testclients liegt in demselben Subnetz, sodass eine Adresse, die Sie als die eines CE in Erinnerung haben,
-nun die des Clients sein kann — in dieser Bereitstellung hält er `10.0.3.6`, was vor einem
-früheren Neuaufbau ein CE hielt.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-Lesen Sie sie aus, statt sie sich zu merken:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Ohne Terraform-State zur Hand fragen Sie Azure über den NIC-Namen, der *stabil* ist:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-Eine Verbindung zu einer erinnerten Adresse bringt Sie auf den falschen Knoten, auf eine VM, die kein CE ist,
-oder nirgendwohin — und Letzteres sieht genauso aus wie „SSH ist nicht aktiviert“.
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## Prüfen, ob die Befehlsoberfläche auf dem Gerät noch der Dokumentation entspricht
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -281,7 +299,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` schreibt nichts und ist daher gegenüber der laufenden Demo unbedenklich.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -303,13 +352,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Ein Customer Edge erreichen"
-    description="Welcher Zugangsweg gilt, welche Anmeldedaten jeder benötigt und warum die Wahl keine Frage der Vorliebe ist."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="BGP-Befehle"
-    description="Die Sicht auf dem Gerät aus FRR — Peering-Zustand, die vollständige Tabelle und was dieser Knoten ankündigt."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/en/demo/index.mdx
+++ b/docs/en/demo/index.mdx
@@ -9,12 +9,13 @@ sidebar:
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-This deployment demonstrates **active/active Customer Edge high availability in Azure**
-with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths**
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
 in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
 The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
@@ -25,24 +26,24 @@ across the next hops — is called out explicitly rather than left to be assumed
 
 ## What it deploys
 
-Observed 2026-08-05. The dual-path regional architecture:
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Rest of World (ROW)              Canada Regional Path
-                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca
-                           |                                 |
-                 Global Public REs               Canada RE Virtual Site
-                         |                     (Toronto & Montreal REs)
-                         |                                   |
-                Azure Route Server                Canada Azure Route Server
-                   ASN 65515                         ASN 65515
-                       |                                     |
-           +-----------+-----------+             +-----------+-----------+
-           |           |           |             |           |           |
-        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03
-       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)
-           |           |           |             |           |           |
-           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
 | Piece | What it is |
@@ -51,12 +52,13 @@ Observed 2026-08-05. The dual-path regional architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
-| Route exchange | Azure Route Servers in `eastus` and `canadacentral`, ASN `var.rs_asn` |
-| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` |
-| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
 | Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
-| Test clients | Client VMs in each regional VNet for driving traffic at the VIPs |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
 Nothing above is a literal you should copy. Every value is readable from the deployment,
 and each page reads it rather than naming it:

--- a/docs/en/demo/spec.mdx
+++ b/docs/en/demo/spec.mdx
@@ -18,12 +18,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +39,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +101,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/en/demo/terraform.mdx
+++ b/docs/en/demo/terraform.mdx
@@ -10,10 +10,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -63,6 +66,12 @@ Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
 Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
@@ -75,6 +84,12 @@ Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deplo
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
 Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
@@ -86,6 +101,12 @@ Everything the documentation reads instead of naming. If a page shows a command,
 Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
+
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
 
 ### `terraform/variables.tf`
 

--- a/docs/en/demo/verify.mdx
+++ b/docs/en/demo/verify.mdx
@@ -293,6 +293,37 @@ bash scripts/capture-sitecli.sh --check \
 
 `--check` writes nothing, so it is safe against the live demo.
 
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
 ## Automated UAT verification script
 
 Automate the four health checks and traffic convergence sampling end-to-end with `scripts/verify-deployment.sh`:

--- a/docs/es/demo/index.mdx
+++ b/docs/es/demo/index.mdx
@@ -10,55 +10,66 @@ sidebar:
   order: 5
   label: Demostración
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Este despliegue demuestra la **alta disponibilidad activo/activo de Customer Edge en Azure**
-sin ningún balanceador de carga de Azure delante de los CE. Cada CE origina la misma ruta de host
-mediante eBGP, y el Azure Route Server instala todas ellas como saltos siguientes de coste igual en la VNet.
-El tejido de enrutamiento, en lugar de un balanceador de carga, es por tanto donde se supone que ocurren
-la distribución del tráfico y la eliminación de los nodos caídos.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-Todo lo que figura en estas páginas se ejecutó contra el despliegue en vivo, y la salida mostrada es la
-salida que produjo. Lo que esa frase *no* cubre —la conmutación por error y cómo se reparte el tráfico
-entre los saltos siguientes— se señala explícitamente en lugar de dejarlo por supuesto.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## Qué despliega
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| Elemento | Qué es |
+| Piece | What it is |
 | --- | --- |
-| Tenant de F5 Distributed Cloud | `var.expected_xc_tenant` — el único lugar donde se nombra el tenant |
-| Namespaces | Sitios CE en `system`; grupo de origen y balanceador de carga en `var.xc_app_namespace` |
-| Customer Edges | `var.ce_count` sitios Secure Mesh v2 de un solo nodo, de 1 a 3, uno por zona de disponibilidad |
-| Software del CE | fijado por `var.ce_sw_version` / `var.ce_os_version` |
-| VM de Azure | tres NIC cada una — gestión/SLO, externa, interna/SLI |
-| Intercambio de rutas | un Azure Route Server, ASN `var.rs_asn`, dos direcciones de instancia |
-| Emparejamientos | uno por CE, denominado `<key>-bgp`, ASN del CE `var.ce_asn` |
-| VIP anunciada | `var.vip` como `/32`, originada de forma idéntica por cada CE |
-| Balanceador de carga | sirve `var.lb_domain`, respaldado por un grupo de origen en `var.origin_ip` |
-| Cliente de prueba | una VM dentro de la misma VNet, para dirigir tráfico a la VIP |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-Nada de lo anterior es un literal que debas copiar. Cada valor puede leerse del despliegue,
-y cada página lo lee en lugar de nombrarlo:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -66,49 +77,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="La VIP debe situarse fuera de todos los CIDR de la VNet">
-`terraform/main.tf` incluye un bloque `check` que verifica que la VIP está fuera de los CIDR
-del hub y del spoke, y rechaza el plan en caso contrario. La razón declarada es que una VIP dentro de un
-CIDR de VNet pierde frente a la propia ruta del sistema de la VNet a pesar de que la ruta BGP sea más específica.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-Trata esa protección como el contrato: si reorientas esta demostración a otro direccionamiento, la
-VIP tiene que salir de los rangos de la VNet junto con él.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="Renombrar es una reconstrucción, no un cambio de nombre">
-Como cada nombre deriva de `var.component`, cambiarlo renombra todo el
-despliegue — pero `site_prefix` no es un cambio cosmético. Se convierte en el `ClusterName`
-del cloud-init de cada CE, `custom_data` solo admite reemplazo y cloud-init solo se ejecuta en el
-primer arranque de un CE. Por tanto, cambiarlo **reemplaza cada VM de CE y su sitio XC**, y la VIP
-sufre entonces una breve pérdida mientras ECMP reconverge.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-Esto no es teórico: adoptar estos nombres derivados en la demostración en ejecución reemplazó tres
-VM de CE, tres sitios, tres objetos BGP, el balanceador de carga, el grupo de origen, el Azure
-Route Server, el Bastion y el cliente de prueba — `23 to add, 3 to change, 26 to destroy`.
-Fija `site_prefix` al valor actual cuando necesites que los sitios existentes permanezcan intactos.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## A dónde ir después
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="Despliégalo"
-    description="Requisitos previos, los dos valores que debes proporcionar, por qué el primer apply es en dos fases y cómo desmantelarlo."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="El Terraform"
-    description="La configuración en sí, leída de los archivos que la despliegan en lugar de reescrita."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="Comprueba que está sana"
-    description="Cuatro comprobaciones en orden y los resultados de apariencia normal que se leen como una interrupción y no lo son."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="Preséntalo"
-    description="Lo que esta demostración puede mostrar, lo que aún no puede mostrar y el único comando que hace visible ECMP."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/es/demo/spec.mdx
+++ b/docs/es/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/es/demo/terraform.mdx
+++ b/docs/es/demo/terraform.mdx
@@ -8,7 +8,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -16,10 +16,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -44,90 +47,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-Cada archivo que aparece a continuación es el archivo que se despliega, importado en el momento de la compilación en lugar de pegado.
-Una copia que puede divergir es una copia que lo hará, por lo que una comprobación en CI falla en el momento en que lo que se
-publica aquí difiere de lo que hay en `terraform/`.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="Por qué la configuración se importa en lugar de mostrarse en línea">
-Pegada dentro de un bloque de código, esta configuración formaría parte del código fuente de la página, y el
-código fuente de la página se traduce a doce idiomas. Los comentarios que contiene se
-traducirían con ella, y cada idioma publicaría una configuración distinta e incorrecta.
-Importada, nunca llega a entrar en el código fuente de la página.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## Módulo raíz
+## Root module
 
 ### `terraform/backend.tf`
 
-Backend de almacenamiento de Azure; su configuración se suministra en el momento de la inicialización y no se registra en el repositorio.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-Búsquedas de solo lectura, incluida la identidad de Azure AD utilizada para derivar el desplegador.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-Donde residen los nombres de objeto derivados. Los valores predeterminados de las variables de Terraform no pueden referenciar otras variables, por lo que cada variable de nombre tiene null como valor predeterminado y se resuelve aquí.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-Conexión de nivel superior, la protección de tenant y la comprobación de VIP fuera de la VNet. El orden de despliegue está documentado al principio de este archivo, que es la versión autorizada.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-Todo lo que la documentación lee en lugar de nombrar. Si una página muestra un comando, hay una salida aquí detrás de él.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-Fija el endpoint de xcsh a var.expected_xc_tenant, que es lo que convierte el tenant en una propiedad de la configuración.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-Componente, entorno, desplegador y etiquetas.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-Suscripción, región, CIDR, Bastion y los nombres de objeto de Azure.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-Recuento de CE, prefijo de sitio, ASN, versiones de imagen y tamaño de VM.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-Tenant, espacio de nombres de aplicación, balanceador de carga, pool de origen y la VIP.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Versión mínima de Terraform y restricciones de proveedor. La restricción de xcsh es un mínimo abierto, y el archivo de bloqueo está en gitignore, por lo que cada init toma el último proveedor publicado.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## Módulos
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-Grupo de recursos, VNet hub, las cuatro subredes, el Azure Route Server y el Bastion opcional. RouteServerSubnet deliberadamente no lleva NSG ni tabla de rutas.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -139,7 +160,7 @@ Grupo de recursos, VNet hub, las cuatro subredes, el Azure Route Server y el Bas
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-El lado de Azure de cada sesión eBGP: un bgpConnection por CE, emparejando el Route Server con la dirección eth0/SLO de ese CE.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -147,7 +168,7 @@ El lado de Azure de cada sesión eBGP: un bgpConnection por CE, emparejando el R
 
 ### `terraform/modules/ce-node/`
 
-Una VM CE por nodo: tres NIC con reenvío de IP, el bloque de plan del marketplace y el cloud-init entregado como custom_data.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -159,13 +180,13 @@ Una VM CE por nodo: tres NIC con reenvío de IP, el bloque de plan del marketpla
 
 ### `terraform/modules/ce-topology/`
 
-Cálculo puro, sin proveedores ni fuentes de datos: expande ce_count en el mapa por CE que impulsa cada for_each. Comprobable con plan a cualquier N sin credenciales.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-El cliente de prueba dentro de la VNet, utilizado para leer las rutas efectivas y dirigir tráfico a la VIP.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -175,7 +196,7 @@ El cliente de prueba dentro de la VNet, utilizado para leer las rutas efectivas 
 
 ### `terraform/modules/xc-site/`
 
-El objeto de sitio XC, su emparejamiento BGP y la aprobación de registro que resuelve un registro `r-<uuid>` por nombre de sitio.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/es/demo/verify.mdx
+++ b/docs/es/demo/verify.mdx
@@ -10,17 +10,17 @@ sidebar:
   order: 30
   label: Verificar
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Ejecute esto antes de presentar. Cada comprobación acota dónde estaría un fallo, de modo que un fallo le
-dice algo en lugar de solo que algo va mal.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-Cada comando lee lo que necesita del despliegue. Defina esto una vez y el resto se deriva:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -30,13 +30,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## Cuatro comprobaciones, en este orden
+## Four checks, in this order
 
 <Steps>
 
-1. **Todos los sitios están `ONLINE`.** Nada aguas abajo puede ser cierto si esto no lo es.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -46,17 +52,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Observado el 2026-07-28, tres CE:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **Cada peering está aprendiendo el anuncio del VIP de ese CE.** Consulte cada peering
-   por separado — vea la primera trampa más abajo, porque es aquí donde la demostración parece
-   estar rota con más frecuencia y no lo está.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -68,28 +74,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Observado el 2026-07-28:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   Tres peerings, tres siguientes saltos distintos, un prefijo. Eso demuestra el lado del anuncio de
-   ECMP.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **Las rutas efectivas del cliente incluyen todos los siguientes saltos.** Esto es el ECMP en sí, tal como
-   la VNet lo ha programado — no lo que los CE afirman, sino lo que Azure hizo con ello.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -97,184 +103,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   Observado el 2026-07-28:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` con una entrada por CE en `nh` es la comprobación. **El orden no es
-   significativo y no es estable** — Azure los devuelve de forma distinta entre llamadas, así que cuéntelos
-   en lugar de compararlos con una ejecución anterior. Un solo siguiente salto donde espera tres significa que un
-   CE ha dejado de anunciar, y el paso 2 identifica cuál.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **El VIP sirve tráfico.** Desde la VM cliente, y **con el encabezado `Host`** — vea la
-   segunda trampa. Muestree suficientes solicitudes para ver un problema: unas pocas docenas se leen como 100 % incluso
-   dentro de la ventana de convergencia descrita más abajo.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   Observado el 2026-07-28:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## Trampa: un peering muestra una sola ruta, y eso es correcto
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` se limita al peering que usted nombra. Informa de lo que **ese** par
-anunció, no de toda la tabla del Route Server.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-Así que consultar un solo peering devuelve un único `/32` del VIP a través de un único siguiente salto, y resulta
-tentador leerlo como «solo un CE está anunciando — los demás están caídos». Nada está
-caído. Los otros anuncios son visibles en sus propios peerings, que es lo que el paso 2 recorre
-en bucle.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-Confirmar ECMP desde la consulta de un único peering no es posible. O recorre todos los peerings, o
-lee la tabla de rutas efectivas del cliente, que muestra el resultado combinado en una sola llamada.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## Trampa: una solicitud con IP desnuda devuelve 404
+## Trap: a bare-IP request returns 404
 
-El balanceador de carga coincide por `Host`. El VIP no es un servidor virtual que sirva cualquier cosa a
-quien se conecte a la dirección.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-Ambos resultados provienen de la misma ejecución contra el despliegue en buen estado:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**Un 404 con IP desnuda es prueba de que la ruta funciona** — la solicitud llegó al CE, el proxy del CE
-respondió, y la rechazó porque ningún dominio configurado coincidió. Leerlo como una interrupción
-le lleva a mirar BGP, donde no encontrará nada mal.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-Lo mismo aplica durante una demostración: si escribe la dirección en un navegador en lugar de resolver
-el dominio hacia ella, obtiene el 404.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## El VIP descarta solicitudes durante los primeros tres cuartos de hora, y luego deja de hacerlo
+## A fresh deployment can have a convergence transient
 
-En una pila recién construida el VIP pierde una pequeña fracción de solicitudes durante aproximadamente los primeros
-45 minutos después de que los CE alcancen `ONLINE`, y después sirve de forma limpia. Medido sobre 1.470
-solicitudes desde la VM cliente, todas con el encabezado `Host`:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| Ventana | Solicitudes | Fallos | Tasa |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| Primeros ~45 minutos tras el establecimiento de ECMP | 570 | 12 | **2,11 %** |
-| Los 23 minutos siguientes | 900 | **0** | **0,00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-Todos los fallos fueron `curl: (28)` — un tiempo de espera agotado con cero bytes recibidos — no un estado
-de error HTTP. El último ocurrió unos 43 minutos después de que ECMP se estableciera. De las 900 solicitudes limpias,
-400 se ejecutaron con un tiempo de espera de 30 segundos y todas terminaron en menos de 2 segundos, así que nada quedó
-oculto por un tiempo de espera corto.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-Se reprodujo de nuevo en una reconstrucción posterior el mismo día, y esa ejecución es la imagen más clara
-porque se muestreó mientras transcurría la ventana en lugar de después. 360 solicitudes, todas con
-el encabezado `Host`, cada lote emparejado con un control directo al origen:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| Tiempo tras `ONLINE` | Solicitudes | Fallos | Tasa | Control al origen |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| inmediatamente | 60 | 8 | **13,3 %** | 30/30 limpias |
-| ~25–40 min (3 lotes) | 180 | 3 | **1,67 %** | 60/60 limpias |
-| ~50 min | 120 | **0** | **0,00 %** | 40/40 limpias |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-Decreciendo monótonamente hasta cero, y el origen estuvo limpio en todos los lotes — incluido
-aquel en el que falló una de cada ocho solicitudes al VIP.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**El origen no fue la causa.** Un lote de control directo al origen
-(`terraform output -raw origin_ip`, evitando el VIP) ejecutó 120 de 120 limpias *simultáneamente
-con* lotes al VIP que fallaban. El fallo está en algún punto de la ruta VIP, ECMP o CE.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-Dos cosas que deliberadamente no se llaman así:
+Two things this is deliberately not called:
 
-- **No es un defecto de estado estable.** Se resuelve por completo y permanece resuelto — 120 de 120 en
-  la marca de los 50 minutos, y 60 de 60 en una pila que llevaba horas en funcionamiento.
-- **No concluya que está ausente a partir de una pequeña muestra temprana.** Un lote de 60 solicitudes tomado
-  inmediatamente después de una reconstrucción devolvió 60 de 60, lo que se leyó como «sin transitorio»; el mismo
-  despliegue perdió 8 de 60 una hora más tarde en la siguiente reconstrucción. Sesenta solicitudes no son suficientes
-  para ver una pérdida en ráfagas. Muestree 100 o más, en lotes separados en el tiempo — la tabla anterior
-  necesitó 360 para mostrar la forma.
-- **No es atribuible a un CE en particular.** Nada en esta topología ofrece un escucha HTTP
-  por nodo, así que no hay forma de vincular una solicitud descartada al nodo que la descartó.
-  Las interfaces externas de los CE no tienen ningún escucha HTTP — solo el `/32` del VIP responde.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-Se reprodujo en una reconstrucción limpia en un tenant diferente, así que depende de la topología más que
-del entorno.
-
-<Aside type="caution" title="No muestree 40 solicitudes y concluya que está bien">
-Lotes de 40 a 50 se leen como 100 % la mayoría de las veces incluso dentro de la ventana con fallos. Así es
-como esto se caracterizó erróneamente primero como un fallo continuo de baja tasa y después como ningún fallo en
-absoluto. Muestree 100 o más, en lotes separados en el tiempo.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## Dos trampas más de medición
+## Two more measurement traps
 
-Ambas produjeron respuestas erróneas con total confianza en este entorno, y ninguna es obvia.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **Sondee desde dentro de la VNet, no desde su estación de trabajo.** Un proxy corporativo puede completar
-  él mismo el saludo TCP en puertos comunes, de modo que un sondeo desde la estación de trabajo informa de un puerto **abierto**
-  que en realidad está cerrado. Los puertos 80 y 443 se leen como abiertos en las direcciones públicas de los CE desde una
-  estación de trabajo y están cerrados cuando se sondean desde dentro de la VNet. Use la VM cliente.
-- **El puerto 22 en un CE responde únicamente en la dirección interna (SLI).** Sondeado desde la VM cliente,
-  la dirección interna de cada CE devuelve un banner de OpenSSH, mientras que sus direcciones de gestión y externas
-  agotan el tiempo de espera — igual que una dirección sin usar empleada como control. eth0 se renombra a
-  `a-i-eth0` y no lleva IP de host, porque el plano de datos es su dueño. Así que sondear la dirección
-  por la que conoce el nodo no le dice nada sobre el estado de SSH del nodo.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="Nunca codifique de forma fija una dirección interna de CE — se reasignan en cada reconstrucción">
-Azure no conserva qué CE recibe qué dirección en la subred interna, y las
-direcciones no están en orden de nodo. Observado el 2026-07-28, los tres CE tenían `10.0.3.7`,
-`10.0.3.5` y `10.0.3.4` — no secuenciales, y distintas de las que tenían antes de esa
-reconstrucción.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-Lo que decide si cambian es la **NIC**, no la VM. Reemplazar solo las VM de los CE
-deja las NIC en su lugar y todas las direcciones sobreviven: verificado el mismo día, cuando adoptar
-los nombres de objeto derivados reemplazó las tres VM de CE y las tres direcciones internas volvieron
-idénticas. Un desmantelamiento que elimina las NIC las reasigna desde el conjunto libre de la subred,
-en el orden en que Azure lo llene.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-La NIC del cliente de prueba está en esa misma subred, así que una dirección que recuerda como la de un CE puede
-ser ahora la del cliente — en este despliegue tiene `10.0.3.6`, que un CE tuvo antes de una
-reconstrucción anterior.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-Léalas en lugar de recordarlas:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Sin el estado de Terraform a mano, pregunte a Azure por nombre de NIC, que *sí* es estable:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-Conectarse a una dirección recordada le lleva al nodo equivocado, a una VM que no es un CE,
-o a ninguna parte — y lo último es idéntico a «SSH no está habilitado».
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## Confirme que la superficie de comandos en el equipo sigue coincidiendo con la documentación
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -282,7 +299,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` no escribe nada, así que es seguro contra la demostración en vivo.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -304,13 +352,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Acceso a un Customer Edge"
-    description="Qué ruta de acceso aplica, las credenciales que necesita cada una y por qué la elección no es una preferencia."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="Comandos BGP"
-    description="La vista en el equipo desde FRR — estado del peering, la tabla completa y qué anuncia este nodo."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/fr/demo/index.mdx
+++ b/docs/fr/demo/index.mdx
@@ -9,56 +9,66 @@ sidebar:
   order: 5
   label: Démonstration
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Ce déploiement démontre la **haute disponibilité actif/actif des Customer Edges dans Azure**
-sans aucun load balancer Azure devant les CE. Chaque CE annonce la même route d'hôte en
-eBGP, et l'Azure Route Server les installe toutes comme sauts suivants à coût égal dans le VNet.
-C'est donc la fabrique de routage, et non un load balancer, qui assure la répartition du trafic
-et le retrait des nœuds défaillants.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-Tout ce qui figure dans ces pages a été exécuté sur le déploiement réel, et les sorties
-présentées sont celles qu'il a produites. Ce que cette phrase *ne couvre pas* — le basculement,
-et la façon dont le trafic se répartit entre les sauts suivants — est signalé explicitement
-plutôt que laissé à la supposition.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## Ce qu'il déploie
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| Élément | De quoi il s'agit |
+| Piece | What it is |
 | --- | --- |
-| Tenant F5 Distributed Cloud | `var.expected_xc_tenant` — le seul endroit où le tenant est nommé |
-| Namespaces | Les sites CE dans `system` ; le pool d'origine et le load balancer dans `var.xc_app_namespace` |
-| Customer Edges | `var.ce_count` sites Secure Mesh v2 à nœud unique, de 1 à 3, un par zone de disponibilité |
-| Logiciel CE | figé par `var.ce_sw_version` / `var.ce_os_version` |
-| VM Azure | trois cartes réseau chacune — management/SLO, externe, interne/SLI |
-| Échange de routes | un Azure Route Server, ASN `var.rs_asn`, deux adresses d'instance |
-| Peerings | un par CE, nommé `<key>-bgp`, ASN CE `var.ce_asn` |
-| VIP annoncé | `var.vip` sous forme de `/32`, annoncé à l'identique par chaque CE |
-| Load balancer | sert `var.lb_domain`, adossé à un pool d'origine sur `var.origin_ip` |
-| Client de test | une VM dans le même VNet, pour générer du trafic vers le VIP |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-Rien de ce qui précède n'est une valeur littérale à recopier. Chaque valeur est lisible depuis
-le déploiement, et chaque page la lit plutôt que de la nommer :
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -66,49 +76,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="Le VIP doit se situer hors de tout CIDR de VNet">
-`terraform/main.tf` contient un bloc `check` qui vérifie que le VIP est en dehors des CIDR du hub
-et du spoke, et refuse le plan dans le cas contraire. La raison invoquée est qu'un VIP situé dans un
-CIDR de VNet perd face à la route système propre au VNet, même si la route BGP est plus spécifique.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-Considérez ce garde-fou comme un contrat : si vous réorientez cette démonstration vers un autre plan
-d'adressage, le VIP doit sortir des plages du VNet avec lui.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="Renommer, c'est reconstruire, pas renommer">
-Puisque chaque nom dérive de `var.component`, le modifier renomme l'ensemble du
-déploiement — mais `site_prefix` n'est pas un changement cosmétique. Il devient le `ClusterName`
-dans le cloud-init de chaque CE, `custom_data` est en remplacement seul, et cloud-init ne s'exécute
-qu'au premier démarrage d'un CE. Le modifier **remplace donc chaque VM de CE et son site XC**, et le VIP
-subit alors brièvement des pertes pendant que l'ECMP reconverge.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-Ce n'est pas théorique : l'adoption de ces noms dérivés sur la démonstration en cours a remplacé trois
-VM de CE, trois sites, trois objets BGP, le load balancer, le pool d'origine, l'Azure
-Route Server, le Bastion et le client de test — `23 to add, 3 to change, 26 to destroy`.
-Figez `site_prefix` sur sa valeur actuelle lorsque vous avez besoin que les sites existants restent en place.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## Où aller ensuite
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="Le déployer"
-    description="Les prérequis, les deux valeurs que vous devez fournir, pourquoi le premier apply se fait en deux phases, et comment tout démanteler."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Le Terraform"
-    description="La configuration elle-même, lue depuis les fichiers qui la déploient plutôt que recopiée."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="Vérifier son bon état"
-    description="Quatre contrôles dans l'ordre, et les résultats d'apparence normale qui ressemblent à une panne sans en être une."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="Le présenter"
-    description="Ce que cette démonstration peut montrer, ce qu'elle ne peut pas encore montrer, et la commande unique qui rend l'ECMP visible."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/fr/demo/spec.mdx
+++ b/docs/fr/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/fr/demo/terraform.mdx
+++ b/docs/fr/demo/terraform.mdx
@@ -8,7 +8,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -16,10 +16,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -44,82 +47,100 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-Chaque fichier ci-dessous est le fichier qui déploie, importé au moment de la compilation plutôt que collé.
-Une copie susceptible de dériver finira par dériver, c'est pourquoi une vérification en CI échoue dès l'instant où ce qui est
-publié ici diffère de ce qui se trouve dans `terraform/`.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="Pourquoi la configuration est importée plutôt qu'affichée en ligne">
-Collée dans un bloc de code, cette configuration ferait partie du source de la page, et le
-source de la page est traduit en douze langues. Les commentaires qu'elle contient seraient
-traduits avec elle, et chaque locale publierait une configuration différente et erronée.
-Importée, elle n'entre jamais dans le source de la page.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## Module racine
+## Root module
 
 ### `terraform/backend.tf`
 
-Backend de stockage Azure ; sa configuration est fournie au moment de l'init et n'est pas commitée.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-Recherches en lecture seule, y compris l'identité Azure AD utilisée pour déterminer le déployeur.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-L'endroit où résident les noms d'objets dérivés. Les valeurs par défaut des variables Terraform ne peuvent pas référencer d'autres variables, chaque variable de nom prend donc la valeur null par défaut et est résolue ici.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-Câblage de haut niveau, la protection du tenant et la vérification du VIP hors du VNet. L'ordre de déploiement est documenté en haut de ce fichier, qui constitue la version faisant autorité.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-Tout ce que la documentation lit au lieu de le nommer. Si une page affiche une commande, une sortie définie ici se trouve derrière.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-Épingle le point de terminaison xcsh à var.expected_xc_tenant, ce qui fait du tenant une propriété de la configuration.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-Composant, environnement, déployeur et étiquettes.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-Abonnement, région, CIDR, Bastion et les noms d'objets Azure.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-Nombre de CE, préfixe de site, ASN, versions d'image et taille de VM.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-Tenant, espace de noms d'application, équilibreur de charge, pool d'origine et le VIP.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Version plancher de Terraform et contraintes de fournisseurs. La contrainte xcsh est un plancher ouvert, et le fichier de verrouillage est ignoré par git, de sorte que chaque init récupère le dernier fournisseur publié.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
@@ -127,7 +148,7 @@ Version plancher de Terraform et contraintes de fournisseurs. La contrainte xcsh
 
 ### `terraform/modules/azure-hub/`
 
-Groupe de ressources, VNet hub, les quatre sous-réseaux, l'Azure Route Server et le Bastion optionnel. RouteServerSubnet ne porte délibérément ni NSG ni table de routage.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -139,7 +160,7 @@ Groupe de ressources, VNet hub, les quatre sous-réseaux, l'Azure Route Server e
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-Le côté Azure de chaque session eBGP — un bgpConnection par CE, appairant le Route Server à l'adresse eth0/SLO de ce CE.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -147,7 +168,7 @@ Le côté Azure de chaque session eBGP — un bgpConnection par CE, appairant le
 
 ### `terraform/modules/ce-node/`
 
-Une VM CE par nœud : trois NIC avec transfert IP, le bloc de plan de la place de marché, et le cloud-init transmis en tant que custom_data.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -159,13 +180,13 @@ Une VM CE par nœud : trois NIC avec transfert IP, le bloc de plan de la place d
 
 ### `terraform/modules/ce-topology/`
 
-Calcul pur, sans fournisseurs ni sources de données : développe ce_count en la carte par CE qui pilote chaque for_each. Testable en plan pour n'importe quel N, sans identifiants.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-Le client de test à l'intérieur du VNet, utilisé pour lire les routes effectives et générer du trafic vers le VIP.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -175,7 +196,7 @@ Le client de test à l'intérieur du VNet, utilisé pour lire les routes effecti
 
 ### `terraform/modules/xc-site/`
 
-L'objet site XC, son appairage BGP, et l'approbation d'enregistrement qui résout un enregistrement `r-<uuid>` par nom de site.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/fr/demo/verify.mdx
+++ b/docs/fr/demo/verify.mdx
@@ -10,19 +10,17 @@ sidebar:
   order: 30
   label: Vérification
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Exécutez-les avant votre présentation. Chaque vérification réduit le périmètre où se situerait
-une panne, de sorte qu'un échec vous apprend quelque chose plutôt que de signaler seulement
-qu'un problème existe.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-Chaque commande lit ce dont elle a besoin depuis le déploiement. Définissez ces variables une
-fois et le reste en découle :
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -32,13 +30,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## Quatre vérifications, dans cet ordre
+## Four checks, in this order
 
 <Steps>
 
-1. **Chaque site est `ONLINE`.** Rien en aval ne peut être vrai si ce n'est pas le cas.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -48,17 +52,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Observé le 2026-07-28, trois CE :
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **Chaque peering apprend l'annonce du VIP de ce CE.** Interrogez chaque peering
-   séparément — voyez le premier piège ci-dessous, car c'est là que la démonstration semble
-   le plus souvent défaillante sans l'être.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -70,28 +74,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Observé le 2026-07-28 :
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   Trois peerings, trois sauts suivants différents, un seul préfixe. C'est le côté annonce de
-   l'ECMP démontré.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **Les routes effectives du client portent chaque saut suivant.** C'est l'ECMP lui-même, tel
-   que le VNet l'a programmé — non pas ce que les CE prétendent, mais ce qu'Azure en a fait.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -99,198 +103,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   Observé le 2026-07-28 :
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` avec une entrée par CE dans `nh` constitue la vérification. **L'ordre n'est
-   pas significatif et n'est pas stable** — Azure les renvoie différemment d'un appel à
-   l'autre, comptez-les donc plutôt que de les comparer à une exécution précédente. Un seul
-   saut suivant là où vous en attendez trois signifie qu'un CE a cessé d'annoncer, et l'étape
-   2 identifie lequel.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **Le VIP sert le trafic.** Depuis la VM cliente, et **avec l'en-tête `Host`** — voyez le
-   deuxième piège. Échantillonnez suffisamment de requêtes pour voir un problème : quelques
-   dizaines se lisent comme 100 % même à l'intérieur de la fenêtre de convergence décrite
-   ci-dessous.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   Observé le 2026-07-28 :
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## Piège : un peering n'affiche qu'une route, et c'est correct
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` est limité au peering que vous nommez. Il rapporte ce que **ce** pair a
-annoncé, non pas la table complète du Route Server.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-Interroger un seul peering renvoie donc un unique `/32` du VIP via un unique saut suivant, et
-il est tentant d'y lire « un seul CE annonce — les autres sont hors service ». Rien n'est hors
-service. Les autres annonces sont visibles sur leurs propres peerings, ce sur quoi l'étape 2
-boucle.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-Confirmer l'ECMP depuis une requête sur un seul peering est impossible. Bouclez sur chaque
-peering, ou lisez la table des routes effectives du client, qui montre le résultat fusionné en
-un seul appel.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## Piège : une requête sur IP nue renvoie 404
+## Trap: a bare-IP request returns 404
 
-L'équilibreur de charge fait correspondre sur `Host`. Le VIP n'est pas un serveur virtuel qui
-sert quelque chose à quiconque se connecte à l'adresse.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-Ces deux résultats proviennent de la même exécution contre le déploiement sain :
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**Un 404 sur IP nue est la preuve que le chemin fonctionne** — la requête a atteint le CE, le
-proxy du CE a répondu, et il a refusé parce qu'aucun domaine configuré ne correspondait. Le
-lire comme une panne vous envoie examiner le BGP, où vous ne trouverez rien d'anormal.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-Il en va de même pendant une démonstration : si vous saisissez l'adresse dans un navigateur
-plutôt que de résoudre le domaine vers celle-ci, vous obtenez le 404.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## Le VIP perd des requêtes pendant les trois premiers quarts d'heure, puis cesse
+## A fresh deployment can have a convergence transient
 
-Sur une pile fraîchement construite, le VIP perd une petite fraction des requêtes pendant
-environ les 45 premières minutes après que les CE atteignent `ONLINE`, puis sert proprement.
-Mesuré sur 1 470 requêtes depuis la VM cliente, toutes avec l'en-tête `Host` :
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| Fenêtre | Requêtes | Échecs | Taux |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| Les ~45 premières minutes après l'établissement de l'ECMP | 570 | 12 | **2,11 %** |
-| Les 23 minutes suivantes | 900 | **0** | **0,00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-Chaque échec était un `curl: (28)` — un délai d'attente dépassé avec zéro octet reçu — et non
-un statut d'erreur HTTP. Le dernier s'est produit environ 43 minutes après l'établissement de
-l'ECMP. Sur les 900 requêtes propres, 400 ont été exécutées avec un délai d'attente de
-30 secondes et chacune s'est terminée en moins de 2 secondes : rien n'a donc été masqué par un
-délai d'attente trop court.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-Le phénomène s'est reproduit lors d'une reconstruction ultérieure le même jour, et cette
-exécution offre l'image la plus claire car elle a été échantillonnée pendant l'écoulement de la
-fenêtre plutôt qu'après. 360 requêtes, toutes avec l'en-tête `Host`, chaque lot associé à un
-contrôle directement vers l'origine :
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| Temps après `ONLINE` | Requêtes | Échecs | Taux | Contrôle origine |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| immédiatement | 60 | 8 | **13,3 %** | 30/30 propres |
-| ~25–40 min (3 lots) | 180 | 3 | **1,67 %** | 60/60 propres |
-| ~50 min | 120 | **0** | **0,00 %** | 40/40 propres |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-Décroissance monotone jusqu'à zéro, et l'origine était propre dans chaque lot — y compris celui
-où une requête VIP sur huit échouait.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**L'origine n'était pas la cause.** Un lot de contrôle directement vers l'origine
-(`terraform output -raw origin_ip`, en contournant le VIP) a exécuté 120 requêtes sur 120
-proprement *simultanément* aux lots VIP en échec. La panne se situe quelque part dans le
-chemin VIP, ECMP ou CE.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-Deux choses que ceci n'est délibérément pas appelé :
+Two things this is deliberately not called:
 
-- **Ce n'est pas un défaut en régime permanent.** Il disparaît complètement et reste absent —
-  120 sur 120 au repère des 50 minutes, et 60 sur 60 sur une pile en service depuis
-  plusieurs heures.
-- **Ne concluez pas à son absence à partir d'un petit échantillon précoce.** Un lot de
-  60 requêtes pris immédiatement après une reconstruction a renvoyé 60 sur 60, ce qui se
-  lisait comme « pas de transitoire » ; le même déploiement a perdu 8 requêtes sur 60 une
-  heure plus tard, à la reconstruction suivante. Soixante requêtes ne suffisent pas pour voir
-  une perte par rafales. Échantillonnez 100 requêtes ou plus, en lots espacés dans le temps —
-  le tableau ci-dessus en a nécessité 360 pour révéler la forme du phénomène.
-- **Ce n'est pas imputable à un CE particulier.** Rien dans cette topologie ne fournit
-  d'écouteur HTTP par nœud, il n'y a donc aucun moyen de rattacher une requête perdue au nœud
-  qui l'a perdue. Les interfaces externes des CE n'ont aucun écouteur HTTP — seul le `/32` du
-  VIP répond.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-Le phénomène s'est reproduit lors d'une reconstruction propre dans un autre locataire : il suit
-donc la topologie plutôt que l'environnement.
-
-<Aside type="caution" title="N'échantillonnez pas 40 requêtes pour conclure que tout va bien">
-Des lots de 40 à 50 requêtes se lisent comme 100 % la plupart du temps, même à l'intérieur de
-la fenêtre défaillante. C'est ainsi que ce phénomène a d'abord été qualifié à tort de défaut
-persistant à faible taux, puis d'absence totale de défaut. Échantillonnez 100 requêtes ou plus,
-en lots espacés dans le temps.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## Deux autres pièges de mesure
+## Two more measurement traps
 
-Tous deux ont produit des réponses fausses mais assurées dans cet environnement, et aucun n'est
-évident.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **Sondez depuis l'intérieur du VNet, non depuis votre poste de travail.** Un proxy
-  d'entreprise peut compléter lui-même la poignée de main TCP sur les ports courants, de sorte
-  qu'une sonde depuis le poste de travail signale un port **ouvert** qui est en réalité fermé.
-  Les ports 80 et 443 se lisent comme ouverts sur les adresses publiques des CE depuis un poste
-  de travail et sont fermés lorsqu'ils sont sondés depuis l'intérieur du VNet. Utilisez la VM
-  cliente.
-- **Le port 22 d'un CE ne répond que sur l'adresse interne (SLI).** Sondée depuis la VM
-  cliente, l'adresse interne de chaque CE renvoie une bannière OpenSSH, tandis que ses adresses
-  de gestion et externe expirent — comme le fait une adresse inutilisée servant de contrôle.
-  eth0 est renommée `a-i-eth0` et ne porte aucune IP hôte, car le plan de données la possède.
-  Sonder l'adresse par laquelle vous connaissez le nœud ne vous apprend donc rien sur l'état
-  SSH de ce nœud.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="Ne codez jamais en dur une adresse interne de CE — elles sont réattribuées à chaque reconstruction">
-Azure ne conserve pas l'attribution des adresses du sous-réseau interne aux CE, et les adresses
-ne suivent pas l'ordre des nœuds. Observé le 2026-07-28, les trois CE détenaient `10.0.3.7`,
-`10.0.3.5` et `10.0.3.4` — non séquentielles, et différentes de celles qu'ils détenaient avant
-cette reconstruction.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-Ce qui détermine si elles changent, c'est la **NIC**, non la VM. Remplacer uniquement les VM des
-CE laisse les NIC en place et chaque adresse survit : vérifié le même jour, lorsque l'adoption
-des noms d'objets dérivés a remplacé les trois VM de CE et que les trois adresses internes sont
-revenues identiques. Une destruction qui supprime les NIC les réattribue depuis le pool libre du
-sous-réseau, dans l'ordre où Azure le remplit.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-La NIC du client de test se trouve dans ce même sous-réseau, de sorte qu'une adresse que vous
-gardez en mémoire comme celle d'un CE peut désormais être celle du client — sur ce déploiement,
-il détient `10.0.3.6`, qu'un CE détenait avant une reconstruction antérieure.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-Lisez-les plutôt que de les mémoriser :
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Sans état Terraform à disposition, interrogez Azure par nom de NIC, qui *est* stable :
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-Se connecter à une adresse mémorisée vous fait aboutir sur le mauvais nœud, sur une VM qui n'est
-pas un CE, ou nulle part — et ce dernier cas est indiscernable de « SSH n'est pas activé ».
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## Confirmer que la surface de commandes embarquée correspond toujours à la documentation
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -298,7 +299,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` n'écrit rien, il est donc sans risque sur la démonstration en service.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -320,13 +352,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Atteindre un Customer Edge"
-    description="Quelle voie d'accès s'applique, les identifiants nécessaires à chacune, et pourquoi ce choix n'est pas une préférence."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="Commandes BGP"
-    description="La vue embarquée depuis FRR — état des peerings, table complète, et ce que ce nœud annonce."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/hi/demo/index.mdx
+++ b/docs/hi/demo/index.mdx
@@ -10,55 +10,66 @@ sidebar:
   order: 5
   label: डेमो
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-यह तैनाती **Azure में active/active Customer Edge उच्च उपलब्धता** को प्रदर्शित करती है,
-जिसमें CEs के सामने कोई Azure लोड बैलेंसर नहीं होता। प्रत्येक CE eBGP द्वारा उसी होस्ट रूट को
-ओरिजिनेट करता है, और Azure Route Server उन सभी को VNet में equal-cost next hops के रूप में स्थापित करता है।
-इसलिए ट्रैफ़िक वितरण और विफल नोड को हटाने का कार्य लोड बैलेंसर के बजाय रूटिंग फ़ैब्रिक में
-होना निर्धारित है।
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-इन पृष्ठों की प्रत्येक बात लाइव तैनाती के विरुद्ध चलाई गई थी, और दिखाया गया आउटपुट वही आउटपुट है
-जो उसने उत्पन्न किया। उस वाक्य में जो *शामिल नहीं* है — फेलओवर, और ट्रैफ़िक next hops के बीच कैसे
-विभाजित होता है — उसे मान लेने के बजाय स्पष्ट रूप से उल्लेखित किया गया है।
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## यह क्या तैनात करता है
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| भाग | यह क्या है |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud टेनेंट | `var.expected_xc_tenant` — एकमात्र स्थान जहाँ टेनेंट का नाम दिया गया है |
-| नेमस्पेस | CE साइटें `system` में; ऑरिजिन पूल और लोड बैलेंसर `var.xc_app_namespace` में |
-| Customer Edges | `var.ce_count` सिंगल-नोड Secure Mesh v2 साइटें, 1 से 3, प्रति उपलब्धता ज़ोन एक |
-| CE सॉफ़्टवेयर | `var.ce_sw_version` / `var.ce_os_version` द्वारा पिन किया गया |
-| Azure VMs | प्रत्येक में तीन NICs — management/SLO, external, internal/SLI |
-| रूट एक्सचेंज | एक Azure Route Server, ASN `var.rs_asn`, दो instance addresses |
-| पीयरिंग | प्रति CE एक, नाम `<key>-bgp`, CE ASN `var.ce_asn` |
-| विज्ञापित VIP | `var.vip` एक `/32` के रूप में, प्रत्येक CE द्वारा समान रूप से ओरिजिनेट किया गया |
-| लोड बैलेंसर | `var.lb_domain` की सेवा करता है, `var.origin_ip` पर एक ऑरिजिन पूल द्वारा समर्थित |
-| परीक्षण क्लाइंट | उसी VNet के भीतर एक VM, VIP पर ट्रैफ़िक चलाने के लिए |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-ऊपर दिया गया कुछ भी ऐसा शाब्दिक मान नहीं है जिसे आपको कॉपी करना चाहिए। प्रत्येक मान तैनाती से पढ़ा जा सकता है,
-और प्रत्येक पृष्ठ उसे नाम देने के बजाय पढ़ता है:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -66,49 +77,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="VIP को प्रत्येक VNet CIDR के बाहर होना चाहिए">
-`terraform/main.tf` में एक `check` ब्लॉक है जो यह अभिकथन करता है कि VIP हब और स्पोक दोनों CIDRs के
-बाहर है, और अन्यथा प्लान को अस्वीकार कर देता है। इसका बताया गया कारण यह है कि VNet CIDR के भीतर स्थित
-VIP, BGP रूट अधिक विशिष्ट होने के बावजूद, VNet के अपने सिस्टम रूट से हार जाता है।
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-इस गार्ड को अनुबंध की तरह मानें: यदि आप इस डेमो को भिन्न एड्रेसिंग पर पुनः इंगित करते हैं, तो VIP को भी
-VNet रेंज से बाहर जाना होगा।
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="नाम बदलना पुनर्निर्माण है, नाम-परिवर्तन नहीं">
-चूँकि प्रत्येक नाम `var.component` से व्युत्पन्न होता है, इसे बदलने से पूरी तैनाती का नाम बदल जाता है —
-लेकिन `site_prefix` कोई सतही बदलाव नहीं है। यह प्रत्येक CE के cloud-init में `ClusterName` बन जाता है,
-`custom_data` केवल replace-only है, और cloud-init केवल CE के पहले बूट पर चलता है। इसलिए इसे बदलने से
-**प्रत्येक CE VM और उसकी XC साइट प्रतिस्थापित हो जाती है**, और तब ECMP के पुनः अभिसरण तक VIP कुछ समय
-के लिए हानिपूर्ण रहता है।
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-यह सैद्धांतिक नहीं है: चल रहे डेमो पर इन व्युत्पन्न नामों को अपनाने से तीन CE VMs, तीन साइटें, तीन BGP
-ऑब्जेक्ट, लोड बैलेंसर, ऑरिजिन पूल, Azure Route Server, Bastion और परीक्षण क्लाइंट प्रतिस्थापित हो गए —
-`23 to add, 3 to change, 26 to destroy`।
-जब आपको चाहिए कि मौजूदा साइटें यथावत रहें, तो `site_prefix` को वर्तमान मान पर पिन करें।
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## आगे कहाँ जाएँ
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="इसे तैनात करें"
-    description="पूर्वापेक्षाएँ, वे दो मान जो आपको देने आवश्यक हैं, पहला apply दो-चरणों में क्यों होता है, और इसे कैसे हटाया जाए।"
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Terraform"
-    description="कॉन्फ़िगरेशन स्वयं, उन फ़ाइलों से पढ़ा गया जो इसे तैनात करती हैं, दोबारा टाइप किया हुआ नहीं।"
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="इसे स्वस्थ साबित करें"
-    description="क्रम में चार जाँचें, और वे सामान्य दिखने वाले परिणाम जो आउटेज जैसे लगते हैं पर हैं नहीं।"
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="इसे प्रस्तुत करें"
-    description="यह डेमो क्या दिखा सकता है, अभी क्या नहीं दिखा सकता, और वह एक कमांड जो ECMP को दृश्यमान बनाता है।"
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/hi/demo/spec.mdx
+++ b/docs/hi/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/hi/demo/terraform.mdx
+++ b/docs/hi/demo/terraform.mdx
@@ -9,7 +9,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -17,10 +17,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -45,89 +48,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-नीचे दी गई प्रत्येक फ़ाइल वही फ़ाइल है जो तैनात होती है, चिपकाई गई नहीं बल्कि बिल्ड समय पर आयात की गई।
-जो प्रतिलिपि भिन्न हो सकती है, वह भिन्न हो ही जाएगी, इसलिए CI में एक जाँच उसी क्षण विफल हो जाती है जब यहाँ
-प्रकाशित सामग्री `terraform/` में मौजूद सामग्री से अलग होती है।
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
 <Aside type="note" title="Why the configuration is imported rather than shown inline">
-कोड फ़ेंस में चिपकाए जाने पर यह कॉन्फ़िगरेशन पृष्ठ स्रोत का हिस्सा बन जाता, और
-पृष्ठ स्रोत बारह भाषाओं में अनुवादित होता है। इसके भीतर की टिप्पणियाँ भी उसके साथ
-अनुवादित हो जातीं, और प्रत्येक लोकेल एक अलग, ग़लत कॉन्फ़िगरेशन प्रकाशित करता। आयात किए जाने पर, यह पृष्ठ स्रोत में कभी प्रवेश ही नहीं करता।
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## रूट मॉड्यूल
+## Root module
 
 ### `terraform/backend.tf`
 
-Azure स्टोरेज बैकएंड; इसका कॉन्फ़िगरेशन init समय पर दिया जाता है और कमिट नहीं किया जाता।
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-केवल-पढ़ने योग्य लुकअप, जिसमें डिप्लॉयर निकालने के लिए उपयोग की जाने वाली Azure AD पहचान शामिल है।
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-जहाँ व्युत्पन्न ऑब्जेक्ट नाम रहते हैं। Terraform वेरिएबल डिफ़ॉल्ट अन्य वेरिएबल्स को संदर्भित नहीं कर सकते, इसलिए प्रत्येक नाम वेरिएबल डिफ़ॉल्ट रूप से null होता है और यहाँ हल किया जाता है।
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-शीर्ष-स्तरीय वायरिंग, टेनेंट गार्ड और VIP-के-VNet-से-बाहर होने की जाँच। तैनाती का क्रम इस फ़ाइल के शीर्ष पर दस्तावेज़ित है, जो आधिकारिक संस्करण है।
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-वह सब कुछ जो दस्तावेज़ीकरण नाम देने के बजाय पढ़ता है। यदि कोई पृष्ठ कोई कमांड दिखाता है, तो उसके पीछे यहाँ कोई आउटपुट है।
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-xcsh एंडपॉइंट को var.expected_xc_tenant पर पिन करता है, जो टेनेंट को कॉन्फ़िगरेशन की एक विशेषता बनाता है।
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-घटक, परिवेश, डिप्लॉयर और टैग।
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-सब्सक्रिप्शन, क्षेत्र, CIDR, Bastion, और Azure ऑब्जेक्ट नाम।
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-CE संख्या, साइट प्रीफ़िक्स, ASN, इमेज संस्करण और VM आकार।
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-टेनेंट, ऐप नेमस्पेस, लोड बैलेंसर, ऑरिजिन पूल और VIP।
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Terraform का न्यूनतम स्तर और प्रोवाइडर अवरोध। xcsh अवरोध एक खुला-अंत न्यूनतम स्तर है, और लॉक फ़ाइल gitignored है, इसलिए प्रत्येक init नवीनतम प्रकाशित प्रोवाइडर लेता है।
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## मॉड्यूल
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-रिसोर्स ग्रुप, हब VNet, चार सबनेट, Azure Route Server और वैकल्पिक Bastion। RouteServerSubnet जानबूझकर कोई NSG या रूट टेबल नहीं रखता।
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -139,7 +161,7 @@ Terraform का न्यूनतम स्तर और प्रोवाइ
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-प्रत्येक eBGP सत्र का Azure पक्ष — प्रति CE एक bgpConnection, जो Route Server को उस CE के eth0/SLO पते के साथ पीयर करता है।
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -147,7 +169,7 @@ Terraform का न्यूनतम स्तर और प्रोवाइ
 
 ### `terraform/modules/ce-node/`
 
-प्रति नोड एक CE VM: IP फ़ॉरवर्डिंग वाले तीन NIC, मार्केटप्लेस प्लान ब्लॉक, और custom_data के रूप में सौंपा गया cloud-init।
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -159,13 +181,13 @@ Terraform का न्यूनतम स्तर और प्रोवाइ
 
 ### `terraform/modules/ce-topology/`
 
-शुद्ध गणना, कोई प्रोवाइडर नहीं और कोई डेटा स्रोत नहीं: ce_count को उस प्रति-CE मैप में विस्तारित करता है जो प्रत्येक for_each को चलाता है। किसी भी N पर क्रेडेंशियल्स के बिना प्लान-परीक्षण योग्य।
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-VNet के भीतर परीक्षण क्लाइंट, जिसका उपयोग प्रभावी रूट पढ़ने और VIP पर ट्रैफ़िक चलाने के लिए किया जाता है।
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -175,7 +197,7 @@ VNet के भीतर परीक्षण क्लाइंट, जिस�
 
 ### `terraform/modules/xc-site/`
 
-XC साइट ऑब्जेक्ट, उसकी BGP पीयरिंग, और वह पंजीकरण अनुमोदन जो साइट नाम द्वारा किसी `r-<uuid>` पंजीकरण को हल करता है।
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/hi/demo/verify.mdx
+++ b/docs/hi/demo/verify.mdx
@@ -9,17 +9,17 @@ sidebar:
   order: 30
   label: सत्यापन
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-प्रस्तुति देने से पहले इन्हें चलाएँ। प्रत्येक जाँच यह सीमित करती है कि खराबी कहाँ हो सकती है, इसलिए कोई विफलता
-आपको कुछ बताती है, न कि केवल यह कि कुछ गलत है।
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-प्रत्येक कमांड जो आवश्यक है वह डिप्लॉयमेंट से पढ़ लेता है। इन्हें एक बार सेट करें और शेष अपने आप चलेंगे:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -29,13 +29,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## चार जाँचें, इसी क्रम में
+## Four checks, in this order
 
 <Steps>
 
-1. **प्रत्येक साइट `ONLINE` है।** यदि यह सत्य नहीं है तो इसके आगे कुछ भी सत्य नहीं हो सकता।
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -45,17 +51,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 को देखा गया, तीन CE:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **प्रत्येक पीयरिंग उस CE का VIP विज्ञापन सीख रही है।** प्रत्येक पीयरिंग की क्वेरी
-   अलग-अलग करें — नीचे दिया पहला जाल देखें, क्योंकि यहीं डेमो सबसे अधिक बार खराब
-   दिखता है और होता नहीं है।
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -67,28 +73,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 को देखा गया:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   तीन पीयरिंग, तीन भिन्न नेक्स्ट हॉप, एक प्रीफ़िक्स। यही ECMP का विज्ञापन पक्ष
-   प्रमाणित होना है।
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **क्लाइंट के प्रभावी रूट प्रत्येक नेक्स्ट हॉप को धारण करते हैं।** यह स्वयं ECMP है, जैसा
-   VNet ने इसे प्रोग्राम किया है — वह नहीं जो CE दावा करते हैं, बल्कि वह जो Azure ने उसके साथ किया।
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -96,183 +102,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   2026-07-28 को देखा गया:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` के साथ `nh` में प्रति CE एक प्रविष्टि — यही जाँच है। **क्रम
-   महत्वपूर्ण नहीं है और स्थिर नहीं है** — Azure कॉल-दर-कॉल इन्हें भिन्न रूप में लौटाता है, इसलिए
-   पिछली बार से तुलना करने के बजाय इन्हें गिनें। जहाँ आप तीन की अपेक्षा करते हैं वहाँ एक नेक्स्ट हॉप का अर्थ है कि
-   कोई CE विज्ञापन करना बंद कर चुका है, और चरण 2 पहचानता है कि कौन सा।
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **VIP ट्रैफ़िक सर्व करता है।** क्लाइंट VM से, और **`Host` हेडर के साथ** — दूसरा
-   जाल देखें। समस्या देखने के लिए पर्याप्त अनुरोध सैंपल करें: नीचे वर्णित कन्वर्जेंस विंडो के भीतर भी
-   कुछ दर्जन अनुरोध 100 % जैसे पढ़े जाते हैं।
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   2026-07-28 को देखा गया:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## जाल: एक पीयरिंग एक रूट दिखाती है, और यह सही है
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` उस पीयरिंग तक सीमित होता है जिसका नाम आप देते हैं। यह वही बताता है जो **उस** पीयर ने
-विज्ञापित किया, Route Server की पूरी तालिका नहीं।
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-इसलिए अकेली एक पीयरिंग की क्वेरी एकल नेक्स्ट हॉप के माध्यम से एकल VIP `/32` लौटाती है, और इसे
-"केवल एक CE विज्ञापन कर रहा है — बाकी डाउन हैं" के रूप में पढ़ने का प्रलोभन होता है। कुछ भी डाउन नहीं है।
-अन्य विज्ञापन अपनी-अपनी पीयरिंग पर दिखते हैं, और चरण 2 उन्हीं पर लूप करता है।
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-एकल पीयरिंग क्वेरी से ECMP की पुष्टि करना संभव नहीं है। या प्रत्येक पीयरिंग पर लूप करें, या
-क्लाइंट की प्रभावी रूट तालिका पढ़ें, जो एक ही कॉल में समेकित परिणाम दिखाती है।
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## जाल: बेयर-IP अनुरोध 404 लौटाता है
+## Trap: a bare-IP request returns 404
 
-लोड बैलेंसर `Host` पर मैच करता है। VIP कोई ऐसा वर्चुअल सर्वर नहीं है जो पते पर कनेक्ट होने वाले
-किसी को भी कुछ भी सर्व करे।
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-ये दोनों स्वस्थ डिप्लॉयमेंट के विरुद्ध उसी रन से आए:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**बेयर-IP 404 इस बात का प्रमाण है कि पथ काम कर रहा है** — अनुरोध CE तक पहुँचा, CE के प्रॉक्सी ने
-उत्तर दिया, और उसने अस्वीकार किया क्योंकि कोई कॉन्फ़िगर किया गया डोमेन मैच नहीं हुआ। इसे आउटेज के रूप में पढ़ना
-आपको BGP देखने भेज देता है, जहाँ आपको कुछ गलत नहीं मिलेगा।
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-यही डेमो के दौरान भी लागू होता है: यदि आप डोमेन को उस पते पर रिज़ॉल्व करने के बजाय ब्राउज़र में पता
-टाइप करते हैं, तो आपको 404 मिलता है।
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## VIP पहले पौन घंटे तक अनुरोध ड्रॉप करता है, फिर रुक जाता है
+## A fresh deployment can have a convergence transient
 
-नए बनाए गए स्टैक पर, CE के `ONLINE` होने के बाद लगभग पहले 45 मिनट तक VIP अनुरोधों का एक छोटा
-अंश खो देता है, और उसके बाद साफ़-सुथरे ढंग से सर्व करता है। क्लाइंट VM से 1,470
-अनुरोधों पर मापा गया, सभी `Host` हेडर के साथ:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| विंडो | अनुरोध | विफलताएँ | दर |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| ECMP उठने के बाद पहले ~45 मिनट | 570 | 12 | **2.11 %** |
-| उसके बाद के 23 मिनट | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-प्रत्येक विफलता `curl: (28)` थी — शून्य बाइट प्राप्त होने के साथ टाइमआउट — कोई HTTP त्रुटि
-स्थिति नहीं। अंतिम विफलता ECMP उठने के लगभग 43 मिनट बाद हुई। 900 साफ़ अनुरोधों में से
-400 30-सेकंड टाइमआउट के साथ चले और प्रत्येक 2 सेकंड से कम में पूरा हुआ, इसलिए छोटे टाइमआउट से कुछ
-छिपा नहीं था।
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-यह उसी दिन एक बाद के रीबिल्ड पर फिर पुनरुत्पन्न हुआ, और वह रन अधिक स्पष्ट चित्र देता है
-क्योंकि उसे विंडो बीत जाने के बाद के बजाय विंडो बीतने के दौरान सैंपल किया गया था। 360 अनुरोध, सभी
-`Host` हेडर के साथ, प्रत्येक बैच के साथ सीधे ऑरिजिन पर एक नियंत्रण बैच जोड़ा गया:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| `ONLINE` के बाद का समय | अनुरोध | विफलताएँ | दर | ऑरिजिन नियंत्रण |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| तत्काल | 60 | 8 | **13.3 %** | 30/30 साफ़ |
-| ~25–40 मिनट (3 बैच) | 180 | 3 | **1.67 %** | 60/60 साफ़ |
-| ~50 मिनट | 120 | **0** | **0.00 %** | 40/40 साफ़ |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-एकरस रूप से घटकर शून्य तक, और प्रत्येक बैच में ऑरिजिन साफ़ रहा — उस बैच में भी जहाँ आठ में से
-एक VIP अनुरोध विफल हुआ।
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**ऑरिजिन कारण नहीं था।** सीधे ऑरिजिन पर एक नियंत्रण बैच
-(`terraform output -raw origin_ip`, VIP को बायपास करते हुए) विफल हो रहे VIP बैचों *के साथ-साथ*
-120 में से 120 साफ़ चला। खराबी VIP, ECMP या CE पथ में कहीं है।
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-दो बातें जिन्हें जानबूझकर ऐसा नहीं कहा जा रहा:
+Two things this is deliberately not called:
 
-- **यह स्थिर-अवस्था दोष नहीं है।** यह पूरी तरह साफ़ हो जाता है और साफ़ रहता है — 50-मिनट के निशान पर
-  120 में से 120, और घंटों से चल रहे स्टैक पर 60 में से 60।
-- **किसी छोटे प्रारंभिक सैंपल से यह निष्कर्ष न निकालें कि यह अनुपस्थित है।** एक रीबिल्ड के तुरंत बाद
-  लिया गया 60-अनुरोध बैच 60 में से 60 लौटाया, जो "कोई ट्रांज़िएंट नहीं" जैसा पढ़ा गया; उसी
-  डिप्लॉयमेंट ने अगले रीबिल्ड पर एक घंटे बाद 60 में से 8 खो दिए। बर्स्टी हानि देखने के लिए साठ अनुरोध
-  पर्याप्त नहीं हैं। 100 या अधिक सैंपल करें, समय में अलग-अलग बैचों में — ऊपर की तालिका को
-  आकार दिखाने के लिए 360 चाहिए थे।
-- **यह किसी विशेष CE को नहीं ठहराया जा सकता।** इस टोपोलॉजी में कुछ भी प्रति-नोड
-  HTTP लिसनर नहीं देता, इसलिए किसी ड्रॉप हुए अनुरोध को उस नोड से बाँधने का कोई तरीका नहीं है जिसने उसे ड्रॉप किया।
-  CE के बाहरी इंटरफ़ेस पर कोई HTTP लिसनर ही नहीं है — केवल VIP `/32` उत्तर देता है।
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-यह एक भिन्न टेनेंट में साफ़ रीबिल्ड पर पुनरुत्पन्न हुआ, इसलिए यह पर्यावरण के बजाय टोपोलॉजी का
-अनुसरण करता है।
-
-<Aside type="caution" title="40 अनुरोध सैंपल कर यह निष्कर्ष न निकालें कि सब ठीक है">
-40 से 50 के बैच विफल हो रही विंडो के भीतर भी अधिकांश समय 100 % जैसे पढ़े जाते हैं। इसी तरह
-इसे पहले एक चालू निम्न-दर खराबी के रूप में और फिर बिल्कुल कोई खराबी न होने के रूप में गलत
-वर्गीकृत किया गया था। 100 या अधिक सैंपल करें, समय में अलग-अलग बैचों में।
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## दो और मापन जाल
+## Two more measurement traps
 
-दोनों ने इस परिवेश में आत्मविश्वास से गलत उत्तर दिए, और दोनों में से कोई स्पष्ट नहीं है।
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **VNet के भीतर से प्रोब करें, अपने वर्कस्टेशन से नहीं।** कोई कॉर्पोरेट प्रॉक्सी सामान्य पोर्ट पर
-  स्वयं TCP हैंडशेक पूरा कर सकता है, इसलिए वर्कस्टेशन प्रोब उस पोर्ट को **खुला** बताता है
-  जो वास्तव में बंद है। वर्कस्टेशन से CE के सार्वजनिक पतों पर पोर्ट 80 और 443 खुले पढ़े जाते हैं
-  और VNet के भीतर से प्रोब करने पर बंद होते हैं। क्लाइंट VM का उपयोग करें।
-- **किसी CE पर पोर्ट 22 केवल आंतरिक (SLI) पते पर उत्तर देता है।** क्लाइंट VM से प्रोब करने पर,
-  प्रत्येक CE का आंतरिक पता OpenSSH बैनर लौटाता है, जबकि उसके प्रबंधन और बाहरी
-  पते टाइमआउट होते हैं — जैसा नियंत्रण के रूप में उपयोग किया गया एक अप्रयुक्त पता भी करता है। eth0 का नाम बदलकर
-  `a-i-eth0` कर दिया गया है और उस पर कोई होस्ट IP नहीं है, क्योंकि डेटापाथ उसका स्वामी है। इसलिए उस पते को
-  प्रोब करना जिससे आप नोड को जानते हैं, नोड की SSH स्थिति के बारे में कुछ नहीं बताता।
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="कभी किसी CE का आंतरिक पता हार्डकोड न करें — वे प्रत्येक रीबिल्ड पर पुनः असाइन होते हैं">
-Azure यह संरक्षित नहीं करता कि आंतरिक सबनेट में किस CE को कौन सा पता मिलता है, और
-पते नोड क्रम में नहीं होते। 2026-07-28 को देखा गया कि तीन CE ने `10.0.3.7`,
-`10.0.3.5` और `10.0.3.4` धारण किए — क्रमिक नहीं, और उस रीबिल्ड से पहले उन्होंने जो धारण किए थे
-उससे भिन्न।
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-यह तय करने वाला कि वे बदलते हैं या नहीं, **NIC** है, VM नहीं। केवल CE VM बदलने पर
-NIC यथावत रहते हैं और प्रत्येक पता बचा रहता है: उसी दिन सत्यापित किया गया, जब व्युत्पन्न
-ऑब्जेक्ट नामों को अपनाने पर तीनों CE VM बदले गए और तीनों आंतरिक पते समान रूप से
-वापस आए। एक टियरडाउन जो NIC हटा देता है, उन्हें सबनेट के मुक्त
-पूल से पुनः असाइन करता है, उस क्रम में जिसमें Azure उसे भरता है।
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-परीक्षण क्लाइंट का NIC उसी सबनेट में बैठता है, इसलिए जो पता आपको किसी CE का याद है वह अब
-क्लाइंट का हो सकता है — इस डिप्लॉयमेंट पर वह `10.0.3.6` धारण करता है, जिसे एक पूर्व रीबिल्ड से पहले
-एक CE ने धारण किया था।
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-उन्हें याद रखने के बजाय पढ़ें:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Terraform स्टेट उपलब्ध न होने पर, Azure से NIC नाम द्वारा पूछें, जो *स्थिर* है:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-किसी याद रखे गए पते से कनेक्ट करने पर आप गलत नोड पर पहुँचते हैं, ऐसे VM पर जो CE नहीं है,
-या कहीं नहीं — और इनमें से अंतिम स्थिति "SSH सक्षम नहीं है" के समान ही दिखती है।
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## पुष्टि करें कि ऑन-बॉक्स कमांड सरफ़ेस अभी भी दस्तावेज़ों से मेल खाता है
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -280,7 +298,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` कुछ भी नहीं लिखता, इसलिए यह लाइव डेमो के विरुद्ध सुरक्षित है।
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -302,13 +351,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Customer Edge तक पहुँचना"
-    description="कौन-सा एक्सेस रूट लागू होता है, प्रत्येक के लिए आवश्यक क्रेडेंशियल, और यह चुनाव प्राथमिकता का विषय क्यों नहीं है।"
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="BGP कमांड"
-    description="FRR से ऑन-बॉक्स दृश्य — पीयरिंग स्थिति, पूरी तालिका, और यह नोड क्या विज्ञापित करता है।"
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/it/demo/index.mdx
+++ b/docs/it/demo/index.mdx
@@ -10,56 +10,66 @@ sidebar:
   order: 5
   label: Demo
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Questa distribuzione dimostra l'**alta disponibilità attiva/attiva dei Customer Edge in Azure**
-senza alcun load balancer Azure davanti ai CE. Ogni CE origina la stessa route host tramite
-eBGP e l'Azure Route Server le installa tutte come next hop a costo equivalente nella VNet.
-È quindi il tessuto di routing, e non un load balancer, il punto in cui avvengono la
-distribuzione del traffico e la rimozione dei nodi guasti.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-Tutto ciò che si trova in queste pagine è stato eseguito sulla distribuzione reale, e l'output
-mostrato è l'output che essa ha prodotto. Ciò che questa frase *non* copre — il failover e il modo
-in cui il traffico si suddivide tra i next hop — viene indicato esplicitamente anziché essere
-lasciato all'ipotesi.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## Cosa distribuisce
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| Elemento | Che cos'è |
+| Piece | What it is |
 | --- | --- |
-| Tenant F5 Distributed Cloud | `var.expected_xc_tenant` — l'unico punto in cui il tenant viene nominato |
-| Namespace | Siti CE in `system`; origin pool e load balancer in `var.xc_app_namespace` |
-| Customer Edge | `var.ce_count` siti Secure Mesh v2 a nodo singolo, da 1 a 3, uno per zona di disponibilità |
-| Software CE | fissato da `var.ce_sw_version` / `var.ce_os_version` |
-| VM Azure | tre NIC ciascuna — gestione/SLO, esterna, interna/SLI |
-| Scambio di route | un Azure Route Server, ASN `var.rs_asn`, due indirizzi di istanza |
-| Peering | uno per CE, denominato `<key>-bgp`, ASN CE `var.ce_asn` |
-| VIP annunciato | `var.vip` come `/32`, originato in modo identico da ogni CE |
-| Load balancer | serve `var.lb_domain`, supportato da un origin pool su `var.origin_ip` |
-| Client di test | una VM all'interno della stessa VNet, per generare traffico verso il VIP |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-Nulla di quanto sopra è un valore letterale da copiare. Ogni valore è leggibile dalla
-distribuzione, e ciascuna pagina lo legge anziché nominarlo:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -67,50 +77,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="Il VIP deve trovarsi al di fuori di ogni CIDR della VNet">
-`terraform/main.tf` include un blocco `check` che verifica che il VIP sia esterno sia al CIDR
-dell'hub sia a quello dello spoke, e rifiuta il plan in caso contrario. La ragione dichiarata è
-che un VIP interno a un CIDR della VNet perde nei confronti della route di sistema della VNet
-stessa, nonostante la route BGP sia più specifica.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-Considerate questa protezione come il contratto: se ripuntate questa demo su un indirizzamento
-diverso, anche il VIP deve spostarsi fuori dagli intervalli della VNet.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="Rinominare significa ricostruire, non rinominare">
-Poiché ogni nome derivа da `var.component`, modificarlo rinomina l'intera
-distribuzione — ma `site_prefix` non è una modifica estetica. Diventa il `ClusterName`
-nel cloud-init di ciascun CE, `custom_data` è replace-only e cloud-init viene eseguito solo al
-primo avvio di un CE. Pertanto, modificarlo **sostituisce ogni VM CE e il relativo sito XC**, e il
-VIP subisce quindi una breve perdita di traffico mentre ECMP riconverge.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-Non è un caso teorico: l'adozione di questi nomi derivati sulla demo in esecuzione ha sostituito tre
-VM CE, tre siti, tre oggetti BGP, il load balancer, l'origin pool, l'Azure
-Route Server, il Bastion e il client di test — `23 to add, 3 to change, 26 to destroy`.
-Fissate `site_prefix` al valore corrente quando volete che i siti esistenti rimangano al loro posto.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## Dove andare adesso
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="Distribuirla"
-    description="Prerequisiti, i due valori che dovete fornire, perché il primo apply è a due fasi e come smantellare tutto."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Il Terraform"
-    description="La configurazione stessa, letta dai file che la distribuiscono anziché ridigitata."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="Verificarne lo stato di salute"
-    description="Quattro controlli in ordine e i risultati apparentemente normali che sembrano un'interruzione ma non lo sono."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="Presentarla"
-    description="Ciò che questa demo può mostrare, ciò che non può ancora mostrare e l'unico comando che rende visibile ECMP."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/it/demo/spec.mdx
+++ b/docs/it/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/it/demo/terraform.mdx
+++ b/docs/it/demo/terraform.mdx
@@ -8,7 +8,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -16,10 +16,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -44,90 +47,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-Ogni file riportato di seguito è il file che viene effettivamente distribuito, importato in fase di build anziché incollato.
-Una copia che può divergere è una copia che divergerà, quindi un controllo in CI fallisce nel momento in cui ciò che
-viene pubblicato qui differisce da ciò che si trova in `terraform/`.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="Perché la configurazione viene importata anziché mostrata inline">
-Incollata in un blocco di codice, questa configurazione farebbe parte del codice sorgente della pagina, e il
-codice sorgente della pagina viene tradotto in dodici lingue. I commenti al suo interno verrebbero
-tradotti insieme ad essa, e ogni locale pubblicherebbe una configurazione diversa ed errata.
-Importata, non entra mai nel codice sorgente della pagina.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## Modulo root
+## Root module
 
 ### `terraform/backend.tf`
 
-Backend di archiviazione Azure; la sua configurazione viene fornita in fase di init e non è committata.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-Lookup in sola lettura, inclusa l'identità Azure AD usata per derivare il deployer.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-Dove risiedono i nomi degli oggetti derivati. I valori predefiniti delle variabili Terraform non possono fare riferimento ad altre variabili, quindi ogni variabile di nome ha come default null e viene risolta qui.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-Il collegamento di primo livello, il guard sul tenant e il controllo del VIP esterno alla VNet. L'ordine di distribuzione è documentato all'inizio di questo file, che è la versione autorevole.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-Tutto ciò che la documentazione legge invece di nominare. Se una pagina mostra un comando, dietro di esso c'è un output definito qui.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-Vincola l'endpoint xcsh a var.expected_xc_tenant, il che rende il tenant una proprietà della configurazione.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-Componente, ambiente, deployer e tag.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-Sottoscrizione, regione, CIDR, Bastion e i nomi degli oggetti Azure.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-Numero di CE, prefisso del sito, ASN, versioni delle immagini e dimensione della VM.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-Tenant, namespace dell'applicazione, load balancer, origin pool e il VIP.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Versione minima di Terraform e vincoli sui provider. Il vincolo su xcsh è una soglia minima aperta, e il lock file è in gitignore, quindi ogni init prende il provider pubblicato più recente.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## Moduli
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-Resource group, VNet hub, le quattro subnet, l'Azure Route Server e il Bastion opzionale. RouteServerSubnet deliberatamente non ha né NSG né route table.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -139,7 +160,7 @@ Resource group, VNet hub, le quattro subnet, l'Azure Route Server e il Bastion o
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-Il lato Azure di ogni sessione eBGP — una bgpConnection per CE, che mette in peering il Route Server con l'indirizzo eth0/SLO di quel CE.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -147,7 +168,7 @@ Il lato Azure di ogni sessione eBGP — una bgpConnection per CE, che mette in p
 
 ### `terraform/modules/ce-node/`
 
-Una VM CE per nodo: tre NIC con IP forwarding, il blocco plan del marketplace e il cloud-init passato come custom_data.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -159,13 +180,13 @@ Una VM CE per nodo: tre NIC con IP forwarding, il blocco plan del marketplace e 
 
 ### `terraform/modules/ce-topology/`
 
-Pura computazione, nessun provider e nessuna data source: espande ce_count nella mappa per singolo CE che alimenta ogni for_each. Testabile in fase di plan con qualsiasi N senza credenziali.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-Il client di test all'interno della VNet, usato per leggere le route effettive e generare traffico verso il VIP.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -175,7 +196,7 @@ Il client di test all'interno della VNet, usato per leggere le route effettive e
 
 ### `terraform/modules/xc-site/`
 
-L'oggetto site XC, il suo peering BGP e l'approvazione della registrazione che risolve una registrazione `r-<uuid>` in base al nome del sito.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/it/demo/verify.mdx
+++ b/docs/it/demo/verify.mdx
@@ -10,16 +10,17 @@ sidebar:
   order: 30
   label: Verifica
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Eseguite questi controlli prima della presentazione. Ogni controllo restringe il punto in cui si troverebbe un guasto, così un esito negativo vi dice qualcosa invece di segnalare soltanto che qualcosa non va.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-Ogni comando legge ciò che gli serve dal deployment. Impostate queste variabili una volta e il resto segue:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -29,13 +30,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## Quattro controlli, in questo ordine
+## Four checks, in this order
 
 <Steps>
 
-1. **Ogni sito è `ONLINE`.** Nulla a valle può essere vero se questo non lo è.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -45,17 +52,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Osservato il 2026-07-28, tre CE:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **Ogni peering sta apprendendo l'annuncio del VIP di quel CE.** Interrogate ogni peering
-   separatamente — si veda la prima trappola più sotto, perché è qui che la demo più spesso sembra
-   guasta senza esserlo.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -67,28 +74,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Osservato il 2026-07-28:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   Tre peering, tre next hop diversi, un solo prefisso. Questo dimostra il lato annuncio
-   dell'ECMP.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **Le rotte effettive del client comprendono ogni next hop.** Questo è l'ECMP vero e proprio, così
-   come la VNet l'ha programmato — non ciò che i CE dichiarano, ma ciò che Azure ne ha fatto.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -96,183 +103,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   Osservato il 2026-07-28:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` con una voce per ogni CE in `nh` è il controllo. **L'ordine non è
-   significativo e non è stabile** — Azure li restituisce in modo diverso tra una chiamata e l'altra, quindi contateli
-   invece di confrontarli con un'esecuzione precedente. Un solo next hop dove ve ne aspettate tre significa che un
-   CE ha smesso di annunciare, e il passaggio 2 identifica quale.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **Il VIP serve traffico.** Dalla VM client, e **con l'header `Host`** — si veda la
-   seconda trappola. Campionate abbastanza richieste da vedere un problema: qualche decina appare come 100 % anche
-   all'interno della finestra di convergenza descritta più sotto.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   Osservato il 2026-07-28:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## Trappola: un peering mostra una sola rotta, ed è corretto
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` è limitato al peering che indicate. Riporta ciò che **quel** peer
-ha annunciato, non l'intera tabella del Route Server.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-Perciò interrogare un solo peering restituisce un unico `/32` del VIP tramite un unico next hop, ed è
-allettante interpretarlo come "solo un CE sta annunciando — gli altri sono giù". Nulla è
-giù. Gli altri annunci sono visibili sui rispettivi peering, ed è su questi che il passaggio 2 itera.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-Confermare l'ECMP da una query su un singolo peering non è possibile. O iterate su ogni peering, oppure
-leggete la tabella delle rotte effettive del client, che mostra il risultato unito in una sola chiamata.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## Trappola: una richiesta su IP nudo restituisce 404
+## Trap: a bare-IP request returns 404
 
-Il load balancer effettua il match su `Host`. Il VIP non è un virtual server che serve qualcosa a
-chiunque si connetta all'indirizzo.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-Entrambi questi risultati provengono dalla stessa esecuzione sul deployment integro:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**Un 404 su IP nudo è la prova che il percorso funziona** — la richiesta ha raggiunto il CE, il proxy del CE
-ha risposto e l'ha rifiutata perché nessun dominio configurato corrispondeva. Interpretarlo come un'interruzione
-vi porta a cercare nel BGP, dove non troverete nulla di sbagliato.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-Lo stesso vale durante una demo: se digitate l'indirizzo in un browser invece di risolvere
-il dominio verso di esso, ottenete il 404.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## Il VIP scarta richieste per i primi tre quarti d'ora, poi smette
+## A fresh deployment can have a convergence transient
 
-Su uno stack appena creato il VIP perde una piccola frazione di richieste per circa i primi
-45 minuti dopo che i CE raggiungono lo stato `ONLINE`, e poi serve senza errori. Misurato su 1.470
-richieste dalla VM client, tutte con l'header `Host`:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| Finestra | Richieste | Fallimenti | Tasso |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| Primi ~45 minuti dopo l'attivazione dell'ECMP | 570 | 12 | **2,11 %** |
-| I 23 minuti successivi | 900 | **0** | **0,00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-Ogni fallimento è stato `curl: (28)` — un timeout con zero byte ricevuti — non uno stato di errore
-HTTP. L'ultimo si è verificato circa 43 minuti dopo l'attivazione dell'ECMP. Delle 900 richieste riuscite,
-400 sono state eseguite con un timeout di 30 secondi e tutte si sono concluse in meno di 2 secondi, quindi nulla è stato
-nascosto da un timeout troppo breve.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-Si è riprodotto di nuovo su una ricostruzione successiva lo stesso giorno, e quell'esecuzione offre un quadro più chiaro
-perché è stata campionata mentre la finestra trascorreva anziché dopo. 360 richieste, tutte con
-l'header `Host`, ogni batch abbinato a un controllo diretto verso l'origine:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| Tempo dopo `ONLINE` | Richieste | Fallimenti | Tasso | Controllo sull'origine |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| immediatamente | 60 | 8 | **13,3 %** | 30/30 riuscite |
-| ~25–40 min (3 batch) | 180 | 3 | **1,67 %** | 60/60 riuscite |
-| ~50 min | 120 | **0** | **0,00 %** | 40/40 riuscite |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-Decremento monotono fino a zero, e l'origine è risultata pulita in ogni batch — compreso
-quello in cui una richiesta VIP su otto è fallita.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**L'origine non era la causa.** Un batch di controllo diretto verso l'origine
-(`terraform output -raw origin_ip`, bypassando il VIP) ha eseguito 120 richieste su 120 senza errori *contemporaneamente
-ai* batch VIP che fallivano. Il guasto è da qualche parte nel percorso VIP, ECMP o CE.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-Due cose che deliberatamente non vengono affermate:
+Two things this is deliberately not called:
 
-- **Non è un difetto a regime.** Si risolve completamente e resta risolto — 120 su 120 al
-  minuto 50, e 60 su 60 su uno stack attivo da ore.
-- **Non concludete che sia assente da un piccolo campione iniziale.** Un batch di 60 richieste eseguito
-  immediatamente dopo una ricostruzione ha restituito 60 su 60, che è stato letto come "nessun transitorio"; lo stesso
-  deployment ha perso 8 richieste su 60 un'ora più tardi alla ricostruzione successiva. Sessanta richieste non bastano
-  a vedere una perdita a raffiche. Campionate 100 o più richieste, in batch separati nel tempo — la tabella qui sopra
-  ha richiesto 360 richieste per mostrare l'andamento.
-- **Non è attribuibile a un CE particolare.** Nulla in questa topologia fornisce un listener HTTP
-  per singolo nodo, quindi non c'è modo di associare una richiesta persa al nodo che l'ha persa.
-  Le interfacce esterne dei CE non hanno alcun listener HTTP — risponde solo il `/32` del VIP.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-Si è riprodotto su una ricostruzione pulita in un tenant diverso, quindi segue la topologia più che
-l'ambiente.
-
-<Aside type="caution" title="Non campionate 40 richieste concludendo che va tutto bene">
-Batch da 40 a 50 richieste appaiono al 100 % la maggior parte delle volte, anche all'interno della finestra di fallimento. È
-così che questo fenomeno è stato dapprima classificato erroneamente come un guasto continuo a basso tasso e poi come nessun guasto
-affatto. Campionate 100 o più richieste, in batch separati nel tempo.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## Altre due trappole di misurazione
+## Two more measurement traps
 
-Entrambe hanno prodotto risposte sbagliate ma convincenti in questo ambiente, e nessuna delle due è ovvia.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **Eseguite le sonde dall'interno della VNet, non dalla vostra workstation.** Un proxy aziendale può completare
-  esso stesso l'handshake TCP sulle porte comuni, per cui una sonda dalla workstation riporta una porta **aperta**
-  che in realtà è chiusa. Le porte 80 e 443 risultano aperte sugli indirizzi pubblici dei CE da una
-  workstation e sono chiuse quando la sonda parte dall'interno della VNet. Usate la VM client.
-- **La porta 22 su un CE risponde solo sull'indirizzo interno (SLI).** Sondato dalla VM client,
-  l'indirizzo interno di ciascun CE restituisce un banner OpenSSH, mentre i suoi indirizzi di management ed esterno
-  vanno in timeout — così come un indirizzo inutilizzato usato come controllo. eth0 è rinominata
-  `a-i-eth0` e non porta alcun IP host, perché appartiene al datapath. Quindi sondare l'indirizzo
-  con cui conoscete il nodo non vi dice nulla sullo stato SSH del nodo.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="Non codificate mai in modo fisso un indirizzo interno di un CE — vengono riassegnati a ogni ricostruzione">
-Azure non preserva quale CE ottiene quale indirizzo nella subnet interna, e gli
-indirizzi non seguono l'ordine dei nodi. Osservato il 2026-07-28: i tre CE avevano `10.0.3.7`,
-`10.0.3.5` e `10.0.3.4` — non sequenziali, e diversi da quelli che avevano prima di quella
-ricostruzione.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-Ciò che determina se cambiano è la **NIC**, non la VM. Sostituire solo le VM dei CE
-lascia le NIC al loro posto e ogni indirizzo sopravvive: verificato lo stesso giorno, quando l'adozione
-dei nomi degli oggetti derivati ha sostituito tutte e tre le VM dei CE e i tre indirizzi interni sono tornati
-identici. Una distruzione che rimuove le NIC li riassegna dal pool libero della subnet,
-nell'ordine in cui Azure lo riempie.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-La NIC del client di test si trova nella stessa subnet, quindi un indirizzo che ricordate come appartenente a un CE potrebbe
-ora essere quello del client — su questo deployment esso detiene `10.0.3.6`, che un CE deteneva prima di una
-ricostruzione precedente.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-Leggeteli invece di ricordarli:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Senza avere a disposizione lo stato Terraform, chiedete ad Azure per nome della NIC, che *è* stabile:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-Connettersi a un indirizzo ricordato vi porta sul nodo sbagliato, su una VM che non è un CE,
-o da nessuna parte — e quest'ultimo caso appare identico a "SSH non è abilitato".
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## Verificare che la superficie di comando on-box corrisponda ancora alla documentazione
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -280,7 +299,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` non scrive nulla, quindi è sicuro sulla demo in esecuzione.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -302,13 +352,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Raggiungere un Customer Edge"
-    description="Quale via di accesso si applica, le credenziali necessarie per ciascuna e perché la scelta non è una preferenza."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="Comandi BGP"
-    description="La vista on-box da FRR — stato del peering, tabella completa e ciò che questo nodo annuncia."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/ja/demo/index.mdx
+++ b/docs/ja/demo/index.mdx
@@ -8,54 +8,66 @@ sidebar:
   order: 5
   label: デモ
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-このデプロイは、CE の前段に Azure ロードバランサーを配置せずに **Azure における
-アクティブ/アクティブの Customer Edge 高可用性** を実証します。各 CE は eBGP で同一のホストルートを
-オリジネートし、Azure Route Server はそのすべてを VNet 内の等コストネクストホップとしてインストールします。
-したがって、トラフィック分散と障害ノードの除外が行われる場所は、ロードバランサーではなくルーティングファブリックです。
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-これらのページに記載された内容はすべて実稼働デプロイに対して実行されたものであり、示されている出力は
-実際に生成された出力です。この文が *カバーしていない* もの — フェイルオーバー、およびトラフィックが
-ネクストホップ間でどのように分割されるか — は、暗黙の前提とせず明示的に言及しています。
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## デプロイされるもの
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| 要素 | 内容 |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud テナント | `var.expected_xc_tenant` — テナント名を指定する唯一の場所 |
-| 名前空間 | CE サイトは `system`、オリジンプールとロードバランサーは `var.xc_app_namespace` |
-| Customer Edge | `var.ce_count` 台のシングルノード Secure Mesh v2 サイト（1〜3、可用性ゾーンごとに 1 台） |
-| CE ソフトウェア | `var.ce_sw_version` / `var.ce_os_version` で固定 |
-| Azure VM | それぞれ 3 つの NIC — 管理/SLO、外部、内部/SLI |
-| ルート交換 | Azure Route Server 1 台、ASN `var.rs_asn`、2 つのインスタンスアドレス |
-| ピアリング | CE ごとに 1 つ、`<key>-bgp` という名前、CE ASN は `var.ce_asn` |
-| アドバタイズされる VIP | `var.vip` を `/32` として、すべての CE が同一にオリジネート |
-| ロードバランサー | `var.lb_domain` を提供し、`var.origin_ip` のオリジンプールをバックエンドとする |
-| テストクライアント | 同一 VNet 内の VM。VIP へトラフィックを送出するために使用 |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-上記のいずれもコピーすべきリテラル値ではありません。すべての値はデプロイから読み取ることができ、
-各ページは値を明示するのではなく読み取っています:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -63,49 +75,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="VIP はすべての VNet CIDR の外側に配置する必要があります">
-`terraform/main.tf` には、VIP がハブとスポークの両方の CIDR の外側にあることをアサートし、
-そうでない場合はプランを拒否する `check` ブロックがあります。その理由として述べられているのは、
-VNet CIDR 内の VIP は、BGP ルートのほうがより具体的であるにもかかわらず、VNet 自身のシステムルートに負けるためです。
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-このガードを契約として扱ってください。このデモを別のアドレッシングに向け直す場合は、
-VIP もそれに合わせて VNet 範囲の外に移動させる必要があります。
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="リネームはリネームではなく再構築です">
-すべての名前が `var.component` から派生するため、これを変更するとデプロイ全体がリネームされます
-— しかし `site_prefix` は見た目だけの変更ではありません。これは各 CE の cloud-init における
-`ClusterName` になり、`custom_data` は置き換え専用で、cloud-init は CE の初回起動時にのみ実行されます。
-したがって、これを変更すると **すべての CE VM とその XC サイトが置き換えられ**、
-ECMP が再収束するまでの間、VIP は一時的にパケットロスを伴います。
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-これは理論上の話ではありません。稼働中のデモでこれらの派生名を採用したところ、3 台の CE VM、
-3 つのサイト、3 つの BGP オブジェクト、ロードバランサー、オリジンプール、Azure Route Server、
-Bastion、テストクライアントが置き換えられました — `23 to add, 3 to change, 26 to destroy`。
-既存のサイトをそのまま維持する必要がある場合は、`site_prefix` を現在の値に固定してください。
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## 次に参照するページ
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="デプロイする"
-    description="前提条件、指定が必要な 2 つの値、最初の apply が 2 フェーズになる理由、そして削除方法。"
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Terraform"
-    description="構成そのもの。再入力ではなく、デプロイに使用されるファイルから読み取ったもの。"
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="健全性を確認する"
-    description="順番に実行する 4 つのチェックと、障害のように見えて実際はそうではない正常な結果。"
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="プレゼンテーションする"
-    description="このデモで示せること、まだ示せないこと、そして ECMP を可視化する唯一のコマンド。"
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/ja/demo/spec.mdx
+++ b/docs/ja/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/ja/demo/terraform.mdx
+++ b/docs/ja/demo/terraform.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -15,10 +15,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -43,90 +46,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-以下に掲載するすべてのファイルは、実際にデプロイに使われるファイルそのものであり、貼り付けたものではなくビルド時にインポートされています。
-乖離しうるコピーは必ず乖離するため、ここで公開される内容が `terraform/` の内容と異なった瞬間に
-CI のチェックが失敗します。
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="構成をインラインで示さずインポートしている理由">
-コードフェンスに貼り付けた場合、この構成はページソースの一部となり、
-ページソースは 12 の言語に翻訳されます。内部のコメントも一緒に翻訳され、
-各ロケールがそれぞれ異なる誤った構成を公開することになります。
-インポートすれば、構成がページソースに入り込むことは一切ありません。
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## ルートモジュール
+## Root module
 
 ### `terraform/backend.tf`
 
-Azure ストレージバックエンド。その構成は init 時に与えられ、コミットされません。
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-読み取り専用のルックアップ。デプロイヤーを導出するために使用する Azure AD ID を含みます。
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-導出されたオブジェクト名を置く場所です。Terraform の変数デフォルト値は他の変数を参照できないため、各名前の変数はデフォルトで null とし、ここで解決します。
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-トップレベルの結線、テナントガード、そして VNet 外 VIP のチェック。デプロイ順序はこのファイルの先頭に記載されており、それが正式版です。
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-ドキュメントが名前を書き下す代わりに読み取るすべての値です。あるページがコマンドを示している場合、その背後にはここの出力があります。
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-xcsh のエンドポイントを var.expected_xc_tenant に固定します。これによりテナントが構成のプロパティになります。
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-コンポーネント、環境、デプロイヤー、そしてタグ。
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-サブスクリプション、リージョン、CIDR、Bastion、および Azure のオブジェクト名。
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-CE 数、サイトプレフィックス、ASN、イメージバージョン、VM サイズ。
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-テナント、アプリ名前空間、ロードバランサー、オリジンプール、そして VIP。
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Terraform の下限バージョンとプロバイダーの制約。xcsh の制約は上限のない下限指定であり、ロックファイルは gitignore されているため、init のたびに公開済みの最新プロバイダーが取得されます。
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## モジュール
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-リソースグループ、ハブ VNet、4 つのサブネット、Azure Route Server、およびオプションの Bastion。RouteServerSubnet には意図的に NSG もルートテーブルも付与していません。
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -138,7 +159,7 @@ Terraform の下限バージョンとプロバイダーの制約。xcsh の制�
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-各 eBGP セッションの Azure 側 — CE ごとに 1 つの bgpConnection を作成し、Route Server をその CE の eth0/SLO アドレスとピアリングします。
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -146,7 +167,7 @@ Terraform の下限バージョンとプロバイダーの制約。xcsh の制�
 
 ### `terraform/modules/ce-node/`
 
-ノードごとに 1 台の CE VM：IP 転送を有効にした 3 つの NIC、マーケットプレイスの plan ブロック、そして custom_data として引き渡す cloud-init。
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -158,13 +179,13 @@ Terraform の下限バージョンとプロバイダーの制約。xcsh の制�
 
 ### `terraform/modules/ce-topology/`
 
-純粋な計算のみで、プロバイダーもデータソースもありません：ce_count を展開して、すべての for_each を駆動する CE 単位のマップを生成します。資格情報なしで任意の N について plan によるテストが可能です。
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-VNet 内のテストクライアント。実効ルートの確認と VIP へのトラフィック生成に使用します。
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -174,7 +195,7 @@ VNet 内のテストクライアント。実効ルートの確認と VIP への�
 
 ### `terraform/modules/xc-site/`
 
-XC サイトオブジェクト、その BGP ピアリング、および `r-<uuid>` 形式の登録をサイト名で解決する登録承認。
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/ja/demo/verify.mdx
+++ b/docs/ja/demo/verify.mdx
@@ -7,17 +7,17 @@ sidebar:
   order: 30
   label: 検証
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-プレゼンテーションの前にこれらを実行してください。各チェックは障害箇所を段階的に絞り込むため、
-失敗した場合は「何かがおかしい」だけでなく、その内容が分かります。
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-すべてのコマンドは必要な情報をデプロイメントから読み取ります。以下を一度設定すれば、残りは続けて実行できます。
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -27,13 +27,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## 4 つのチェック、この順序で
+## Four checks, in this order
 
 <Steps>
 
-1. **すべてのサイトが `ONLINE` である。** これが成り立たなければ、下流のどれも成り立ちません。
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -43,17 +49,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 に観測、CE 3 台:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **すべてのピアリングがその CE の VIP アドバタイズを学習している。** 各ピアリングを
-   個別にクエリしてください — 下記の最初の罠を参照。ここがデモで最も頻繁に
-   壊れているように見えて、実際は正常な箇所です。
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -65,28 +71,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 に観測:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   3 つのピアリング、3 つの異なるネクストホップ、1 つのプレフィックス。これで ECMP の
-   アドバタイズ側が証明されました。
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **クライアントの有効ルートがすべてのネクストホップを保持している。** これは VNet が
-   プログラムした ECMP そのものです — CE が主張する内容ではなく、Azure が実際に処理した結果です。
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -94,181 +100,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   2026-07-28 に観測:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` であり、`nh` に CE ごとに 1 エントリあることがチェック内容です。**順序に
-   意味はなく、安定もしていません** — Azure は呼び出しごとに異なる順序で返すため、以前の実行と
-   比較するのではなく数を数えてください。3 つ期待している場所にネクストホップが 1 つしかない場合は、
-   ある CE がアドバタイズを停止していることを意味し、ステップ 2 でどれかが判別できます。
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **VIP がトラフィックを処理している。** クライアント VM から、**`Host` ヘッダー付きで** — 2 番目の
-   罠を参照。問題を確認できる十分な数のリクエストをサンプルしてください。数十件では、
-   下記で説明する収束ウィンドウの中でも 100 % と読み取れてしまいます。
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   2026-07-28 に観測:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## 罠: あるピアリングにルートが 1 つしか表示されるが、それは正しい
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` は指定したピアリングにスコープされます。**そのピア**がアドバタイズした
-内容を報告するもので、Route Server のテーブル全体ではありません。
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-そのため 1 つのピアリングだけをクエリすると、単一のネクストホップ経由の単一の VIP `/32` が返り、
-これを「1 つの CE だけがアドバタイズしている — 他はダウンしている」と読みたくなります。何も
-ダウンしていません。他のアドバタイズはそれぞれのピアリング上で見えており、それがステップ 2 が
-ループしている対象です。
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-単一のピアリングクエリから ECMP を確認することはできません。すべてのピアリングをループするか、
-1 回の呼び出しでマージ結果を示すクライアントの有効ルートテーブルを読んでください。
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## 罠: ベア IP のリクエストが 404 を返す
+## Trap: a bare-IP request returns 404
 
-ロードバランサーは `Host` でマッチします。VIP は、そのアドレスに接続してきた相手に何かを
-返す仮想サーバーではありません。
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-以下の両方は、正常なデプロイメントに対する同じ実行から得られたものです:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**ベア IP の 404 は経路が機能していることの証拠です** — リクエストは CE に到達し、CE の
-プロキシが応答し、設定済みドメインに一致しなかったため拒否したということです。これを障害と
-読み取ると BGP を調べに行くことになりますが、そこには何の問題も見つかりません。
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-デモ中も同じです。ドメインを解決するのではなくブラウザにアドレスを直接入力すると、404 が返ります。
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## VIP は最初の 45 分間ほどリクエストをドロップし、その後止まる
+## A fresh deployment can have a convergence transient
 
-新規構築したスタックでは、CE が `ONLINE` に到達してから最初の約 45 分間、VIP はごく一部の
-リクエストを失い、その後はクリーンに処理します。クライアント VM から 1,470 リクエストを
-すべて `Host` ヘッダー付きで測定した結果:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| ウィンドウ | リクエスト | 失敗 | 率 |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| ECMP 確立後の最初の約 45 分 | 570 | 12 | **2.11 %** |
-| その後の 23 分間 | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-すべての失敗は `curl: (28)` — 受信バイト数 0 のタイムアウト — であり、HTTP エラー
-ステータスではありませんでした。最後の失敗は ECMP 確立から約 43 分後に発生しました。クリーンな
-900 リクエストのうち 400 は 30 秒のタイムアウトで実行し、すべて 2 秒未満で完了したため、
-短いタイムアウトによって隠された事象はありません。
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-同日の後の再構築でも再現し、その実行はウィンドウ経過後ではなく経過中にサンプルしたため、
-より明確な描像が得られています。360 リクエスト、すべて `Host` ヘッダー付き、各バッチは
-オリジンへの直接コントロールと対になっています:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| `ONLINE` 後の経過時間 | リクエスト | 失敗 | 率 | オリジンコントロール |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| 直後 | 60 | 8 | **13.3 %** | 30/30 クリーン |
-| 約 25〜40 分（3 バッチ） | 180 | 3 | **1.67 %** | 60/60 クリーン |
-| 約 50 分 | 120 | **0** | **0.00 %** | 40/40 クリーン |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-単調にゼロまで減少し、オリジンはすべてのバッチでクリーンでした — VIP リクエストの 8 件に 1 件が
-失敗したバッチも含めてです。
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**原因はオリジンではありませんでした。** オリジンへ直接向けたコントロールバッチ
-（`terraform output -raw origin_ip`、VIP をバイパス）は、失敗している VIP バッチと*同時に*
-実行して 120 件中 120 件クリーンでした。障害は VIP、ECMP、または CE の経路のどこかにあります。
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-これについて意図的にそう呼んでいない 2 点:
+Two things this is deliberately not called:
 
-- **定常状態の欠陥ではありません。** 完全に解消し、その状態が続きます — 50 分時点で 120 件中
-  120 件、数時間稼働していたスタックでは 60 件中 60 件。
-- **少数の早期サンプルから存在しないと結論しないでください。** ある再構築の直後に取得した
-  60 リクエストのバッチは 60 件中 60 件を返し、「一時的事象なし」と読めました。しかし同じ
-  デプロイメントは、次の再構築の 1 時間後に 60 件中 8 件を失いました。バースト的な損失を
-  見るには 60 リクエストでは不十分です。時間を分けたバッチで 100 件以上をサンプルしてください —
-  上記の表は形状を示すのに 360 件を必要としました。
-- **特定の CE に帰属させることはできません。** このトポロジーではノードごとの HTTP リスナーが
-  存在しないため、ドロップされたリクエストをドロップしたノードに結び付ける方法がありません。
-  CE の外部インターフェースには HTTP リスナーがまったくありません — VIP `/32` のみが応答します。
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-別のテナントでのクリーンな再構築でも再現したため、環境ではなくトポロジーに起因します。
-
-<Aside type="caution" title="40 リクエストをサンプルして問題なしと結論しないこと">
-40〜50 件のバッチは、失敗ウィンドウの中でもほとんどの場合 100 % と読み取れます。そのために
-これは最初、継続的な低率の障害として誤って特徴付けられ、次に障害はまったくないと
-誤解されました。時間を分けたバッチで 100 件以上をサンプルしてください。
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## さらに 2 つの測定上の罠
+## Two more measurement traps
 
-どちらもこの環境で自信を持った誤った答えを生み、いずれも自明ではありません。
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **ワークステーションからではなく、VNet 内部からプローブしてください。** 企業プロキシは
-  一般的なポートで TCP ハンドシェイクを自ら完了することがあるため、ワークステーションからの
-  プローブは実際には閉じているポートを**オープン**と報告します。ポート 80 と 443 は
-  ワークステーションからは CE のパブリックアドレスでオープンと読み取れますが、VNet 内部から
-  プローブすると閉じています。クライアント VM を使用してください。
-- **CE のポート 22 は内部 (SLI) アドレスでのみ応答します。** クライアント VM からプローブすると、
-  各 CE の内部アドレスは OpenSSH バナーを返しますが、管理アドレスと外部アドレスはタイムアウトします —
-  コントロールとして使用した未使用アドレスと同様です。eth0 は `a-i-eth0` にリネームされ、
-  データパスが所有しているためホスト IP を持ちません。したがって、あなたがそのノードを識別している
-  アドレスをプローブしても、ノードの SSH 状態については何も分かりません。
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="CE の内部アドレスをハードコードしないこと — 再構築ごとに再割り当てされます">
-Azure は内部サブネットでどの CE がどのアドレスを得るかを保持せず、アドレスはノード順でも
-ありません。2026-07-28 に観測した 3 台の CE は `10.0.3.7`、`10.0.3.5`、`10.0.3.4` を
-保持していました — 連続しておらず、その再構築前に保持していたものとも異なります。
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-移動するかどうかを決めるのは VM ではなく **NIC** です。CE VM のみを置き換えると NIC は
-そのまま残り、すべてのアドレスが維持されます。同日に検証済みで、派生オブジェクト名を採用した際に
-3 台の CE VM すべてが置き換えられましたが、3 つの内部アドレスは同一のまま戻ってきました。
-NIC を削除するテアダウンでは、Azure が埋める順序でサブネットの空きプールから再割り当てされます。
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-テストクライアントの NIC は同じサブネットにあるため、CE のものとして記憶していたアドレスが
-今はクライアントのものになっている可能性があります — このデプロイメントでは `10.0.3.6` を
-保持しており、これは以前の再構築前に CE が保持していたものです。
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-記憶するのではなく読み取ってください:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Terraform state が手元にない場合は、*安定している* NIC 名で Azure に問い合わせてください:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-記憶していたアドレスに接続すると、誤ったノード、CE ではない VM、あるいはどこにも
-たどり着きません — そして最後のケースは「SSH が有効化されていない」と見分けがつきません。
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## オンボックスのコマンド面がドキュメントと一致していることを確認する
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -276,7 +296,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` は何も書き込まないため、稼働中のデモに対して安全です。
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -298,13 +349,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Customer Edge への接続"
-    description="どのアクセス経路が該当するか、それぞれに必要な認証情報、そしてこの選択が好みの問題ではない理由。"
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="BGP コマンド"
-    description="FRR からのオンボックスビュー — ピアリング状態、完全なテーブル、そしてこのノードがアドバタイズしている内容。"
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/ko/demo/index.mdx
+++ b/docs/ko/demo/index.mdx
@@ -8,54 +8,66 @@ sidebar:
   order: 5
   label: 데모
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-이 배포는 CE 앞에 Azure 로드 밸런서를 두지 않고 **Azure에서 액티브/액티브 Customer Edge 고가용성**을
-구현하는 방식을 보여줍니다. 각 CE는 동일한 호스트 경로를 eBGP로 원발하며, Azure Route Server는
-이들 모두를 VNet 내의 등가 넥스트홉으로 설치합니다. 따라서 트래픽 분산과 장애 노드 제거는
-로드 밸런서가 아니라 라우팅 패브릭에서 이루어지도록 되어 있습니다.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-이 페이지들의 모든 내용은 실제 운영 중인 배포를 대상으로 실행되었으며, 표시된 출력은 그 배포가
-생성한 실제 출력입니다. 그 문장이 *포함하지 않는* 것 — 페일오버, 그리고 트래픽이 넥스트홉 간에
-어떻게 나뉘는지 — 은 가정하도록 남겨두지 않고 명시적으로 밝혀 둡니다.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## 배포되는 구성 요소
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| 구성 요소 | 설명 |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud 테넌트 | `var.expected_xc_tenant` — 테넌트 이름이 지정되는 유일한 위치 |
-| 네임스페이스 | CE 사이트는 `system`에, 오리진 풀과 로드 밸런서는 `var.xc_app_namespace`에 |
-| Customer Edge | `var.ce_count`개의 단일 노드 Secure Mesh v2 사이트, 1~3개, 가용 영역당 하나 |
-| CE 소프트웨어 | `var.ce_sw_version` / `var.ce_os_version`으로 고정 |
-| Azure VM | 각각 NIC 3개 — 관리/SLO, 외부, 내부/SLI |
-| 경로 교환 | Azure Route Server 1개, ASN `var.rs_asn`, 인스턴스 주소 2개 |
-| 피어링 | CE당 하나, 이름은 `<key>-bgp`, CE ASN은 `var.ce_asn` |
-| 광고되는 VIP | `var.vip`를 `/32`로, 모든 CE가 동일하게 원발 |
-| 로드 밸런서 | `var.lb_domain`을 서비스하며, `var.origin_ip`의 오리진 풀이 백엔드 |
-| 테스트 클라이언트 | 동일 VNet 내부의 VM으로, VIP를 향해 트래픽을 발생시키는 용도 |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-위의 어떤 것도 그대로 복사해야 할 리터럴이 아닙니다. 모든 값은 배포에서 읽어올 수 있으며,
-각 페이지는 값을 명시하는 대신 읽어옵니다:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -63,49 +75,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="VIP는 모든 VNet CIDR 바깥에 있어야 합니다">
-`terraform/main.tf`에는 VIP가 허브 및 스포크 CIDR 양쪽 모두의 바깥에 있음을 단언하는 `check`
-블록이 있으며, 그렇지 않으면 플랜을 거부합니다. 그 이유는 VNet CIDR 내부의 VIP는 BGP 경로가
-더 구체적임에도 불구하고 VNet 자체의 시스템 경로에 밀리기 때문입니다.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-이 가드를 계약으로 여기십시오. 이 데모를 다른 주소 체계로 재지정한다면 VIP도 함께 VNet 범위
-바깥으로 이동해야 합니다.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="이름 변경은 재빌드이지, 단순한 이름 바꾸기가 아닙니다">
-모든 이름이 `var.component`에서 파생되기 때문에 이를 변경하면 배포 전체의 이름이 바뀝니다 —
-그러나 `site_prefix`는 겉모습만 바뀌는 변경이 아닙니다. 이 값은 각 CE의 cloud-init에서
-`ClusterName`이 되고, `custom_data`는 교체 전용이며, cloud-init은 CE의 최초 부팅 시에만
-실행됩니다. 따라서 이를 변경하면 **모든 CE VM과 해당 XC 사이트가 교체되며**, ECMP가 재수렴하는
-동안 VIP는 잠시 손실이 발생합니다.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-이는 이론상의 이야기가 아닙니다. 실행 중인 데모에 이러한 파생 이름을 적용한 결과 CE VM 3개,
-사이트 3개, BGP 객체 3개, 로드 밸런서, 오리진 풀, Azure Route Server, Bastion 및 테스트
-클라이언트가 교체되었습니다 — `23 to add, 3 to change, 26 to destroy`.
-기존 사이트를 그대로 유지해야 한다면 `site_prefix`를 현재 값으로 고정하십시오.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## 다음 단계
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="배포하기"
-    description="전제 조건, 반드시 제공해야 하는 두 개의 값, 첫 apply가 2단계인 이유, 그리고 해체 방법."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Terraform 구성"
-    description="다시 타이핑한 것이 아니라, 실제로 배포하는 파일에서 읽어온 구성 자체."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="정상 상태 확인하기"
-    description="순서대로 진행하는 네 가지 점검과, 장애처럼 보이지만 실제로는 정상인 결과들."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="시연하기"
-    description="이 데모가 보여줄 수 있는 것, 아직 보여줄 수 없는 것, 그리고 ECMP를 눈에 보이게 만드는 단 하나의 명령."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/ko/demo/spec.mdx
+++ b/docs/ko/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/ko/demo/terraform.mdx
+++ b/docs/ko/demo/terraform.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -15,10 +15,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -43,89 +46,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-아래의 모든 파일은 실제로 배포되는 파일이며, 붙여넣은 것이 아니라 빌드 시점에 가져온 것입니다.
-어긋날 수 있는 복사본은 결국 어긋나기 때문에, 여기에 게시된 내용이 `terraform/`에 있는 내용과
-달라지는 순간 CI의 검사가 실패합니다.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="구성을 인라인으로 표시하지 않고 가져오는 이유">
-코드 펜스에 붙여넣으면 이 구성은 페이지 소스의 일부가 되며, 페이지 소스는 12개 언어로
-번역됩니다. 그 안의 주석도 함께 번역되어, 각 로케일이 서로 다른 잘못된 구성을 게시하게
-됩니다. 가져오는 방식이라면 구성이 페이지 소스에 아예 들어가지 않습니다.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## 루트 모듈
+## Root module
 
 ### `terraform/backend.tf`
 
-Azure 스토리지 백엔드입니다. 해당 구성은 init 시점에 제공되며 커밋되지 않습니다.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-읽기 전용 조회이며, 배포자를 도출하는 데 사용되는 Azure AD 자격 증명도 포함합니다.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-도출된 객체 이름이 위치하는 곳입니다. Terraform 변수 기본값은 다른 변수를 참조할 수 없으므로, 각 이름 변수는 기본값이 null이며 여기에서 확정됩니다.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-최상위 연결 구성, 테넌트 가드, 그리고 VNet 외부 VIP 검사입니다. 배포 순서는 이 파일 상단에 문서화되어 있으며, 그것이 정본입니다.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-문서가 이름을 직접 지정하는 대신 읽어오는 모든 값입니다. 어떤 페이지가 명령을 표시한다면, 그 배후에는 여기의 출력값이 있습니다.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-xcsh 엔드포인트를 var.expected_xc_tenant에 고정하며, 이로 인해 테넌트가 구성의 속성이 됩니다.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-구성 요소, 환경, 배포자, 태그입니다.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-구독, 리전, CIDR, Bastion, 그리고 Azure 객체 이름입니다.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-CE 개수, 사이트 접두사, ASN, 이미지 버전, VM 크기입니다.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-테넌트, 앱 네임스페이스, 로드 밸런서, 오리진 풀, 그리고 VIP입니다.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Terraform 최소 버전과 프로바이더 제약입니다. xcsh 제약은 상한이 없는 최소 버전이며 lock 파일은 gitignore 처리되어 있으므로, 모든 init은 최신 게시 프로바이더를 가져옵니다.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## 모듈
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-리소스 그룹, 허브 VNet, 네 개의 서브넷, Azure Route Server, 그리고 선택적 Bastion입니다. RouteServerSubnet은 의도적으로 NSG나 라우팅 테이블을 갖지 않습니다.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -137,7 +159,7 @@ Terraform 최소 버전과 프로바이더 제약입니다. xcsh 제약은 상�
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-각 eBGP 세션의 Azure 측입니다 — CE마다 하나의 bgpConnection으로, Route Server를 해당 CE의 eth0/SLO 주소와 피어링합니다.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -145,7 +167,7 @@ Terraform 최소 버전과 프로바이더 제약입니다. xcsh 제약은 상�
 
 ### `terraform/modules/ce-node/`
 
-노드당 하나의 CE VM입니다: IP 포워딩이 설정된 세 개의 NIC, 마켓플레이스 plan 블록, 그리고 custom_data로 전달되는 cloud-init입니다.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -157,13 +179,13 @@ Terraform 최소 버전과 프로바이더 제약입니다. xcsh 제약은 상�
 
 ### `terraform/modules/ce-topology/`
 
-순수 계산만 수행하며 프로바이더도 데이터 소스도 없습니다: ce_count를 모든 for_each를 구동하는 CE별 맵으로 확장합니다. 자격 증명 없이도 임의의 N에서 plan 테스트가 가능합니다.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-VNet 내부의 테스트 클라이언트로, 유효 경로를 확인하고 VIP로 트래픽을 발생시키는 데 사용됩니다.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -173,7 +195,7 @@ VNet 내부의 테스트 클라이언트로, 유효 경로를 확인하고 VIP�
 
 ### `terraform/modules/xc-site/`
 
-XC 사이트 객체, 해당 BGP 피어링, 그리고 사이트 이름으로 `r-<uuid>` 등록을 확인하는 등록 승인입니다.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/ko/demo/verify.mdx
+++ b/docs/ko/demo/verify.mdx
@@ -7,16 +7,17 @@ sidebar:
   order: 30
   label: 검증
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-발표 전에 이 항목들을 실행하십시오. 각 점검은 결함이 있을 수 있는 범위를 좁혀 주므로, 실패가 발생하면 단순히 무언가 잘못되었다는 사실만이 아니라 그 이상의 정보를 알려 줍니다.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-모든 명령은 필요한 값을 배포에서 읽어 옵니다. 다음을 한 번 설정해 두면 나머지는 그대로 따라갑니다:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -26,13 +27,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## 네 가지 점검, 이 순서대로
+## Four checks, in this order
 
 <Steps>
 
-1. **모든 사이트가 `ONLINE`인지 확인합니다.** 이것이 참이 아니면 그 아래의 어떤 것도 참일 수 없습니다.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -42,15 +49,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 관측, CE 3대:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **모든 피어링이 해당 CE의 VIP 광고를 학습하고 있는지 확인합니다.** 각 피어링을 개별적으로 쿼리하십시오 — 아래 첫 번째 함정을 참고하십시오. 데모가 고장 난 것처럼 보이지만 실제로는 아닌 경우가 여기서 가장 자주 발생합니다.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -62,26 +71,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 관측:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   피어링 3개, 서로 다른 넥스트 홉 3개, 프리픽스 1개. 이것이 ECMP의 광고 측면이 입증된 모습입니다.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **클라이언트의 유효 경로가 모든 넥스트 홉을 담고 있는지 확인합니다.** 이것이 VNet이 프로그래밍한 그대로의 ECMP 자체입니다 — CE가 주장하는 바가 아니라, Azure가 실제로 처리한 결과입니다.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -89,133 +100,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   2026-07-28 관측:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `nh`에 CE당 항목이 하나씩 있고 `state: Active`인지가 점검 포인트입니다. **순서는 의미가 없으며 안정적이지도 않습니다** — Azure는 호출마다 다른 순서로 반환하므로, 이전 실행과 비교하지 말고 개수를 세십시오. 넥스트 홉이 세 개여야 하는데 하나만 있다면 어떤 CE가 광고를 중단한 것이며, 2단계에서 어느 것인지 확인할 수 있습니다.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **VIP가 트래픽을 서비스하는지 확인합니다.** 클라이언트 VM에서, 그리고 **`Host` 헤더와 함께** 수행하십시오 — 두 번째 함정을 참고하십시오. 문제를 확인할 수 있을 만큼 충분한 요청을 샘플링하십시오. 수십 건 정도는 아래에 설명한 수렴 구간 안에서도 100 %로 나옵니다.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   2026-07-28 관측:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## 함정: 하나의 피어링이 경로 하나만 보여 주는 것은 정상입니다
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes`는 지정한 피어링으로 범위가 한정됩니다. Route Server의 전체 테이블이 아니라 **그** 피어가 광고한 내용을 보고합니다.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-따라서 피어링 하나만 쿼리하면 단일 넥스트 홉을 통한 단일 VIP `/32`가 반환되고, 이를 "CE 하나만 광고 중이고 나머지는 다운되었다"로 읽기 쉽습니다. 다운된 것은 없습니다. 다른 광고들은 각자의 피어링에서 확인할 수 있으며, 2단계에서 반복하는 것이 바로 그것입니다.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-단일 피어링 쿼리로는 ECMP를 확인할 수 없습니다. 모든 피어링을 순회하거나, 병합된 결과를 한 번의 호출로 보여 주는 클라이언트의 유효 경로 테이블을 읽으십시오.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## 함정: 베어 IP 요청은 404를 반환합니다
+## Trap: a bare-IP request returns 404
 
-로드 밸런서는 `Host`로 매칭합니다. VIP는 해당 주소로 접속하는 누구에게나 무언가를 제공하는 가상 서버가 아닙니다.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-다음 두 결과는 정상 배포에 대한 동일한 실행에서 나온 것입니다:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**베어 IP 404는 경로가 동작한다는 증거입니다** — 요청이 CE에 도달했고, CE의 프록시가 응답했으며, 구성된 도메인과 일치하는 것이 없어 거부한 것입니다. 이를 장애로 해석하면 BGP를 들여다보게 되지만 거기에는 잘못된 것이 없습니다.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-데모 중에도 마찬가지입니다. 도메인을 해석하는 대신 브라우저에 주소를 직접 입력하면 404가 나옵니다.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## VIP는 처음 45분 동안 요청을 일부 버리다가 멈춥니다
+## A fresh deployment can have a convergence transient
 
-새로 빌드한 스택에서는 CE가 `ONLINE`에 도달한 뒤 대략 처음 45분 동안 VIP가 요청의 극히 일부를 잃고, 그 이후에는 깨끗하게 서비스합니다. 클라이언트 VM에서 모두 `Host` 헤더를 붙여 1,470건의 요청으로 측정한 결과:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| 구간 | 요청 수 | 실패 수 | 비율 |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| ECMP가 올라온 후 처음 약 45분 | 570 | 12 | **2.11 %** |
-| 그 다음 23분 | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-모든 실패는 `curl: (28)`이었습니다 — 수신 바이트 0의 타임아웃이며, HTTP 오류 상태가 아닙니다. 마지막 실패는 ECMP가 올라온 뒤 약 43분에 발생했습니다. 정상 처리된 900건 중 400건은 30초 타임아웃으로 실행했으며 모두 2초 이내에 완료되었으므로, 짧은 타임아웃 때문에 가려진 것은 없습니다.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-같은 날 나중에 재빌드했을 때도 재현되었고, 그 실행이 더 명확한 그림을 보여 줍니다. 구간이 지난 뒤가 아니라 구간이 경과하는 동안 샘플링했기 때문입니다. 모두 `Host` 헤더를 붙인 360건의 요청이며, 각 배치는 오리진으로 직접 보내는 대조군과 짝을 이루었습니다:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| `ONLINE` 이후 경과 시간 | 요청 수 | 실패 수 | 비율 | 오리진 대조군 |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| 즉시 | 60 | 8 | **13.3 %** | 30/30 정상 |
-| 약 25–40분 (배치 3회) | 180 | 3 | **1.67 %** | 60/60 정상 |
-| 약 50분 | 120 | **0** | **0.00 %** | 40/40 정상 |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-단조 감소하여 0에 이르렀고, 모든 배치에서 오리진은 정상이었습니다 — VIP 요청 여덟 건 중 한 건이 실패한 배치에서도 마찬가지였습니다.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**오리진은 원인이 아니었습니다.** VIP를 우회해 오리진으로 직접 보낸 대조 배치(`terraform output -raw origin_ip`)는 실패하는 VIP 배치와 *동시에* 실행되어 120건 중 120건이 정상이었습니다. 결함은 VIP, ECMP 또는 CE 경로 어딘가에 있습니다.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-이것을 의도적으로 이렇게 부르지 않는 두 가지 이유:
+Two things this is deliberately not called:
 
-- **정상 상태의 결함이 아닙니다.** 완전히 해소되고 그 상태가 유지됩니다 — 50분 시점에 120건 중 120건, 그리고 몇 시간 동안 가동된 스택에서 60건 중 60건.
-- **소규모 초기 샘플만으로 없다고 결론짓지 마십시오.** 어느 재빌드 직후에 수행한 60건 배치는 60건 중 60건을 반환해 "일시적 문제 없음"으로 읽혔지만, 같은 배포가 그 다음 재빌드에서 한 시간 뒤 60건 중 8건을 잃었습니다. 60건으로는 버스트성 손실을 확인하기에 부족합니다. 시간 간격을 둔 배치로 100건 이상을 샘플링하십시오 — 위 표의 형태를 드러내는 데 360건이 필요했습니다.
-- **특정 CE의 문제로 귀속할 수 없습니다.** 이 토폴로지에는 노드별 HTTP 리스너가 없으므로, 버려진 요청을 그것을 버린 노드에 결부할 방법이 없습니다. CE 외부 인터페이스에는 HTTP 리스너가 전혀 없습니다 — VIP `/32`만 응답합니다.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-다른 테넌트에서 깨끗하게 재빌드했을 때도 재현되었으므로, 환경이 아니라 토폴로지를 따라갑니다.
-
-<Aside type="caution" title="40건만 샘플링하고 괜찮다고 결론짓지 마십시오">
-40~50건 규모의 배치는 실패 구간 안에서도 대부분 100 %로 나옵니다. 이 때문에 처음에는 지속적인 저비율 결함으로 잘못 규정했다가, 그 다음에는 아예 결함이 없다고 잘못 판단했습니다. 시간 간격을 둔 배치로 100건 이상을 샘플링하십시오.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## 측정 함정 두 가지 더
+## Two more measurement traps
 
-둘 다 이 환경에서 확신에 찬 오답을 만들어 냈고, 어느 쪽도 자명하지 않습니다.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **워크스테이션이 아니라 VNet 내부에서 프로브하십시오.** 기업 프록시는 일반적인 포트에서 TCP 핸드셰이크를 스스로 완료할 수 있으므로, 워크스테이션 프로브는 실제로는 닫혀 있는 포트를 **열림**으로 보고합니다. 포트 80과 443은 워크스테이션에서 CE 공인 주소에 대해 열림으로 읽혔지만 VNet 내부에서 프로브하면 닫혀 있습니다. 클라이언트 VM을 사용하십시오.
-- **CE의 22번 포트는 내부(SLI) 주소에서만 응답합니다.** 클라이언트 VM에서 프로브하면 각 CE의 내부 주소는 OpenSSH 배너를 반환하는 반면, 관리 주소와 외부 주소는 타임아웃됩니다 — 대조군으로 사용한 미사용 주소도 마찬가지입니다. eth0은 `a-i-eth0`으로 이름이 바뀌고 호스트 IP를 갖지 않는데, 데이터패스가 그것을 소유하기 때문입니다. 따라서 노드를 식별할 때 사용하는 주소를 프로브하는 것만으로는 그 노드의 SSH 상태에 대해 아무것도 알 수 없습니다.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="CE 내부 주소를 절대 하드코딩하지 마십시오 — 재빌드할 때마다 재할당됩니다">
-Azure는 내부 서브넷에서 어떤 CE가 어떤 주소를 갖는지 보존하지 않으며, 주소는 노드 순서대로 배정되지도 않습니다. 2026-07-28 관측 당시 세 CE는 `10.0.3.7`, `10.0.3.5`, `10.0.3.4`를 보유했습니다 — 연속적이지 않으며, 그 재빌드 이전에 보유했던 것과도 다릅니다.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-이동 여부를 결정하는 것은 VM이 아니라 **NIC**입니다. CE VM만 교체하면 NIC은 그대로 남고 모든 주소가 유지됩니다. 같은 날 파생된 오브젝트 이름을 채택하면서 CE VM 세 대가 모두 교체되었을 때 세 개의 내부 주소가 동일하게 돌아온 것으로 검증했습니다. NIC까지 제거하는 teardown은 Azure가 채우는 임의의 순서대로 서브넷의 가용 풀에서 주소를 재할당합니다.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-테스트 클라이언트의 NIC도 같은 서브넷에 있으므로, CE의 것으로 기억하는 주소가 지금은 클라이언트의 것일 수 있습니다 — 이 배포에서는 `10.0.3.6`을 보유하고 있으며, 이는 이전 재빌드에서 어떤 CE가 갖고 있던 주소입니다.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-기억하지 말고 읽어 오십시오:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Terraform 상태를 사용할 수 없다면, *실제로* 안정적인 NIC 이름으로 Azure에 조회하십시오:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-기억에 의존한 주소로 접속하면 잘못된 노드나 CE가 아닌 VM에 도달하거나, 아무 데도 도달하지 못합니다 — 그리고 마지막 경우는 "SSH가 활성화되지 않았다"와 똑같아 보입니다.
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## 온박스 명령 표면이 여전히 문서와 일치하는지 확인
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -223,7 +296,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check`는 아무것도 기록하지 않으므로 라이브 데모에 대해 안전합니다.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -245,13 +349,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Customer Edge에 접속하기"
-    description="어떤 접속 경로가 해당되는지, 각각에 필요한 자격 증명, 그리고 그 선택이 취향의 문제가 아닌 이유."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="BGP 명령"
-    description="FRR에서 본 온박스 관점 — 피어링 상태, 전체 테이블, 그리고 이 노드가 광고하는 내용."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/pt-br/demo/index.mdx
+++ b/docs/pt-br/demo/index.mdx
@@ -10,55 +10,66 @@ sidebar:
   order: 5
   label: Demonstração
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Esta implantação demonstra a **alta disponibilidade ativo/ativo do Customer Edge no Azure**
-sem nenhum balanceador de carga do Azure à frente dos CEs. Cada CE origina a mesma rota de host
-por eBGP, e o Azure Route Server instala todas elas como próximos saltos de custo igual na VNet.
-A malha de roteamento, e não um balanceador de carga, é portanto onde a distribuição de tráfego
-e a remoção de nós com falha devem acontecer.
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-Tudo nestas páginas foi executado contra a implantação ativa, e a saída exibida é a
-saída que ela produziu. O que essa frase *não* cobre — failover e como o tráfego se divide
-entre os próximos saltos — é apontado explicitamente, em vez de ser deixado como suposição.
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## O que ela implanta
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| Peça | O que é |
+| Piece | What it is |
 | --- | --- |
-| Locatário do F5 Distributed Cloud | `var.expected_xc_tenant` — o único lugar em que o locatário é nomeado |
-| Namespaces | Sites CE em `system`; pool de origem e balanceador de carga em `var.xc_app_namespace` |
-| Customer Edges | `var.ce_count` sites Secure Mesh v2 de nó único, de 1 a 3, um por zona de disponibilidade |
-| Software do CE | fixado por `var.ce_sw_version` / `var.ce_os_version` |
-| VMs do Azure | três NICs cada — gerenciamento/SLO, externa, interna/SLI |
-| Troca de rotas | um Azure Route Server, ASN `var.rs_asn`, dois endereços de instância |
-| Peerings | um por CE, nomeado `<key>-bgp`, ASN do CE `var.ce_asn` |
-| VIP anunciado | `var.vip` como um `/32`, originado de forma idêntica por cada CE |
-| Balanceador de carga | atende `var.lb_domain`, apoiado por um pool de origem em `var.origin_ip` |
-| Cliente de teste | uma VM dentro da mesma VNet, para direcionar tráfego ao VIP |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-Nada acima é um literal que você deva copiar. Cada valor é legível a partir da implantação,
-e cada página o lê em vez de nomeá-lo:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -66,49 +77,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="O VIP deve ficar fora de todo CIDR de VNet">
-`terraform/main.tf` contém um bloco `check` que verifica se o VIP está fora dos CIDRs do hub
-e do spoke, e recusa o plano caso contrário. A razão declarada é que um VIP dentro de um
-CIDR de VNet perde para a rota de sistema da própria VNet, apesar de a rota BGP ser mais específica.
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-Trate a proteção como o contrato: se você reapontar esta demonstração para um endereçamento diferente, o
-VIP tem de sair das faixas da VNet junto com ele.
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="Renomear é uma reconstrução, não uma renomeação">
-Como cada nome deriva de `var.component`, alterá-lo renomeia toda a
-implantação — mas `site_prefix` não é uma mudança cosmética. Ele se torna o `ClusterName`
-no cloud-init de cada CE, `custom_data` é somente-substituição, e o cloud-init roda apenas no
-primeiro boot de um CE. Portanto, alterá-lo **substitui cada VM de CE e seu site XC**, e o VIP
-fica então brevemente com perdas enquanto o ECMP reconverge.
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-Isso não é teórico: adotar esses nomes derivados na demonstração em execução substituiu três
-VMs de CE, três sites, três objetos BGP, o balanceador de carga, o pool de origem, o Azure
-Route Server, o Bastion e o cliente de teste — `23 to add, 3 to change, 26 to destroy`.
-Fixe `site_prefix` no valor atual quando precisar que os sites existentes permaneçam intactos.
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## Para onde ir em seguida
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="Implante-a"
-    description="Pré-requisitos, os dois valores que você deve fornecer, por que o primeiro apply é em duas fases e como desfazê-la."
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="O Terraform"
-    description="A própria configuração, lida a partir dos arquivos que a implantam em vez de redigitada."
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="Comprove sua integridade"
-    description="Quatro verificações em ordem, e os resultados de aparência normal que parecem uma indisponibilidade e não são."
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="Apresente-a"
-    description="O que esta demonstração consegue mostrar, o que ela ainda não consegue mostrar e o único comando que torna o ECMP visível."
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/pt-br/demo/spec.mdx
+++ b/docs/pt-br/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/pt-br/demo/terraform.mdx
+++ b/docs/pt-br/demo/terraform.mdx
@@ -8,7 +8,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -16,10 +16,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -44,90 +47,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-Cada arquivo abaixo é o arquivo que implanta, importado em tempo de build em vez de colado.
-Uma cópia que pode divergir é uma cópia que vai divergir, portanto uma verificação na CI falha no momento em que o que é
-publicado aqui difere do que está em `terraform/`.
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="Por que a configuração é importada em vez de exibida inline">
-Colada em um bloco de código, esta configuração faria parte do código-fonte da página, e o
-código-fonte da página é traduzido para doze idiomas. Os comentários dentro dela seriam
-traduzidos junto, e cada localidade publicaria uma configuração diferente e incorreta.
-Importada, ela nunca entra no código-fonte da página.
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## Módulo raiz
+## Root module
 
 ### `terraform/backend.tf`
 
-Backend de armazenamento do Azure; sua configuração é fornecida no momento do init e não é versionada.
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-Consultas somente leitura, incluindo a identidade do Azure AD usada para derivar o implantador.
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-Onde residem os nomes de objetos derivados. Valores padrão de variáveis do Terraform não podem referenciar outras variáveis, portanto cada variável de nome tem padrão null e é resolvida aqui.
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-Ligação de nível superior, a proteção de tenant e a verificação de VIP fora da VNet. A ordenação da implantação está documentada no início deste arquivo, que é a versão autoritativa.
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-Tudo o que a documentação lê em vez de nomear. Se uma página mostra um comando, há um output aqui por trás dele.
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-Fixa o endpoint do xcsh em var.expected_xc_tenant, o que torna o tenant uma propriedade da configuração.
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-Componente, ambiente, implantador e tags.
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-Subscription, região, CIDRs, Bastion e os nomes dos objetos do Azure.
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-Quantidade de CEs, prefixo do site, ASNs, versões de imagem e tamanho da VM.
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-Tenant, namespace da aplicação, load balancer, origin pool e o VIP.
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Versão mínima do Terraform e restrições de provider. A restrição do xcsh é um piso aberto, e o arquivo de lock está no gitignore, portanto cada init obtém o provider publicado mais recente.
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## Módulos
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-Resource group, VNet hub, as quatro subnets, o Azure Route Server e o Bastion opcional. A RouteServerSubnet deliberadamente não possui NSG nem tabela de rotas.
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -139,7 +160,7 @@ Resource group, VNet hub, as quatro subnets, o Azure Route Server e o Bastion op
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-O lado Azure de cada sessão eBGP — um bgpConnection por CE, fazendo peering do Route Server com o endereço eth0/SLO daquele CE.
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -147,7 +168,7 @@ O lado Azure de cada sessão eBGP — um bgpConnection por CE, fazendo peering d
 
 ### `terraform/modules/ce-node/`
 
-Uma VM de CE por nó: três NICs com IP forwarding, o bloco de plan do marketplace e o cloud-init entregue como custom_data.
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -159,13 +180,13 @@ Uma VM de CE por nó: três NICs com IP forwarding, o bloco de plan do marketpla
 
 ### `terraform/modules/ce-topology/`
 
-Computação pura, sem providers e sem data sources: expande ce_count no mapa por CE que alimenta cada for_each. Testável em plan com qualquer N, sem credenciais.
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-O cliente de teste dentro da VNet, usado para ler rotas efetivas e gerar tráfego no VIP.
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -175,7 +196,7 @@ O cliente de teste dentro da VNet, usado para ler rotas efetivas e gerar tráfeg
 
 ### `terraform/modules/xc-site/`
 
-O objeto de site do XC, seu peering BGP e a aprovação de registro que resolve um registro `r-<uuid>` pelo nome do site.
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/pt-br/demo/verify.mdx
+++ b/docs/pt-br/demo/verify.mdx
@@ -10,17 +10,17 @@ sidebar:
   order: 30
   label: Verificar
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-Execute estas verificações antes de apresentar. Cada verificação restringe onde uma falha estaria, de modo que uma falha lhe
-diz algo em vez de apenas indicar que algo está errado.
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-Todos os comandos leem o que precisam da implantação. Defina isto uma vez e o resto segue:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -30,13 +30,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## Quatro verificações, nesta ordem
+## Four checks, in this order
 
 <Steps>
 
-1. **Todos os sites estão `ONLINE`.** Nada downstream pode ser verdadeiro se isto não for.
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -46,17 +52,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Observado em 2026-07-28, três CEs:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **Cada peering está aprendendo o anúncio de VIP daquele CE.** Consulte cada peering
-   separadamente — veja a primeira armadilha abaixo, porque é aqui que a demonstração mais frequentemente parece
-   quebrada e não está.
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -68,28 +74,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   Observado em 2026-07-28:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   Três peerings, três next hops diferentes, um prefixo. Esse é o lado do anúncio do
-   ECMP comprovado.
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **As rotas efetivas do cliente carregam todos os next hops.** Este é o ECMP em si, conforme
-   a VNet o programou — não o que os CEs afirmam, mas o que o Azure fez com isso.
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -97,184 +103,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   Observado em 2026-07-28:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` com uma entrada por CE em `nh` é a verificação. **A ordem não é
-   significativa e não é estável** — o Azure os retorna de forma diferente entre chamadas, portanto conte-os
-   em vez de comparar com uma execução anterior. Um next hop onde você espera três significa que um
-   CE parou de anunciar, e a etapa 2 identifica qual.
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **O VIP atende tráfego.** A partir da VM cliente, e **com o cabeçalho `Host`** — veja a
-   segunda armadilha. Amostre requisições suficientes para ver um problema: algumas dezenas são lidas como 100 % mesmo
-   dentro da janela de convergência descrita abaixo.
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   Observado em 2026-07-28:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## Armadilha: um peering mostra uma rota, e isso está correto
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` tem escopo limitado ao peering que você nomeia. Ele relata o que **aquele** peer
-anunciou, não a tabela completa do Route Server.
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-Portanto, consultar um peering isoladamente retorna um único `/32` do VIP via um único next hop, e é
-tentador ler isso como "apenas um CE está anunciando — os outros estão fora". Nada está
-fora. Os outros anúncios estão visíveis em seus próprios peerings, que é o que a etapa 2 percorre
-em loop.
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-Confirmar ECMP a partir de uma consulta a um único peering não é possível. Ou percorra todos os peerings, ou
-leia a tabela de rotas efetivas do cliente, que mostra o resultado combinado em uma única chamada.
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## Armadilha: uma requisição para o IP puro retorna 404
+## Trap: a bare-IP request returns 404
 
-O balanceador de carga corresponde pelo `Host`. O VIP não é um virtual server que serve algo a
-quem quer que se conecte ao endereço.
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-Ambos vieram da mesma execução contra a implantação saudável:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**Um 404 no IP puro é prova de que o caminho funciona** — a requisição chegou ao CE, o proxy do CE
-respondeu, e recusou porque nenhum domínio configurado correspondeu. Lê-la como uma indisponibilidade
-faz você procurar no BGP, onde não encontrará nada errado.
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-O mesmo se aplica durante uma demonstração: se você digitar o endereço em um navegador em vez de resolver
-o domínio para ele, você obtém o 404.
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## O VIP descarta requisições nos primeiros três quartos de hora, e depois para
+## A fresh deployment can have a convergence transient
 
-Em uma pilha recém-construída, o VIP perde uma pequena fração das requisições durante aproximadamente os primeiros
-45 minutos depois que os CEs alcançam `ONLINE`, e depois passa a atender sem falhas. Medido em 1.470
-requisições a partir da VM cliente, todas com o cabeçalho `Host`:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| Janela | Requisições | Falhas | Taxa |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| Primeiros ~45 minutos após o ECMP subir | 570 | 12 | **2,11 %** |
-| Os 23 minutos seguintes | 900 | **0** | **0,00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-Toda falha foi `curl: (28)` — um timeout com zero bytes recebidos — não um status de erro
-HTTP. A última ocorreu cerca de 43 minutos depois de o ECMP subir. Das 900 requisições sem falha,
-400 rodaram com timeout de 30 segundos e todas terminaram em menos de 2 segundos, então nada foi
-escondido por um timeout curto.
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-Reproduziu-se novamente em uma reconstrução posterior no mesmo dia, e aquela execução é o retrato mais claro
-porque foi amostrada enquanto a janela transcorria, e não depois dela. 360 requisições, todas com
-o cabeçalho `Host`, cada lote emparelhado com um controle direto para a origem:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| Tempo após `ONLINE` | Requisições | Falhas | Taxa | Controle na origem |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| imediatamente | 60 | 8 | **13,3 %** | 30/30 sem falha |
-| ~25–40 min (3 lotes) | 180 | 3 | **1,67 %** | 60/60 sem falha |
-| ~50 min | 120 | **0** | **0,00 %** | 40/40 sem falha |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-Decrescendo monotonicamente até zero, e a origem estava limpa em todos os lotes — incluindo
-aquele em que uma requisição ao VIP em cada oito falhou.
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**A origem não foi a causa.** Um lote de controle direto para a origem
-(`terraform output -raw origin_ip`, contornando o VIP) executou 120 de 120 sem falha *simultaneamente
-com* lotes de VIP que falhavam. A falha está em algum ponto do caminho VIP, ECMP ou CE.
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-Duas coisas que isto deliberadamente não é chamado:
+Two things this is deliberately not called:
 
-- **Não é um defeito de regime estacionário.** Ele desaparece completamente e permanece assim — 120 de 120 na
-  marca de 50 minutos, e 60 de 60 em uma pilha que estava no ar há horas.
-- **Não conclua que está ausente a partir de uma pequena amostra inicial.** Um lote de 60 requisições tomado
-  imediatamente após uma reconstrução retornou 60 de 60, o que foi lido como "sem transiente"; a mesma
-  implantação perdeu 8 de 60 uma hora depois, na reconstrução seguinte. Sessenta requisições não são suficientes
-  para ver uma perda em rajadas. Amostre 100 ou mais, em lotes separados no tempo — a tabela acima
-  precisou de 360 para mostrar o formato.
-- **Não é atribuível a um CE específico.** Nada nesta topologia fornece um listener HTTP
-  por nó, portanto não há como vincular uma requisição descartada ao nó que a descartou.
-  As interfaces externas dos CEs não têm listener HTTP algum — apenas o `/32` do VIP responde.
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-Reproduziu-se em uma reconstrução limpa em um tenant diferente, portanto acompanha a topologia e não
-o ambiente.
-
-<Aside type="caution" title="Não amostre 40 requisições e conclua que está tudo bem">
-Lotes de 40 a 50 são lidos como 100 % na maior parte do tempo, mesmo dentro da janela de falhas. Foi
-assim que isto foi primeiro caracterizado erroneamente como uma falha contínua de baixa taxa e depois como nenhuma falha
-alguma. Amostre 100 ou mais, em lotes separados no tempo.
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## Duas outras armadilhas de medição
+## Two more measurement traps
 
-Ambas produziram respostas erradas com confiança neste ambiente, e nenhuma delas é óbvia.
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **Sonde de dentro da VNet, não da sua estação de trabalho.** Um proxy corporativo pode completar
-  ele mesmo o handshake TCP em portas comuns, de modo que uma sondagem da estação de trabalho relata uma porta **aberta**
-  que na verdade está fechada. As portas 80 e 443 são lidas como abertas nos endereços públicos dos CEs a partir de uma
-  estação de trabalho e estão fechadas quando sondadas de dentro da VNet. Use a VM cliente.
-- **A porta 22 em um CE responde apenas no endereço interno (SLI).** Sondado a partir da VM cliente,
-  o endereço interno de cada CE retorna um banner do OpenSSH, enquanto seus endereços de gerenciamento e externo
-  expiram — assim como um endereço não utilizado usado como controle. A eth0 é renomeada para
-  `a-i-eth0` e não carrega IP de host, porque o datapath a possui. Portanto, sondar o endereço
-  pelo qual você conhece o nó não lhe diz nada sobre o estado de SSH do nó.
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="Nunca fixe no código um endereço interno de CE — eles são reatribuídos em cada reconstrução">
-O Azure não preserva qual CE recebe qual endereço na sub-rede interna, e os
-endereços não estão em ordem de nó. Observado em 2026-07-28, os três CEs detinham `10.0.3.7`,
-`10.0.3.5` e `10.0.3.4` — não sequenciais, e diferentes dos que detinham antes daquela
-reconstrução.
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-O que decide se eles mudam é a **NIC**, não a VM. Substituir apenas as VMs dos CEs
-deixa as NICs no lugar e todos os endereços sobrevivem: verificado no mesmo dia, quando a adoção
-dos nomes de objeto derivados substituiu todas as três VMs de CE e os três endereços internos
-voltaram idênticos. Uma destruição que remove as NICs faz com que sejam reatribuídos a partir do pool livre
-da sub-rede, na ordem em que o Azure o preencher.
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-A NIC do cliente de teste fica nessa mesma sub-rede, portanto um endereço que você lembra como sendo de um CE pode
-agora ser o do cliente — nesta implantação ele detém `10.0.3.6`, que um CE detinha antes de uma
-reconstrução anterior.
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-Leia-os em vez de memorizá-los:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-Sem o estado do Terraform à mão, pergunte ao Azure pelo nome da NIC, que *é* estável:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-Conectar-se a um endereço memorizado leva você ao nó errado, a uma VM que não é um CE,
-ou a lugar nenhum — e o último caso parece idêntico a "o SSH não está habilitado".
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## Confirme que a superfície de comandos no equipamento ainda corresponde à documentação
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -282,7 +299,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` não escreve nada, portanto é seguro contra a demonstração em produção.
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -304,13 +352,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="Alcançando um Customer Edge"
-    description="Qual rota de acesso se aplica, as credenciais que cada uma exige e por que a escolha não é uma preferência."
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="Comandos BGP"
-    description="A visão no equipamento a partir do FRR — estado do peering, a tabela completa e o que este nó anuncia."
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/th/demo/index.mdx
+++ b/docs/th/demo/index.mdx
@@ -10,55 +10,66 @@ sidebar:
   order: 5
   label: การสาธิต
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-การ deploy นี้สาธิต **ความพร้อมใช้งานสูงของ Customer Edge แบบ active/active ใน Azure**
-โดยไม่มี Azure load balancer อยู่ด้านหน้า CE แต่ละ CE จะประกาศ host route เดียวกันด้วย
-eBGP และ Azure Route Server จะติดตั้งทั้งหมดเป็น next hop แบบ equal-cost ภายใน VNet
-ดังนั้นโครงสร้าง routing fabric จึงเป็นจุดที่การกระจายทราฟฟิกและการนำโหนดที่ล้มเหลวออก
-เกิดขึ้น แทนที่จะเป็น load balancer
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-ทุกสิ่งในหน้าเหล่านี้ถูกรันกับการ deploy ที่ใช้งานจริง และผลลัพธ์ที่แสดงคือผลลัพธ์ที่
-เกิดขึ้นจริง สิ่งที่ประโยคนั้น *ไม่* ครอบคลุม — คือ failover และวิธีที่ทราฟฟิกถูกแบ่ง
-ระหว่าง next hop ต่าง ๆ — จะถูกระบุไว้อย่างชัดเจนแทนที่จะปล่อยให้เป็นการคาดเดา
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## สิ่งที่มันจะ deploy
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| ส่วนประกอบ | คืออะไร |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — ที่เดียวที่มีการระบุชื่อ tenant |
-| Namespaces | CE site อยู่ใน `system`; origin pool และ load balancer อยู่ใน `var.xc_app_namespace` |
-| Customer Edges | ไซต์ Secure Mesh v2 แบบโหนดเดียวจำนวน `var.ce_count` ตั้งแต่ 1 ถึง 3 หนึ่งตัวต่อ availability zone |
-| ซอฟต์แวร์ CE | ตรึงเวอร์ชันด้วย `var.ce_sw_version` / `var.ce_os_version` |
-| Azure VMs | สาม NIC ต่อเครื่อง — management/SLO, external, internal/SLI |
-| Route exchange | Azure Route Server หนึ่งตัว, ASN `var.rs_asn`, สอง instance address |
-| Peerings | หนึ่งรายการต่อ CE ตั้งชื่อว่า `<key>-bgp`, CE ASN `var.ce_asn` |
-| VIP ที่ประกาศ | `var.vip` เป็น `/32` ประกาศเหมือนกันโดยทุก CE |
-| Load balancer | ให้บริการ `var.lb_domain` โดยมี origin pool ที่ `var.origin_ip` รองรับ |
-| Test client | VM ภายใน VNet เดียวกัน สำหรับส่งทราฟฟิกไปยัง VIP |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-ไม่มีสิ่งใดข้างต้นที่เป็นค่าตายตัวที่คุณควรคัดลอกไปใช้ ทุกค่าสามารถอ่านได้จากการ deploy
-และแต่ละหน้าจะอ่านค่าแทนที่จะระบุชื่อค่านั้น:
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -66,29 +77,29 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="VIP ต้องอยู่นอก CIDR ของทุก VNet">
-`terraform/main.tf` มี `check` block ที่ยืนยันว่า VIP อยู่นอกทั้ง CIDR ของ hub และ
-spoke และจะปฏิเสธ plan หากไม่เป็นเช่นนั้น เหตุผลที่ระบุไว้คือ VIP ที่อยู่ภายใน CIDR ของ
-VNet จะแพ้ให้กับ system route ของ VNet เอง แม้ว่า BGP route จะมีความเฉพาะเจาะจงมากกว่า
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-จงถือว่า guard นี้เป็นข้อสัญญา: หากคุณเปลี่ยนการสาธิตนี้ไปใช้การกำหนดที่อยู่แบบอื่น
-VIP ก็ต้องย้ายออกจากช่วงของ VNet ไปด้วย
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="การเปลี่ยนชื่อคือการสร้างใหม่ ไม่ใช่การเปลี่ยนชื่อ">
-เนื่องจากทุกชื่อได้มาจาก `var.component` การเปลี่ยนค่านี้จะเปลี่ยนชื่อทั้งการ
-deploy — แต่ `site_prefix` ไม่ใช่การเปลี่ยนแปลงเพียงผิวเผิน มันกลายเป็น `ClusterName`
-ใน cloud-init ของแต่ละ CE, `custom_data` เป็นแบบ replace-only เท่านั้น และ cloud-init
-จะรันเฉพาะตอนที่ CE บูตครั้งแรก ดังนั้นการเปลี่ยนค่านี้จึง **แทนที่ CE VM ทุกตัวและ
-ไซต์ XC ของมัน** และ VIP จะสูญเสียทราฟฟิกช่วงสั้น ๆ ระหว่างที่ ECMP รวมเส้นทางใหม่
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-นี่ไม่ใช่เรื่องทฤษฎี: การนำชื่อที่ได้มาเหล่านี้มาใช้กับการสาธิตที่กำลังทำงานอยู่ได้แทนที่
-CE VM สามตัว, ไซต์สามแห่ง, BGP object สามรายการ, load balancer, origin pool, Azure
-Route Server, Bastion และ test client — `23 to add, 3 to change, 26 to destroy`
-ตรึงค่า `site_prefix` ไว้ที่ค่าปัจจุบันเมื่อคุณต้องการให้ไซต์ที่มีอยู่คงอยู่ที่เดิม
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## ขั้นตอนต่อไป
+## Where to go next
 
 <CardGrid>
   <LinkCard

--- a/docs/th/demo/spec.mdx
+++ b/docs/th/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/th/demo/terraform.mdx
+++ b/docs/th/demo/terraform.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 20
   label: เทอร์ราฟอร์ม
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -15,10 +15,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -43,89 +46,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-ทุกไฟล์ด้านล่างนี้คือไฟล์ที่ใช้ปรับใช้จริง ซึ่งถูกนำเข้ามาในขั้นตอนการบิลด์แทนการคัดลอกวาง
-สำเนาที่สามารถคลาดเคลื่อนได้ย่อมคลาดเคลื่อนในที่สุด ดังนั้นการตรวจสอบใน CI จะล้มเหลวทันทีที่สิ่งที่
-เผยแพร่ในหน้านี้แตกต่างจากสิ่งที่อยู่ใน `terraform/`
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="เหตุใดการกำหนดค่าจึงถูกนำเข้ามาแทนที่จะแสดงแบบอินไลน์">
-หากวางไว้ในโค้ดเฟนซ์ การกำหนดค่านี้จะกลายเป็นส่วนหนึ่งของซอร์สของหน้า และซอร์สของหน้า
-จะถูกแปลเป็นสิบสองภาษา ความคิดเห็นภายในนั้นจะถูกแปลไปด้วย และแต่ละภาษาจะเผยแพร่
-การกำหนดค่าที่แตกต่างกันและไม่ถูกต้อง เมื่อนำเข้ามา มันจะไม่เข้าไปอยู่ในซอร์สของหน้าเลย
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## โมดูลราก
+## Root module
 
 ### `terraform/backend.tf`
 
-แบ็กเอนด์ Azure storage; การกำหนดค่าของมันถูกส่งให้ในขณะ init และไม่ถูกคอมมิต
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-การค้นหาแบบอ่านอย่างเดียว รวมถึงข้อมูลระบุตัวตน Azure AD ที่ใช้เพื่อหาผู้ปรับใช้
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-ที่ซึ่งชื่ออ็อบเจ็กต์ที่ได้มาถูกเก็บไว้ ค่าเริ่มต้นของตัวแปร Terraform ไม่สามารถอ้างอิงตัวแปรอื่นได้ ดังนั้นตัวแปรชื่อแต่ละตัวจะมีค่าเริ่มต้นเป็น null และถูกแก้ค่าที่นี่
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-การเชื่อมต่อระดับบนสุด ตัวป้องกันเทนแนนต์ และการตรวจสอบ VIP ที่อยู่ภายนอก VNet ลำดับการปรับใช้ถูกจัดทำเป็นเอกสารไว้ที่ส่วนต้นของไฟล์นี้ ซึ่งเป็นเวอร์ชันที่เชื่อถือได้
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-ทุกสิ่งที่เอกสารอ่านค่ามาแทนการระบุชื่อ หากหน้าใดแสดงคำสั่ง จะมีเอาต์พุตที่นี่อยู่เบื้องหลัง
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-ตรึงเอนด์พอยต์ xcsh ไว้กับ var.expected_xc_tenant ซึ่งเป็นสิ่งที่ทำให้เทนแนนต์เป็นคุณสมบัติหนึ่งของการกำหนดค่า
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-ส่วนประกอบ สภาพแวดล้อม ผู้ปรับใช้ และแท็ก
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-การสมัครใช้บริการ ภูมิภาค CIDR, Bastion และชื่ออ็อบเจ็กต์ของ Azure
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-จำนวน CE, คำนำหน้าไซต์, ASN, เวอร์ชันอิมเมจ และขนาด VM
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-เทนแนนต์ เนมสเปซของแอป โหลดบาลานเซอร์ พูลต้นทาง และ VIP
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-ระดับขั้นต่ำของ Terraform และข้อจำกัดของผู้ให้บริการ ข้อจำกัดของ xcsh เป็นระดับขั้นต่ำแบบปลายเปิด และไฟล์ล็อกถูก gitignore ไว้ ดังนั้นทุกครั้งที่ init จะได้ผู้ให้บริการเวอร์ชันล่าสุดที่เผยแพร่
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## โมดูล
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-รีซอร์สกรุ๊ป, hub VNet, ซับเน็ตทั้งสี่, Azure Route Server และ Bastion ที่เป็นตัวเลือก RouteServerSubnet ถูกกำหนดโดยเจตนาให้ไม่มี NSG หรือตารางเส้นทาง
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -137,7 +159,7 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-ฝั่ง Azure ของแต่ละเซสชัน eBGP — หนึ่ง bgpConnection ต่อหนึ่ง CE โดยทำ peering ระหว่าง Route Server กับที่อยู่ eth0/SLO ของ CE นั้น
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -145,7 +167,7 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/ce-node/`
 
-หนึ่ง CE VM ต่อหนึ่งโหนด: NIC สามตัวที่เปิดใช้ IP forwarding, บล็อกแผน marketplace และ cloud-init ที่ส่งต่อไปเป็น custom_data
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -157,13 +179,13 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/ce-topology/`
 
-การคำนวณล้วน ไม่มีผู้ให้บริการและไม่มีแหล่งข้อมูล: ขยาย ce_count ออกเป็นแมประดับ CE ที่ขับเคลื่อนทุก for_each สามารถทดสอบแผนได้ที่ค่า N ใดก็ได้โดยไม่ต้องใช้ข้อมูลรับรอง
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-ไคลเอนต์ทดสอบภายใน VNet ใช้เพื่ออ่านเส้นทางที่มีผลบังคับใช้และส่งทราฟฟิกไปที่ VIP
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -173,7 +195,7 @@ import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/ver
 
 ### `terraform/modules/xc-site/`
 
-อ็อบเจ็กต์ไซต์ XC, การทำ BGP peering ของมัน และการอนุมัติการลงทะเบียนที่แก้ไขการลงทะเบียน `r-<uuid>` ตามชื่อไซต์
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/th/demo/verify.mdx
+++ b/docs/th/demo/verify.mdx
@@ -10,16 +10,17 @@ sidebar:
   order: 30
   label: ตรวจสอบ
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-รันสิ่งเหล่านี้ก่อนที่คุณจะนำเสนอ การตรวจสอบแต่ละขั้นจะจำกัดขอบเขตว่าความผิดพลาดอยู่ตรงไหน ดังนั้นเมื่อขั้นใดล้มเหลว มันจะบอกอะไรบางอย่างกับคุณ ไม่ใช่เพียงบอกว่ามีบางอย่างผิดพลาด
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-ทุกคำสั่งจะอ่านสิ่งที่ต้องการจากการปรับใช้เอง ตั้งค่าเหล่านี้เพียงครั้งเดียวแล้วส่วนที่เหลือจะตามมา:
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -29,13 +30,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## การตรวจสอบสี่ขั้น ตามลำดับนี้
+## Four checks, in this order
 
 <Steps>
 
-1. **ทุกไซต์อยู่ในสถานะ `ONLINE`** ไม่มีสิ่งใดที่อยู่ถัดจากนี้จะเป็นจริงได้ถ้าข้อนี้ไม่เป็นจริง
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -45,15 +52,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   สังเกตเมื่อ 2026-07-28, CE สามตัว:
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **ทุก peering กำลังเรียนรู้การประกาศ VIP ของ CE นั้น** ให้สอบถามแต่ละ peering แยกกัน — ดูกับดักข้อแรกด้านล่าง เพราะนี่คือจุดที่การสาธิตมักดูเหมือนพังทั้งที่ไม่ได้พัง
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -65,26 +74,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   สังเกตเมื่อ 2026-07-28:
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   สาม peering, สาม next hop ที่ต่างกัน, หนึ่ง prefix นั่นคือการพิสูจน์ฝั่งการประกาศของ ECMP
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **เส้นทางที่มีผล (effective routes) ของไคลเอนต์มี next hop ครบทุกตัว** นี่คือตัว ECMP เอง ตามที่ VNet ได้โปรแกรมไว้ — ไม่ใช่สิ่งที่ CE อ้าง แต่คือสิ่งที่ Azure ทำกับมัน
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -92,133 +103,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   สังเกตเมื่อ 2026-07-28:
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   `state: Active` พร้อมกับหนึ่งรายการต่อหนึ่ง CE ใน `nh` คือสิ่งที่ต้องตรวจ **ลำดับไม่มีความสำคัญและไม่คงที่** — Azure ส่งคืนลำดับต่างกันในแต่ละครั้งที่เรียก ดังนั้นให้นับจำนวนแทนที่จะเปรียบเทียบกับการรันครั้งก่อน หากมี next hop เพียงตัวเดียวในขณะที่คุณคาดว่าจะมีสามตัว หมายความว่ามี CE หนึ่งตัวหยุดประกาศ และขั้นที่ 2 จะระบุว่าเป็นตัวไหน
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **VIP ให้บริการทราฟฟิกได้** จากเครื่อง VM ไคลเอนต์ และ **พร้อมส่วนหัว `Host`** — ดูกับดักข้อที่สอง สุ่มตัวอย่างคำขอให้มากพอที่จะเห็นปัญหา: ไม่กี่สิบคำขอจะอ่านได้เป็น 100 % แม้อยู่ในช่วงเวลาการรวมเส้นทาง (convergence window) ที่อธิบายไว้ด้านล่าง
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   สังเกตเมื่อ 2026-07-28:
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## กับดัก: peering หนึ่งแสดงเส้นทางเดียว และนั่นถูกต้องแล้ว
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` มีขอบเขตจำกัดอยู่ที่ peering ที่คุณระบุชื่อ มันรายงานสิ่งที่ peer **นั้น** ประกาศ ไม่ใช่ตารางทั้งหมดของ Route Server
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-ดังนั้นการสอบถาม peering เดียวจะคืนค่า VIP `/32` เพียงรายการเดียวผ่าน next hop เดียว และเป็นเรื่องน่าเข้าใจผิดที่จะอ่านว่า "มี CE ตัวเดียวเท่านั้นที่กำลังประกาศ — ตัวอื่นล่ม" ไม่มีอะไรล่มเลย การประกาศของตัวอื่นมองเห็นได้บน peering ของตัวเอง ซึ่งเป็นสิ่งที่ขั้นที่ 2 วนลูปตรวจสอบ
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-การยืนยัน ECMP จากการสอบถาม peering เดียวเป็นไปไม่ได้ ให้วนลูปทุก peering หรืออ่านตารางเส้นทางที่มีผลของไคลเอนต์ ซึ่งแสดงผลลัพธ์ที่รวมกันแล้วในการเรียกครั้งเดียว
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## กับดัก: คำขอด้วย IP เปล่าคืนค่า 404
+## Trap: a bare-IP request returns 404
 
-ตัวกระจายโหลดจับคู่ด้วย `Host` VIP ไม่ใช่เวอร์ชวลเซิร์ฟเวอร์ที่ให้บริการอะไรก็ตามแก่ผู้ที่เชื่อมต่อมายังที่อยู่นั้น
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-ทั้งสองอย่างนี้มาจากการรันครั้งเดียวกันกับการปรับใช้ที่สมบูรณ์ดี:
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**404 จากการเรียก IP เปล่าคือหลักฐานว่าเส้นทางใช้งานได้** — คำขอไปถึง CE, พร็อกซีของ CE ตอบกลับ และมันปฏิเสธเพราะไม่มีโดเมนที่กำหนดค่าไว้ตรงกัน การอ่านผลนี้ว่าเป็นเหตุขัดข้องจะทำให้คุณไปไล่ดู BGP ซึ่งคุณจะไม่พบสิ่งใดผิดปกติ
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-เรื่องเดียวกันนี้ใช้ได้ระหว่างการสาธิต: ถ้าคุณพิมพ์ที่อยู่ลงในเบราว์เซอร์แทนที่จะแปลงชื่อโดเมนมายังที่อยู่นั้น คุณจะได้ 404
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## VIP ทิ้งคำขอในช่วงสามในสี่ชั่วโมงแรก แล้วจึงหยุด
+## A fresh deployment can have a convergence transient
 
-บนสแตกที่เพิ่งสร้างใหม่ VIP จะสูญเสียคำขอเป็นสัดส่วนเล็กน้อยในช่วงประมาณ 45 นาทีแรกหลังจาก CE เข้าสู่สถานะ `ONLINE` แล้วจากนั้นจึงให้บริการได้อย่างสะอาด วัดจาก 1,470 คำขอจากเครื่อง VM ไคลเอนต์ ทั้งหมดพร้อมส่วนหัว `Host`:
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| ช่วงเวลา | คำขอ | ความล้มเหลว | อัตรา |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| ~45 นาทีแรกหลังจาก ECMP ขึ้นมา | 570 | 12 | **2.11 %** |
-| 23 นาทีถัดมา | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-ความล้มเหลวทุกครั้งคือ `curl: (28)` — การหมดเวลาโดยได้รับข้อมูลศูนย์ไบต์ — ไม่ใช่สถานะข้อผิดพลาด HTTP ครั้งสุดท้ายเกิดขึ้นประมาณ 43 นาทีหลังจาก ECMP ขึ้นมา จาก 900 คำขอที่สะอาด มี 400 คำขอที่รันด้วยการหมดเวลา 30 วินาที และทุกคำขอเสร็จภายในไม่ถึง 2 วินาที ดังนั้นจึงไม่มีอะไรถูกซ่อนไว้ด้วยการตั้งเวลาหมดเวลาที่สั้นเกินไป
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-ปัญหานี้เกิดซ้ำอีกครั้งในการสร้างใหม่ครั้งหลังในวันเดียวกัน และการรันครั้งนั้นให้ภาพที่ชัดเจนกว่าเพราะสุ่มตัวอย่างขณะที่ช่วงเวลากำลังผ่านไป ไม่ใช่หลังจากนั้น 360 คำขอ ทั้งหมดพร้อมส่วนหัว `Host` แต่ละชุดจับคู่กับชุดควบคุมที่ยิงตรงไปยังต้นทาง:
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| เวลาหลังจาก `ONLINE` | คำขอ | ความล้มเหลว | อัตรา | ชุดควบคุมไปยังต้นทาง |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| ทันที | 60 | 8 | **13.3 %** | 30/30 สะอาด |
-| ~25–40 นาที (3 ชุด) | 180 | 3 | **1.67 %** | 60/60 สะอาด |
-| ~50 นาที | 120 | **0** | **0.00 %** | 40/40 สะอาด |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-ลดลงอย่างต่อเนื่องจนถึงศูนย์ และต้นทางสะอาดในทุกชุด — รวมถึงชุดที่คำขอ VIP หนึ่งในแปดล้มเหลว
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**ต้นทางไม่ใช่สาเหตุ** ชุดควบคุมที่ยิงตรงไปยังต้นทาง (`terraform output -raw origin_ip` โดยข้าม VIP) รันได้สะอาด 120 จาก 120 *ในขณะเดียวกันกับ* ชุด VIP ที่ล้มเหลว ความผิดพลาดอยู่ที่ใดที่หนึ่งในเส้นทาง VIP, ECMP หรือ CE
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-สองสิ่งที่จงใจไม่เรียกปัญหานี้ว่า:
+Two things this is deliberately not called:
 
-- **ไม่ใช่ข้อบกพร่องในสภาวะคงตัว** มันหายไปโดยสมบูรณ์และคงสภาพนั้นไว้ — 120 จาก 120 ที่เครื่องหมาย 50 นาที และ 60 จาก 60 บนสแตกที่เปิดใช้งานมาหลายชั่วโมงแล้ว
-- **อย่าสรุปว่าไม่มีปัญหาจากตัวอย่างเล็ก ๆ ในช่วงต้น** ชุด 60 คำขอที่เก็บทันทีหลังการสร้างใหม่ครั้งหนึ่งคืนค่า 60 จาก 60 ซึ่งอ่านได้ว่า "ไม่มีปัญหาชั่วคราว" แต่การปรับใช้เดียวกันสูญเสีย 8 จาก 60 หนึ่งชั่วโมงต่อมาในการสร้างใหม่ครั้งถัดไป หกสิบคำขอไม่เพียงพอที่จะเห็นการสูญเสียแบบเป็นช่วงระเบิด ให้สุ่มตัวอย่าง 100 คำขอขึ้นไป โดยแบ่งเป็นชุดที่เว้นระยะเวลา — ตารางข้างต้นต้องใช้ถึง 360 คำขอจึงจะเห็นรูปแบบ
-- **ไม่สามารถระบุได้ว่าเกิดจาก CE ตัวใดตัวหนึ่ง** ไม่มีสิ่งใดในโทโพโลยีนี้ที่ให้ตัวรับฟัง HTTP ต่อโหนด ดังนั้นจึงไม่มีทางผูกคำขอที่ถูกทิ้งเข้ากับโหนดที่ทิ้งมันได้ อินเทอร์เฟซภายนอกของ CE ไม่มีตัวรับฟัง HTTP เลย — มีเพียง VIP `/32` เท่านั้นที่ตอบสนอง
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-ปัญหานี้เกิดซ้ำบนการสร้างใหม่ที่สะอาดในเทแนนต์อื่น ดังนั้นมันจึงติดตามโทโพโลยีมากกว่าสภาพแวดล้อม
-
-<Aside type="caution" title="อย่าสุ่มตัวอย่างเพียง 40 คำขอแล้วสรุปว่าไม่มีปัญหา">
-ชุดขนาด 40 ถึง 50 คำขอมักอ่านได้เป็น 100 % เกือบตลอดเวลา แม้อยู่ในช่วงที่เกิดความล้มเหลว นั่นคือสาเหตุที่ปัญหานี้ถูกอธิบายผิดตั้งแต่แรกว่าเป็นความผิดพลาดอัตราต่ำที่ดำเนินอยู่ และต่อมาถูกอธิบายผิดว่าไม่มีความผิดพลาดเลย ให้สุ่มตัวอย่าง 100 คำขอขึ้นไป โดยแบ่งเป็นชุดที่เว้นระยะเวลา
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## กับดักการวัดอีกสองข้อ
+## Two more measurement traps
 
-ทั้งสองข้อให้คำตอบที่ผิดอย่างมั่นใจในสภาพแวดล้อมนี้ และไม่มีข้อใดที่ชัดเจนในทันที
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **ตรวจสอบจากภายใน VNet ไม่ใช่จากเวิร์กสเตชันของคุณ** พร็อกซีขององค์กรสามารถทำ TCP handshake ให้เสร็จสมบูรณ์ด้วยตัวเองบนพอร์ตทั่วไป ดังนั้นการตรวจจากเวิร์กสเตชันจะรายงานว่าพอร์ต **เปิด** ทั้งที่จริงแล้วปิดอยู่ พอร์ต 80 และ 443 อ่านได้ว่าเปิดบนที่อยู่สาธารณะของ CE เมื่อตรวจจากเวิร์กสเตชัน และปิดเมื่อตรวจจากภายใน VNet ให้ใช้เครื่อง VM ไคลเอนต์
-- **พอร์ต 22 บน CE ตอบสนองเฉพาะบนที่อยู่ภายใน (SLI) เท่านั้น** เมื่อตรวจจากเครื่อง VM ไคลเอนต์ ที่อยู่ภายในของ CE แต่ละตัวจะคืนค่าแบนเนอร์ OpenSSH ในขณะที่ที่อยู่สำหรับการจัดการและที่อยู่ภายนอกจะหมดเวลา — เช่นเดียวกับที่อยู่ที่ไม่ได้ใช้งานซึ่งใช้เป็นตัวควบคุม eth0 ถูกเปลี่ยนชื่อเป็น `a-i-eth0` และไม่มี IP ของโฮสต์ เพราะ datapath เป็นเจ้าของมัน ดังนั้นการตรวจสอบที่อยู่ที่คุณใช้ระบุโหนดนั้นจึงไม่บอกอะไรเลยเกี่ยวกับสถานะ SSH ของโหนด
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="อย่าฮาร์ดโค้ดที่อยู่ภายในของ CE เด็ดขาด — มันถูกกำหนดใหม่ทุกครั้งที่สร้างใหม่">
-Azure ไม่รักษาไว้ว่า CE ตัวใดจะได้ที่อยู่ใดในซับเน็ตภายใน และที่อยู่เหล่านั้นก็ไม่ได้เรียงตามลำดับโหนด สังเกตเมื่อ 2026-07-28 CE ทั้งสามถือ `10.0.3.7`, `10.0.3.5` และ `10.0.3.4` — ไม่เรียงลำดับ และต่างจากที่พวกมันถือก่อนการสร้างใหม่ครั้งนั้น
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-สิ่งที่ตัดสินว่าที่อยู่จะย้ายหรือไม่คือ **NIC** ไม่ใช่ VM การแทนที่เฉพาะ VM ของ CE จะทำให้ NIC ยังคงอยู่ที่เดิม และทุกที่อยู่จะคงอยู่: ยืนยันแล้วในวันเดียวกัน เมื่อการนำชื่ออ็อบเจกต์ที่ได้มาใช้ทำให้ VM ของ CE ทั้งสามตัวถูกแทนที่ และที่อยู่ภายในทั้งสามกลับมาเหมือนเดิม ส่วนการรื้อถอนที่ลบ NIC ออกด้วยจะทำให้ที่อยู่ถูกกำหนดใหม่จากพูลว่างของซับเน็ต ตามลำดับใดก็ตามที่ Azure เติมเข้าไป
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-NIC ของไคลเอนต์ทดสอบอยู่ในซับเน็ตเดียวกันนั้น ดังนั้นที่อยู่ที่คุณจำได้ว่าเป็นของ CE อาจกลายเป็นของไคลเอนต์ในตอนนี้ — บนการปรับใช้นี้ ไคลเอนต์ถือ `10.0.3.6` ซึ่งเคยเป็นของ CE ก่อนการสร้างใหม่ครั้งก่อนหน้า
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-จงอ่านค่าเหล่านั้นแทนที่จะจำมัน:
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-หากไม่มีสถานะ Terraform อยู่ในมือ ให้ถาม Azure ด้วยชื่อ NIC ซึ่ง *เป็น* สิ่งที่คงที่:
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-การเชื่อมต่อไปยังที่อยู่ที่จำมาจะพาคุณไปยังโหนดที่ผิด ไปยัง VM ที่ไม่ใช่ CE หรือไม่ไปไหนเลย — และกรณีสุดท้ายนั้นดูเหมือนกับ "SSH ไม่ได้เปิดใช้งาน" ทุกประการ
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## ยืนยันว่าชุดคำสั่งบนเครื่องยังคงตรงกับเอกสาร
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -226,7 +299,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` ไม่เขียนอะไรเลย จึงปลอดภัยต่อการสาธิตที่กำลังใช้งานจริง
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -248,13 +352,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="การเข้าถึง Customer Edge"
-    description="เส้นทางการเข้าถึงใดที่ใช้ได้ ข้อมูลรับรองที่แต่ละเส้นทางต้องการ และเหตุใดตัวเลือกนี้จึงไม่ใช่เรื่องของความชอบ"
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="คำสั่ง BGP"
-    description="มุมมองบนเครื่องจาก FRR — สถานะ peering, ตารางทั้งหมด และสิ่งที่โหนดนี้ประกาศออกไป"
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/zh-cn/demo/index.mdx
+++ b/docs/zh-cn/demo/index.mdx
@@ -7,54 +7,66 @@ sidebar:
   order: 5
   label: 演示
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-本部署展示了 **Azure 中的主动/主动 Customer Edge 高可用性**，
-且 CE 前端不放置任何 Azure 负载均衡器。每个 CE 通过 eBGP 发布相同的主机路由，
-Azure Route Server 将它们全部作为等价下一跳安装到 VNet 中。
-因此，流量分发与故障节点移除应当发生在路由架构中，而非负载均衡器上。
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-这些页面中的所有内容都是针对实际部署运行得出的，展示的输出即其产生的输出。
-这句话*未*涵盖的内容 —— 故障切换，以及流量如何在各下一跳之间分配 ——
-会被明确指出，而不是留待假设。
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## 它部署了什么
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| 组成部分 | 说明 |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud 租户 | `var.expected_xc_tenant` —— 唯一指定租户名称的位置 |
-| 命名空间 | CE 站点位于 `system`；源站池和负载均衡器位于 `var.xc_app_namespace` |
-| Customer Edge | `var.ce_count` 个单节点 Secure Mesh v2 站点，1 至 3 个，每个可用区一个 |
-| CE 软件 | 由 `var.ce_sw_version` / `var.ce_os_version` 固定版本 |
-| Azure 虚拟机 | 每台三张网卡 —— 管理/SLO、外部、内部/SLI |
-| 路由交换 | 一个 Azure Route Server，ASN 为 `var.rs_asn`，两个实例地址 |
-| 对等连接 | 每个 CE 一个，命名为 `<key>-bgp`，CE ASN 为 `var.ce_asn` |
-| 发布的 VIP | `var.vip` 以 `/32` 形式，由每个 CE 以完全相同的方式发布 |
-| 负载均衡器 | 服务 `var.lb_domain`，后端为位于 `var.origin_ip` 的源站池 |
-| 测试客户端 | 同一 VNet 内的一台虚拟机，用于向 VIP 发起流量 |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-以上内容都不是可以直接复制的字面值。每个值都可从部署中读取，
-各页面均从部署中读取而非直接写出：
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -62,49 +74,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="VIP 必须位于所有 VNet CIDR 之外">
-`terraform/main.tf` 中包含一个 `check` 块，用于断言 VIP 位于中心和分支 CIDR 之外，
-否则拒绝该计划。其给出的理由是：位于 VNet CIDR 内的 VIP，即使 BGP 路由更为具体，
-仍会输给 VNet 自身的系统路由。
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-请将该守护规则视为契约：如果你将本演示重新指向不同的地址规划，
-VIP 也必须随之移出 VNet 地址范围。
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="重命名意味着重建，而非改名">
-由于所有名称都派生自 `var.component`，更改它会重命名整个部署 ——
-但 `site_prefix` 并非表面上的修改。它会成为每个 CE 的 cloud-init 中的 `ClusterName`，
-`custom_data` 只能替换，而 cloud-init 仅在 CE 首次启动时运行。
-因此更改它会**替换每一台 CE 虚拟机及其 XC 站点**，
-而在 ECMP 重新收敛期间 VIP 会短暂丢包。
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-这并非理论推测：在运行中的演示上采用这些派生名称，替换了三台 CE 虚拟机、
-三个站点、三个 BGP 对象、负载均衡器、源站池、Azure Route Server、
-Bastion 以及测试客户端 —— `23 to add, 3 to change, 26 to destroy`。
-当你需要现有站点保持不变时，请将 `site_prefix` 固定为当前值。
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## 接下来去哪里
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="部署它"
-    description="前置条件、你必须提供的两个值、为什么首次 apply 分为两个阶段，以及如何拆除。"
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Terraform 配置"
-    description="配置本身，从执行部署的文件中读取，而非重新键入。"
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="验证健康状态"
-    description="按顺序执行的四项检查，以及那些看似故障实则正常的结果。"
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="进行演示"
-    description="本演示能展示什么、目前还不能展示什么，以及让 ECMP 可见的那一条命令。"
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/zh-cn/demo/spec.mdx
+++ b/docs/zh-cn/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/zh-cn/demo/terraform.mdx
+++ b/docs/zh-cn/demo/terraform.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -13,10 +13,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -41,89 +44,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-下面的每个文件都是实际执行部署的文件，在构建时导入而非粘贴。
-可能产生偏差的副本终将产生偏差，因此 CI 中有一项检查：一旦此处发布的内容与
-`terraform/` 中的内容不同，检查即告失败。
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="为什么配置是导入的而非内联展示">
-如果粘贴进代码块，这份配置就会成为页面源文件的一部分，而页面源文件会被翻译成十二种语言。
-其中的注释会随之被翻译，于是每个语言版本都会发布一份不同的、错误的配置。
-采用导入方式，它根本不会进入页面源文件。
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## 根模块
+## Root module
 
 ### `terraform/backend.tf`
 
-Azure 存储后端；其配置在 init 时提供，不提交到代码库。
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-只读查询，包括用于推导部署者身份的 Azure AD 身份。
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-派生对象名称所在之处。Terraform 变量的默认值无法引用其他变量，因此每个名称变量默认为 null，并在此处解析。
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-顶层接线、租户守卫以及 VIP 位于 VNet 之外的检查。部署顺序记录在该文件顶部，那是权威版本。
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-文档所读取而非直接写死名称的全部内容。如果某个页面展示了一条命令，其背后就有此处的一个输出。
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-将 xcsh 端点固定到 var.expected_xc_tenant，正是这一点让租户成为配置的一个属性。
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-组件、环境、部署者与标签。
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-订阅、区域、CIDR、Bastion 以及 Azure 对象名称。
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-CE 数量、站点前缀、ASN、镜像版本与 VM 规格。
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-租户、应用命名空间、负载均衡器、源站池以及 VIP。
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Terraform 版本下限与 provider 约束。xcsh 的约束是一个开放式下限，且锁定文件被 gitignore，因此每次 init 都会取用最新发布的 provider。
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## 模块
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-资源组、中心 VNet、四个子网、Azure Route Server 以及可选的 Bastion。RouteServerSubnet 有意不带任何 NSG 或路由表。
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -135,7 +157,7 @@ Terraform 版本下限与 provider 约束。xcsh 的约束是一个开放式下�
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-每个 eBGP 会话的 Azure 侧——每个 CE 一个 bgpConnection，将 Route Server 与该 CE 的 eth0/SLO 地址建立对等。
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -143,7 +165,7 @@ Terraform 版本下限与 provider 约束。xcsh 的约束是一个开放式下�
 
 ### `terraform/modules/ce-node/`
 
-每个节点一台 CE 虚拟机：三块启用 IP 转发的网卡、市场镜像的 plan 块，以及作为 custom_data 传入的 cloud-init。
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -155,13 +177,13 @@ Terraform 版本下限与 provider 约束。xcsh 的约束是一个开放式下�
 
 ### `terraform/modules/ce-topology/`
 
-纯计算，无 provider、无数据源：将 ce_count 展开为驱动所有 for_each 的按 CE 映射。在任意 N 下都可在无凭据的情况下进行 plan 测试。
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-VNet 内的测试客户端，用于读取有效路由并向 VIP 发起流量。
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -171,7 +193,7 @@ VNet 内的测试客户端，用于读取有效路由并向 VIP 发起流量。
 
 ### `terraform/modules/xc-site/`
 
-XC 站点对象、其 BGP 对等，以及按站点名称解析 `r-<uuid>` 注册项的注册审批。
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/zh-cn/demo/verify.mdx
+++ b/docs/zh-cn/demo/verify.mdx
@@ -7,16 +7,17 @@ sidebar:
   order: 30
   label: 验证
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-在演示之前先运行这些检查。每项检查都会缩小故障可能存在的范围，因此一旦失败，你能得到的不只是"出问题了"这一信息。
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-每条命令都会从部署中读取所需内容。设置一次以下变量，其余命令即可沿用：
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -26,13 +27,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## 四项检查，按此顺序进行
+## Four checks, in this order
 
 <Steps>
 
-1. **每个站点均为 `ONLINE`。** 如果这一点不成立，后续任何结论都不可能成立。
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -42,15 +49,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 观测结果，三个 CE：
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **每个对等会话都学习到了对应 CE 的 VIP 通告。** 分别查询每个对等会话——参见下方第一个陷阱，因为这里最常出现演示看起来坏了但其实没坏的情况。
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -62,26 +71,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 观测结果：
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   三个对等会话、三个不同的下一跳、一个前缀。这就证明了 ECMP 的通告侧。
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **客户端的有效路由包含每一个下一跳。** 这才是 ECMP 本身——是 VNet 实际编程的结果，不是 CE 声称的内容，而是 Azure 对其所做的处理。
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -89,133 +100,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   2026-07-28 观测结果：
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   检查点是 `state: Active`，且 `nh` 中每个 CE 各有一条条目。**顺序没有意义，也不稳定**——Azure 在不同调用之间返回的顺序不同，因此应统计数量，而不是与上一次运行结果比对。本应有三个下一跳而只有一个，说明某个 CE 已停止通告，第 2 步可以指出是哪一个。
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **VIP 能正常处理流量。** 从客户端 VM 发起，并且**带上 `Host` 头**——参见第二个陷阱。采样量要足够大才能发现问题：即使在下文所述的收敛窗口内，几十个请求也会显示为 100 %。
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   2026-07-28 观测结果：
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## 陷阱：某个对等会话只显示一条路由，而这是正确的
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` 的作用范围仅限于你指定的那个对等会话。它报告的是**那个**对等体所通告的内容，而不是 Route Server 的整张路由表。
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-因此单独查询一个对等会话只会返回经由单个下一跳的一条 VIP `/32`，很容易被解读为"只有一个 CE 在通告——其他都挂了"。其实什么都没挂。其他通告在各自的对等会话上可见，这正是第 2 步所循环遍历的内容。
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-从单次对等会话查询无法确认 ECMP。要么遍历所有对等会话，要么读取客户端的有效路由表，后者可以在一次调用中显示合并后的结果。
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## 陷阱：裸 IP 请求返回 404
+## Trap: a bare-IP request returns 404
 
-负载均衡器依据 `Host` 进行匹配。VIP 并不是一个会向任何连接该地址的人提供服务的虚拟服务器。
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-以下两条结果来自针对健康部署的同一次运行：
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**裸 IP 返回 404 恰恰证明路径是通的**——请求到达了 CE，CE 的代理作出了响应，并因为没有匹配到已配置的域名而拒绝了它。把它当成故障，会让你去查 BGP，而那里根本没有问题。
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-演示过程中同理：如果你在浏览器里直接输入地址，而不是把域名解析到该地址，你就会得到 404。
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## VIP 在最初的三刻钟内丢弃请求，随后停止
+## A fresh deployment can have a convergence transient
 
-在刚构建好的环境中，CE 达到 `ONLINE` 之后大约最初 45 分钟内，VIP 会丢失一小部分请求，随后即可干净地提供服务。从客户端 VM 发出的 1,470 个请求（全部带 `Host` 头）测得：
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| 窗口 | 请求数 | 失败数 | 比率 |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| ECMP 建立后最初约 45 分钟 | 570 | 12 | **2.11 %** |
-| 随后的 23 分钟 | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-所有失败都是 `curl: (28)`——超时且未收到任何字节——而不是 HTTP 错误状态码。最后一次失败发生在 ECMP 建立后约 43 分钟。在 900 个成功请求中，有 400 个使用了 30 秒超时，且全部在 2 秒内完成，因此不存在被过短超时掩盖的情况。
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-同一天的后续重建中再次复现，而那次运行的图景更清晰，因为它是在窗口期内随时间采样，而非事后采样。360 个请求，全部带 `Host` 头，每一批都配有一组直连源站的对照：
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| `ONLINE` 之后的时间 | 请求数 | 失败数 | 比率 | 源站对照 |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| 立即 | 60 | 8 | **13.3 %** | 30/30 正常 |
-| 约 25–40 分钟（3 批） | 180 | 3 | **1.67 %** | 60/60 正常 |
-| 约 50 分钟 | 120 | **0** | **0.00 %** | 40/40 正常 |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-比率单调递减至零，而每一批的源站都是正常的——包括每八个 VIP 请求就失败一个的那一批。
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**源站不是原因。** 一组直连源站（`terraform output -raw origin_ip`，绕过 VIP）的对照批次在与失败的 VIP 批次*同时进行*的情况下，120 个请求全部成功。故障出在 VIP、ECMP 或 CE 路径上的某处。
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-有两点是刻意不这样描述的：
+Two things this is deliberately not called:
 
-- **这不是稳态缺陷。** 它会完全消失并保持消失——50 分钟节点上 120 个请求全部成功，已运行数小时的环境上 60 个请求全部成功。
-- **不要因为早期一次小样本就断定它不存在。** 某次重建后立即执行的 60 个请求批次返回 60/60，看起来"没有瞬时故障"；而同一部署在一小时后的下一次重建中却在 60 个请求中丢了 8 个。60 个请求不足以发现突发性丢包。请采样 100 个以上，并分成在时间上彼此分隔的批次——上面那张表需要 360 个请求才能呈现出趋势。
-- **它无法归因于某个特定的 CE。** 该拓扑中没有任何机制提供逐节点的 HTTP 侦听器，因此无法把被丢弃的请求绑定到丢弃它的节点上。CE 的外部接口完全没有 HTTP 侦听器——只有 VIP `/32` 会响应。
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-它在另一个租户的一次干净重建中也复现了，因此它跟随拓扑而非环境。
-
-<Aside type="caution" title="不要只采样 40 个请求就断定一切正常">
-即使处于失败窗口内，40 到 50 个请求的批次大多数时候也会显示为 100 %。正是因此，这个现象最初先被误判为持续存在的低比率故障，随后又被误判为完全没有故障。请采样 100 个以上，并分成在时间上彼此分隔的批次。
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## 另外两个测量陷阱
+## Two more measurement traps
 
-这两者都在本环境中给出过自信但错误的答案，而且都不显而易见。
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **从 VNet 内部探测，而不是从你的工作站。** 企业代理可能会在常见端口上自行完成 TCP 握手，因此工作站上的探测会把一个实际关闭的端口报告为**开放**。从工作站探测 CE 公网地址时，80 和 443 端口显示为开放，而从 VNet 内部探测时则是关闭的。请使用客户端 VM。
-- **CE 上的 22 端口仅在内部（SLI）地址上响应。** 从客户端 VM 探测时，每个 CE 的内部地址都会返回 OpenSSH 横幅，而其管理地址和外部地址则超时——作为对照的一个未使用地址同样超时。eth0 被重命名为 `a-i-eth0` 且不承载主机 IP，因为数据平面占用了它。因此，探测你所熟知的那个节点地址，无法说明该节点的 SSH 状态。
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="切勿硬编码 CE 内部地址——每次重建都会重新分配">
-Azure 不会保留哪个 CE 在内部子网中获得哪个地址，而且这些地址也不按节点顺序排列。2026-07-28 观测到三个 CE 分别持有 `10.0.3.7`、`10.0.3.5` 和 `10.0.3.4`——既不连续，也与该次重建之前所持有的地址不同。
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-决定它们是否变动的是 **NIC**，而不是 VM。仅替换 CE VM 会保留 NIC，所有地址都会保持不变：同一天已验证——在采用派生对象名称时替换了全部三个 CE VM，三个内部地址完全一致地回来了。而移除 NIC 的销毁操作会从子网的空闲池中重新分配地址，顺序完全取决于 Azure 如何填充。
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-测试客户端的 NIC 位于同一子网，因此你记忆中属于某个 CE 的地址现在可能属于客户端——在本部署中它持有 `10.0.3.6`，而这个地址在更早一次重建之前是由某个 CE 持有的。
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-请读取它们，而不要凭记忆：
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-若手边没有 Terraform 状态，可按 NIC 名称向 Azure 查询，NIC 名称*是*稳定的：
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-连接到记忆中的地址，会让你落到错误的节点、落到一台并非 CE 的 VM 上，或者哪里都到不了——而最后这种情况看起来与"SSH 未启用"完全一样。
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## 确认盒内命令界面仍与文档一致
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -223,7 +296,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` 不会写入任何内容，因此对正在运行的演示是安全的。
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -245,13 +349,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="接入 Customer Edge"
-    description="适用哪种访问途径、每种途径所需的凭据，以及为何这一选择并非偏好问题。"
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="BGP 命令"
-    description="来自 FRR 的盒内视图——对等状态、完整路由表，以及本节点所通告的内容。"
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>

--- a/docs/zh-tw/demo/index.mdx
+++ b/docs/zh-tw/demo/index.mdx
@@ -7,54 +7,66 @@ sidebar:
   order: 5
   label: 示範
 i18n:
-  sourceHash: 4fbc25642229
+  sourceHash: 8fc8320a0a1f
   translator: machine
 ---
 
 import { Aside, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-此部署示範 **Azure 中的 active/active Customer Edge 高可用性**，
-且 CE 前方不放置任何 Azure 負載平衡器。每個 CE 都透過 eBGP 發布相同的主機路由，
-Azure Route Server 則將它們全部安裝為 VNet 中的等價下一躍點。
-因此，流量分配與失效節點的移除是由路由架構負責，而非由負載平衡器負責。
+This deployment demonstrates **active/active Customer Edge high availability in Azure and On-Premise KVM**
+with no Azure load balancer in front of the CEs, expanded to support **parallel regional network paths and an on-premise KVM extension**
+in a single Terraform plan:
 
-這些頁面中的所有內容都是針對實際運行的部署執行而得，顯示的輸出即為其產生的輸出。
-這句話**未**涵蓋的部分 —— 容錯移轉，以及流量如何分配到各個下一躍點 ——
-會被明確指出，而不是留給讀者自行假設。
+1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
+2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
+3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
-## 它部署了什麼
+Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
+The routing fabric, rather than a load balancer, is where traffic distribution and failed-node removal happen.
+
+Everything in these pages was run against the live deployment, and the output shown is the
+output it produced. What that sentence does *not* cover — failover, and how traffic divides
+across the next hops — is called out explicitly rather than left to be assumed.
+
+## What it deploys
+
+Observed 2026-08-05. The three-path hybrid architecture:
 
 ```text
-                     Azure Route Server            ASN 65515
-                      two instance addresses
-                                 |
-             +-------------------+-------------------+
-             |                   |                   |
-        <key>-bgp           <key>-bgp           <key>-bgp        eBGP
-             |                   |                   |         CE ASN 64512
-        CE eth0/SLO         CE eth0/SLO         CE eth0/SLO
-          CE site             CE site             CE site
-             |                   |                   |
-             +--- each advertises the same VIP /32 ---+
-                    equal-cost multipath into the VNet
+                     Rest of World (ROW)              Canada Regional Path               On-Premise KVM Extension
+                 mcn-ce-ha.f5-sales-demo.com       mcn-ce-ha.f5-sales-demo.ca           onprem.mcn-ce-ha.example.com
+                           |                                 |                                        |
+                 Global Public REs               Canada RE Virtual Site                       On-Prem KVM Virtual Site
+                         |                     (Toronto & Montreal REs)                    (KVM Customer Edge Sites)
+                         |                                   |                                        |
+                Azure Route Server                Canada Azure Route Server                 FRR ToR BGP Router (Container)
+                   ASN 65515                         ASN 65515                                ASN 65515 (10.100.0.1)
+                       |                                     |                                        |
+           +-----------+-----------+             +-----------+-----------+                    +-----------+-----------+
+           |           |           |             |           |           |                    |           |           |
+        CE-01       CE-02       CE-03         CE-CA-01    CE-CA-02    CE-CA-03             CE-KV-01    CE-KV-02    CE-KV-03
+       (eastus)    (eastus)    (eastus)     (canadacentral) (canadacentral) (canadacentral)   (onprem-01) (onprem-02) (onprem-03)
+           |           |           |             |           |           |                    |           |           |
+           +---- VIP <ROW_VIP> ----+             +---- VIP <CA_VIP> -------+                    +---- VIP <KVM_VIP> --------+
 ```
 
-| 元件 | 說明 |
+| Piece | What it is |
 | --- | --- |
-| F5 Distributed Cloud 租戶 | `var.expected_xc_tenant` —— 唯一指定租戶名稱的地方 |
-| 命名空間 | CE 站點位於 `system`；origin pool 與負載平衡器位於 `var.xc_app_namespace` |
-| Customer Edge | `var.ce_count` 個單節點 Secure Mesh v2 站點，1 至 3 個，每個可用區各一個 |
-| CE 軟體 | 由 `var.ce_sw_version` / `var.ce_os_version` 鎖定版本 |
-| Azure VM | 各有三張 NIC —— 管理/SLO、external、internal/SLI |
-| 路由交換 | 一個 Azure Route Server，ASN 為 `var.rs_asn`，兩個 instance address |
-| Peering | 每個 CE 一個，命名為 `<key>-bgp`，CE ASN 為 `var.ce_asn` |
-| 發布的 VIP | `var.vip` 以 `/32` 形式，由每個 CE 以相同方式發布 |
-| 負載平衡器 | 服務 `var.lb_domain`，後端為位於 `var.origin_ip` 的 origin pool |
-| 測試用戶端 | 位於同一 VNet 內的 VM，用於對 VIP 發送流量 |
+| F5 Distributed Cloud tenant | `var.expected_xc_tenant` — the only place the tenant is named |
+| Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
+| Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
+| Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
+| On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
+| Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
+| Route exchange | Azure Route Servers in `eastus` and `canadacentral` (ASN `var.rs_asn`), FRR ToR BGP Router for KVM (ASN `65515`, `10.100.0.1`) |
+| Peerings | eBGP peerings per CE, CE ASN `var.ce_asn` (`64512`) |
+| Advertised VIPs | `var.vip` (`10.250.0.10`) for ROW; `var.ca_vip` (`10.250.1.10`) for Canada; `10.100.0.10` for On-Prem KVM |
+| Load balancers | `var.lb_domain` (`f5-sales-demo.com`) for ROW; `var.ca_lb_domain` (`f5-sales-demo.ca`) for Canada |
+| Test clients | Client VMs in each regional VNet and local test environment for driving traffic at the VIPs |
 
-以上內容都不是應該照抄的字面值。每個值都可從部署中讀取，
-而各頁面都是讀取這些值，而非直接寫明：
+Nothing above is a literal you should copy. Every value is readable from the deployment,
+and each page reads it rather than naming it:
 
 ```bash
 cd terraform
@@ -62,47 +74,49 @@ terraform output -raw resource_group_name
 terraform output -json xc_site_names
 ```
 
-<Aside type="caution" title="VIP 必須位於所有 VNet CIDR 之外">
-`terraform/main.tf` 帶有一個 `check` 區塊，用於斷言 VIP 位於 hub 與 spoke CIDR 之外，
-否則將拒絕該 plan。其明述的原因是：位於 VNet CIDR 內的 VIP，即使 BGP 路由更為明確，
-仍會敗給 VNet 自身的系統路由。
+<Aside type="caution" title="The VIP must sit outside every VNet CIDR">
+`terraform/main.tf` carries a `check` block that asserts the VIP is outside both the hub
+and spoke CIDRs, and refuses the plan otherwise. Its stated reason is that a VIP inside a
+VNet CIDR loses to the VNet's own system route despite the BGP route being more specific.
 
-請將此保護視為契約：若你將此示範改指向不同的位址規劃，VIP 也必須隨之移出 VNet 範圍。
+Treat the guard as the contract: if you re-point this demo at different addressing, the
+VIP has to move out of the VNet ranges with it.
 </Aside>
 
-<Aside type="caution" title="重新命名是重建，而非改名">
-由於每個名稱都衍生自 `var.component`，變更它會重新命名整個部署 ——
-但 `site_prefix` 並非只是外觀上的變更。它會成為每個 CE 的 cloud-init 中的 `ClusterName`，
-`custom_data` 為 replace-only，而 cloud-init 只會在 CE 首次開機時執行。
-因此變更它會**取代每一個 CE VM 及其 XC 站點**，而在 ECMP 重新收斂期間，VIP 會短暫發生封包遺失。
+<Aside type="caution" title="Renaming is a rebuild, not a rename">
+Because every name derives from `var.component`, changing it renames the whole
+deployment — but `site_prefix` is not a cosmetic change. It becomes the `ClusterName`
+in each CE's cloud-init, `custom_data` is replace-only, and cloud-init runs only on a
+CE's first boot. So changing it **replaces every CE VM and its XC site**, and the VIP is
+then briefly lossy while ECMP reconverges.
 
-這並非理論上的問題：在運行中的示範上採用這些衍生名稱，替換了三個 CE VM、
-三個站點、三個 BGP 物件、負載平衡器、origin pool、Azure Route Server、Bastion 與測試用戶端 ——
-`23 to add, 3 to change, 26 to destroy`。
-當你需要現有站點維持不變時，請將 `site_prefix` 鎖定為目前的值。
+That is not theoretical: adopting these derived names on the running demo replaced three
+CE VMs, three sites, three BGP objects, the load balancer, the origin pool, the Azure
+Route Server, the Bastion and the test client — `23 to add, 3 to change, 26 to destroy`.
+Pin `site_prefix` to the current value when you need existing sites to stay put.
 </Aside>
 
-## 接下來前往何處
+## Where to go next
 
 <CardGrid>
   <LinkCard
-    title="部署它"
-    description="前置需求、你必須提供的兩個值、為何首次 apply 分為兩階段，以及如何拆除。"
+    title="Deploy it"
+    description="Prerequisites, the two values you must supply, why the first apply is two-phase, and how to tear it down."
     href="./deploy/"
   />
   <LinkCard
-    title="Terraform 設定"
-    description="設定本身，直接從部署它的檔案讀取而非重新輸入。"
+    title="The Terraform"
+    description="The configuration itself, read from the files that deploy it rather than retyped."
     href="./terraform/"
   />
   <LinkCard
-    title="驗證健康狀態"
-    description="依序進行的四項檢查，以及那些看似正常卻會被誤讀為故障、實際上並非故障的結果。"
+    title="Prove it healthy"
+    description="Four checks in order, and the normal-looking results that read as an outage and are not."
     href="./verify/"
   />
   <LinkCard
-    title="進行演示"
-    description="這個示範能展示什麼、目前還無法展示什麼，以及讓 ECMP 可視化的那一道命令。"
+    title="Present it"
+    description="What this demo can show, what it cannot yet show, and the one command that makes ECMP visible."
     href="./present/"
   />
 </CardGrid>

--- a/docs/zh-tw/demo/spec.mdx
+++ b/docs/zh-tw/demo/spec.mdx
@@ -4,6 +4,9 @@ description: Human-readable, minimal engineering specification derived from the 
 sidebar:
   order: 26
   label: Engineering Spec
+i18n:
+  sourceHash: e71d46628f44
+  translator: machine
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,12 +21,13 @@ It functions as both an architectural specification and an execution prompt for 
 
 Observed 2026-08-05. Architectural specification:
 
-The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension.
+The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC) Customer Edge (CE) Secure Mesh v2 topology** on Microsoft Azure with a parallel Canadian regional extension and an On-Premise KVM extension.
 
-- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server (ASN `65515`). The VNet uses native ECMP for active/active traffic distribution without an Azure Load Balancer.
-- **Dual Network Paths**:
+- **Routing Fabric**: CEs originate host routes (`/32`) via eBGP (ASN `64512`) to an Azure Route Server or containerized ToR BGP router (ASN `65515`). The VNets and local libvirt networks use native ECMP for active/active traffic distribution.
+- **Three Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
+  3. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
 
@@ -38,6 +42,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.
+  - `dmacvicar/libvirt` (`~> 0.8.0` / `v0.8.3`): Manages local KVM domains, volumes, seed ISOs, and network bridges for on-premise Customer Edge nodes.
 - **Backend**: Partial Azure Blob storage backend (`backend "azurerm" {}` with `backend.hcl.example`).
 
 ### Tenant Guard & CIDR Safety Checks (`data.tf`, `main.tf`, `scripts/xc-env-tenant.sh`)
@@ -99,6 +104,15 @@ Pure-computation module expanding `ce_count` (1..3) into per-CE node maps:
 
 - **`modules/azure-route-server-bgp`**: Resource `azurerm_route_server_bgp_connection` connecting Route Server to CE management private IP.
 - **`modules/client-vm`**: Test client Ubuntu VM in `snet-hub-internal` with NSG, public IP, `admin_username = "azureuser"`, and `private_ip_address_allocation = "Dynamic"`.
+
+### On-Premise KVM Infrastructure (`kvm.tf`, `onprem_kvm.tf`, `providers_libvirt.tf`)
+
+- **libvirt Provider**: `provider "libvirt"` targeting local QEMU hypervisor (`qemu:///system`).
+- **Network Bridge**: `libvirt_network.ce_bgp_net` creating NAT-mode bridge `virbr-ce-bgp` on subnet `10.100.0.0/24` with DHCP and DNS enabled.
+- **Base Image & Storage**: `libvirt_volume.base_cloud` importing base cloud OS image, and `libvirt_volume.ce_disk` provisioning 20 GB root overlay disks per CE (`onprem-ce-01`, `02`, `03`).
+- **Cloud-Init ISO Seed**: `libvirt_cloudinit_disk.ce_cloudinit` injecting `/etc/vpm/config.yaml` with `ClusterName: onprem-kvm-site` and `ClusterType: ce`.
+- **KVM Domains**: `libvirt_domain.ce_node` defining 2 vCPU / 2048 MB RAM VMs with autostart enabled, attached to `ce-bgp-net`.
+- **F5 XC Site & eBGP**: `xcsh_securemesh_site_v2.onprem_kvm` (`onprem-kvm-site`) and `xcsh_bgp.onprem_ebgp` peering CE ASN `64512` to containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) on port 179 over `eth0`.
 
 ---
 

--- a/docs/zh-tw/demo/terraform.mdx
+++ b/docs/zh-tw/demo/terraform.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 20
   label: Terraform
 i18n:
-  sourceHash: b8380b6bc381
+  sourceHash: d28c74652ff4
   translator: machine
 ---
 
@@ -13,10 +13,13 @@ import { Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 import backend from "../../_includes/terraform/backend.tf?raw";
 import data from "../../_includes/terraform/data.tf?raw";
+import kvm from "../../_includes/terraform/kvm.tf?raw";
 import locals from "../../_includes/terraform/locals.tf?raw";
 import main from "../../_includes/terraform/main.tf?raw";
+import onpremKvm from "../../_includes/terraform/onprem_kvm.tf?raw";
 import outputs from "../../_includes/terraform/outputs.tf?raw";
 import providers from "../../_includes/terraform/providers.tf?raw";
+import providersLibvirt from "../../_includes/terraform/providers_libvirt.tf?raw";
 import variables from "../../_includes/terraform/variables.tf?raw";
 import variablesAzure from "../../_includes/terraform/variables_azure.tf?raw";
 import variablesCe from "../../_includes/terraform/variables_ce.tf?raw";
@@ -41,89 +44,108 @@ import modulesXcSiteOutputs from "../../_includes/terraform/modules/xc-site/outp
 import modulesXcSiteVariables from "../../_includes/terraform/modules/xc-site/variables.tf?raw";
 import modulesXcSiteVersions from "../../_includes/terraform/modules/xc-site/versions.tf?raw";
 
-以下每個檔案都是實際執行部署的檔案，在建置階段匯入而非貼上。
-會偏移的副本終究會偏移，因此只要此處發布的內容與 `terraform/` 中的內容有任何差異，
-CI 中的檢查便會立即失敗。
+Every file below is the file that deploys, imported at build time rather than pasted.
+A copy that can drift is a copy that will, so a check in CI fails the moment what is
+published here differs from what is in `terraform/`.
 
-<Aside type="note" title="為何設定內容是匯入而非直接內嵌顯示">
-若貼進程式碼區塊，這份設定就會成為頁面原始碼的一部分，而頁面原始碼會被翻譯成十二種語言。
-其中的註解會一併被翻譯，於是每個語系都會發布一份不同且錯誤的設定。
-改為匯入之後，它根本不會進入頁面原始碼。
+<Aside type="note" title="Why the configuration is imported rather than shown inline">
+Pasted into a code fence, this configuration would be part of the page source, and the
+page source is translated into twelve languages. The comments inside it would be
+translated with it, and each locale would publish a different, wrong configuration.
+Imported, it never enters the page source at all.
 </Aside>
 
-## 根模組
+## Root module
 
 ### `terraform/backend.tf`
 
-Azure 儲存體後端；其設定於 init 階段提供，不會提交到版本控制。
+Azure storage backend; its configuration is supplied at init time and not committed.
 
 <Code code={backend} lang="hcl" title="terraform/backend.tf" />
 
 ### `terraform/data.tf`
 
-唯讀查詢，包含用於推導部署者身分的 Azure AD 身分識別。
+Read-only lookups, including the Azure AD identity used to derive the deployer.
 
 <Code code={data} lang="hcl" title="terraform/data.tf" />
 
+### `terraform/kvm.tf`
+
+Declarative KVM & libvirt infrastructure managed natively via `dmacvicar/libvirt` (`v0.8.3`). Provisions local network bridge `ce-bgp-net` (`10.100.0.0/24`), base cloud storage volumes, per-CE overlay disks, cloud-init seed ISOs containing `/etc/vpm/config.yaml` bootstrap configs, and KVM virtual machine domains (`onprem-ce-01`, `02`, `03`).
+
+<Code code={kvm} lang="hcl" title="terraform/kvm.tf" />
+
 ### `terraform/locals.tf`
 
-推導而來的物件名稱所在之處。Terraform 變數預設值無法引用其他變數，因此每個名稱變數的預設值均為 null，並在此處解析。
+Where the derived object names live. Terraform variable defaults cannot reference other variables, so each name variable defaults to null and is resolved here.
 
 <Code code={locals} lang="hcl" title="terraform/locals.tf" />
 
 ### `terraform/main.tf`
 
-最上層的接線、租戶防護，以及 VIP 位於 VNet 之外的檢查。部署順序記載於本檔案開頭，該處為權威版本。
+Top-level wiring, the tenant guard and the VIP-outside-the-VNet check. The deploy ordering is documented at the top of this file, which is the authoritative version.
 
 <Code code={main} lang="hcl" title="terraform/main.tf" />
 
+### `terraform/onprem_kvm.tf`
+
+On-Premise KVM SecureMesh v2 Site (`xcsh_securemesh_site_v2.onprem_kvm`) and eBGP peering configuration (`xcsh_bgp.onprem_ebgp`). Connects on-premise CEs (ASN `64512`) over `eth0` to containerized FRR ToR BGP router (`10.100.0.1`, ASN `65515`).
+
+<Code code={onpremKvm} lang="hcl" title="terraform/onprem_kvm.tf" />
+
 ### `terraform/outputs.tf`
 
-文件中所有以讀取取代直接命名的內容。若某個頁面展示了一道命令，其背後必有此處的一項輸出。
+Everything the documentation reads instead of naming. If a page shows a command, an output here is behind it.
 
 <Code code={outputs} lang="hcl" title="terraform/outputs.tf" />
 
 ### `terraform/providers.tf`
 
-將 xcsh 端點釘選至 var.expected_xc_tenant，這使得租戶成為設定的一項屬性。
+Pins the xcsh endpoint to var.expected_xc_tenant, which is what makes the tenant a property of the configuration.
 
 <Code code={providers} lang="hcl" title="terraform/providers.tf" />
 
+### `terraform/providers_libvirt.tf`
+
+Configures the libvirt provider targeting the local hypervisor daemon URI (`qemu:///system`).
+
+<Code code={providersLibvirt} lang="hcl" title="terraform/providers_libvirt.tf" />
+
 ### `terraform/variables.tf`
 
-元件、環境、部署者與標籤。
+Component, environment, deployer and tags.
 
 <Code code={variables} lang="hcl" title="terraform/variables.tf" />
 
 ### `terraform/variables_azure.tf`
 
-訂閱、區域、CIDR、Bastion，以及 Azure 物件名稱。
+Subscription, region, CIDRs, Bastion, and the Azure object names.
 
 <Code code={variablesAzure} lang="hcl" title="terraform/variables_azure.tf" />
 
 ### `terraform/variables_ce.tf`
 
-CE 數量、站點前綴、ASN、映像版本與 VM 規格大小。
+CE count, site prefix, ASNs, image versions and VM size.
 
 <Code code={variablesCe} lang="hcl" title="terraform/variables_ce.tf" />
 
 ### `terraform/variables_xc.tf`
 
-租戶、應用程式命名空間、負載平衡器、來源池與 VIP。
+Tenant, app namespace, load balancer, origin pool and the VIP.
 
 <Code code={variablesXc} lang="hcl" title="terraform/variables_xc.tf" />
 
 ### `terraform/versions.tf`
 
-Terraform 版本下限與提供者限制條件。xcsh 的限制條件是開放式的下限，且鎖定檔案已被 gitignore，因此每次 init 都會取得最新發布的提供者。
+Terraform floor and provider constraints. The xcsh constraint is an open-ended floor, and the lock file is gitignored, so every init takes the latest published provider.
 
 <Code code={versions} lang="hcl" title="terraform/versions.tf" />
 
-## 模組
+## Modules
 
 ### `terraform/modules/azure-hub/`
 
-資源群組、hub VNet、四個子網路、Azure Route Server 與選用的 Bastion。RouteServerSubnet 刻意不搭載任何 NSG 或路由表。
+Resource group, hub VNet, the four subnets, the Azure Route Server and the optional Bastion. RouteServerSubnet deliberately carries no NSG or route table.
 
 <Code code={modulesAzureHubMain} lang="hcl" title="terraform/modules/azure-hub/main.tf" />
 
@@ -135,7 +157,7 @@ Terraform 版本下限與提供者限制條件。xcsh 的限制條件是開放�
 
 ### `terraform/modules/azure-route-server-bgp/`
 
-每個 eBGP 工作階段的 Azure 側 — 每個 CE 對應一個 bgpConnection，將 Route Server 與該 CE 的 eth0/SLO 位址對等連線。
+The Azure side of each eBGP session — one bgpConnection per CE, peering the Route Server to that CE eth0/SLO address.
 
 <Code code={modulesAzureRouteServerBgpMain} lang="hcl" title="terraform/modules/azure-route-server-bgp/main.tf" />
 
@@ -143,7 +165,7 @@ Terraform 版本下限與提供者限制條件。xcsh 的限制條件是開放�
 
 ### `terraform/modules/ce-node/`
 
-每個節點一台 CE VM：三張啟用 IP 轉送的 NIC、marketplace plan 區塊，以及以 custom_data 傳遞的 cloud-init。
+One CE VM per node: three NICs with IP forwarding, the marketplace plan block, and the cloud-init handed over as custom_data.
 
 <Code code={modulesCeNodeMain} lang="hcl" title="terraform/modules/ce-node/main.tf" />
 
@@ -155,13 +177,13 @@ Terraform 版本下限與提供者限制條件。xcsh 的限制條件是開放�
 
 ### `terraform/modules/ce-topology/`
 
-純運算，不含提供者也不含資料來源：將 ce_count 展開為驅動每一個 for_each 的 per-CE 對應表。在任何 N 值下皆可不需憑證即進行 plan 測試。
+Pure computation, no providers and no data sources: expands ce_count into the per-CE map that drives every for_each. Plan-testable at any N without credentials.
 
 <Code code={modulesCeTopologyMain} lang="hcl" title="terraform/modules/ce-topology/main.tf" />
 
 ### `terraform/modules/client-vm/`
 
-VNet 內的測試客戶端，用於讀取有效路由並對 VIP 產生流量。
+The test client inside the VNet, used to read effective routes and drive traffic at the VIP.
 
 <Code code={modulesClientVmMain} lang="hcl" title="terraform/modules/client-vm/main.tf" />
 
@@ -171,7 +193,7 @@ VNet 內的測試客戶端，用於讀取有效路由並對 VIP 產生流量。
 
 ### `terraform/modules/xc-site/`
 
-XC 站點物件、其 BGP 對等連線，以及依站點名稱解析 `r-<uuid>` 註冊的註冊核准。
+The XC site object, its BGP peering, and the registration approval that resolves a `r-<uuid>` registration by site name.
 
 <Code code={modulesXcSiteMain} lang="hcl" title="terraform/modules/xc-site/main.tf" />
 

--- a/docs/zh-tw/demo/verify.mdx
+++ b/docs/zh-tw/demo/verify.mdx
@@ -7,16 +7,17 @@ sidebar:
   order: 30
   label: 驗證
 i18n:
-  sourceHash: 200ef0fb5d0c
+  sourceHash: c90aadf52c9b
   translator: machine
 ---
 
 import { Aside, Steps, CardGrid } from "@astrojs/starlight/components";
 import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
-在展示之前先執行這些檢查。每一項檢查都會縮小故障可能存在的範圍，因此失敗會告訴你某些具體訊息，而不只是「有東西出錯了」。
+Run these before you present. Each check narrows where a fault would be, so a failure tells
+you something rather than only that something is wrong.
 
-每道指令都會從部署中讀取自己需要的資訊。設定一次以下變數，其餘指令即可沿用：
+Every command reads what it needs from the deployment. Set these once and the rest follow:
 
 ```bash
 cd terraform
@@ -26,13 +27,19 @@ CLIENT=$(terraform output -raw client_vm_name)
 DOMAIN=$(terraform output -raw lb_domain)
 VIP=$(terraform output -raw vip)
 NIC=$(terraform output -raw client_nic_name)
+
+# Canada Regional Path variables (when enable_canada = true)
+CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
+CA_VIP=$(terraform output -raw ca_vip)
+CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
+CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
 ```
 
-## 四項檢查，依此順序
+## Four checks, in this order
 
 <Steps>
 
-1. **每個 Site 都是 `ONLINE`。** 若這一點不成立，下游的任何結果都不可能為真。
+1. **Every site is `ONLINE`.** Nothing downstream can be true if this is not.
 
    ```bash
    for s in $(terraform output -json xc_site_names | jq -r '.[]'); do
@@ -42,15 +49,17 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 觀測結果，三台 CE：
+   Observed 2026-08-03 after the from-zero rebuild:
 
    ```text
-   mcn-ce-ha-eastus01 -> ONLINE
-   mcn-ce-ha-eastus02 -> ONLINE
-   mcn-ce-ha-eastus03 -> ONLINE
+   <SITE_01> -> ONLINE
+   <SITE_02> -> ONLINE
+   <SITE_03> -> ONLINE
    ```
 
-2. **每個 peering 都學到該 CE 的 VIP 通告。** 請分別查詢每個 peering——參見下方第一個陷阱，因為這正是本示範最常看起來壞掉、實際上卻沒壞的地方。
+2. **Every peering is learning that CE's VIP advertisement.** Query each peering
+   separately — see the first trap below, because this is where the demo most often looks
+   broken and is not.
 
    ```bash
    for k in $(terraform output -json xc_site_names | jq -r 'keys[]'); do
@@ -62,26 +71,28 @@ NIC=$(terraform output -raw client_nic_name)
    done
    ```
 
-   2026-07-28 觀測結果：
+   Observed 2026-08-03. The live addresses are omitted; read them from the command:
 
    ```text
    --- eastus01-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.4   64512     EBgp
+   <VIP>/32        <CE_01_SLO_IP>  <CE_ASN>  EBgp
    --- eastus02-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.5   64512     EBgp
+   <VIP>/32        <CE_02_SLO_IP>  <CE_ASN>  EBgp
    --- eastus03-bgp
    Net             NextHop    AsPath    Origin
    --------------  ---------  --------  --------
-   10.250.0.10/32  10.0.1.6   64512     EBgp
+   <VIP>/32        <CE_03_SLO_IP>  <CE_ASN>  EBgp
    ```
 
-   三個 peering、三個不同的 next hop、一個前綴。這就證明了 ECMP 的通告端。
+   Three peerings, three different next hops, one prefix. That is the advertisement side of
+   ECMP proven.
 
-3. **用戶端的有效路由涵蓋每一個 next hop。** 這才是 ECMP 本身，是 VNet 實際編寫的結果——不是 CE 宣稱了什麼，而是 Azure 據此做了什麼。
+3. **The client's effective routes carry every next hop.** This is the ECMP itself, as the
+   VNet has programmed it — not what the CEs claim, but what Azure did with it.
 
    ```bash
    az network nic show-effective-route-table -g "$RG" -n "$NIC" \
@@ -89,133 +100,195 @@ NIC=$(terraform output -raw client_nic_name)
      -o json
    ```
 
-   2026-07-28 觀測結果：
+   Observed 2026-08-03. The array contained the three addresses returned by
+   `terraform output -json ce_mgmt_private_ips`:
 
    ```json
    [
      {
-       "nh": ["10.0.1.5", "10.0.1.6", "10.0.1.4"],
-       "prefix": "10.250.0.10/32",
+       "nh": ["<CE_01_SLO_IP>", "<CE_02_SLO_IP>", "<CE_03_SLO_IP>"],
+       "prefix": "<VIP>/32",
        "state": "Active",
        "type": "VirtualNetworkGateway"
      }
    ]
    ```
 
-   檢查重點是 `state: Active`，且 `nh` 中每台 CE 各有一筆。**順序不具意義，也不穩定**——Azure 每次呼叫回傳的順序都不同，所以請計算數量，而不要與先前的執行結果比對。若你預期三個 next hop 卻只看到一個，代表有一台 CE 已停止通告，而步驟 2 能指出是哪一台。
+   `state: Active` with one entry per CE in `nh` is the check. **The order is not
+   significant and is not stable** — Azure returns them differently between calls, so count
+   them rather than comparing to a previous run. One next hop where you expect three means a
+   CE has stopped advertising, and step 2 identifies which.
 
-4. **VIP 能提供服務。** 從用戶端 VM 執行，並且**帶上 `Host` 標頭**——參見第二個陷阱。取樣數量要足以看出問題：即使在下文所述的收斂視窗內，幾十次請求也會顯示為 100 %。
+4. **The VIPs serve traffic.** From the client VM, and **with the `Host` header** — see the
+   second trap. Sample both the Rest of World (`f5-sales-demo.com`) and Canada (`f5-sales-demo.ca`) domains.
 
    ```bash
    az vm run-command invoke -g "$RG" -n "$CLIENT" \
      --command-id RunShellScript --query "value[0].message" -o tsv \
      --scripts "ok=0; fail=0
-                for i in \$(seq 1 60); do
+                for i in \$(seq 1 30); do
                   c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
                         -H 'Host: ${DOMAIN}' http://${VIP}/)
                   [ \"\$c\" = 200 ] && ok=\$((ok+1)) || fail=\$((fail+1))
                 done
-                echo \"OK=\$ok FAIL=\$fail\""
+                echo \"ROW_DOMAIN_OK=\$ok ROW_DOMAIN_FAIL=\$fail\"
+                if [ -n \"${CA_LB_DOMAIN:-}\" ] && [ -n \"${CA_VIP:-}\" ]; then
+                  ca_ok=0; ca_fail=0
+                  for i in \$(seq 1 30); do
+                    c=\$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+                          -H 'Host: ${CA_LB_DOMAIN}' http://${CA_VIP}/)
+                    [ \"\$c\" = 200 ] && ca_ok=\$((ca_ok+1)) || ca_fail=\$((ca_fail+1))
+                  done
+                  echo \"CANADA_DOMAIN_OK=\$ca_ok CANADA_DOMAIN_FAIL=\$ca_fail\"
+                fi"
    ```
 
-   2026-07-28 觀測結果：
+   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
 
    ```text
-   VIP with Host header: OK=60 FAIL=0
-   bare IP (no Host): 404
+   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
    ```
 
 </Steps>
 
-## 陷阱：某個 peering 只顯示一條路由，而這是正確的
+## Trap: one peering shows one route, and that is correct
 
-`list-learned-routes` 的範圍限於你指定的那個 peering。它回報的是**該**對等體所通告的內容，而非 Route Server 的整張路由表。
+`list-learned-routes` is scoped to the peering you name. It reports what **that** peer
+advertised, not the Route Server's whole table.
 
-因此單獨查詢一個 peering 只會回傳一條經由單一 next hop 的 VIP `/32`，很容易被誤讀為「只有一台 CE 在通告——其他都掛了」。其實沒有任何東西掛掉。其他通告會出現在各自的 peering 上，而這正是步驟 2 迴圈所走訪的內容。
+So querying one peering alone returns a single VIP `/32` via a single next hop, and it is
+tempting to read that as "only one CE is advertising — the others are down". Nothing is
+down. The other advertisements are visible on their own peerings, which is what step 2 loops
+over.
 
-無法只憑單一 peering 查詢就確認 ECMP。要嘛迴圈走訪每個 peering，要嘛讀取用戶端的有效路由表，後者能在一次呼叫中顯示合併後的結果。
+Confirming ECMP from a single peering query is not possible. Either loop every peering, or
+read the client's effective route table, which shows the merged result in one call.
 
-## 陷阱：裸 IP 請求回傳 404
+## Trap: a bare-IP request returns 404
 
-負載平衡器是依 `Host` 比對的。VIP 並不是一個會對任何連上該位址的人提供服務的虛擬伺服器。
+The load balancer matches on `Host`. The VIP is not a virtual server that serves anything to
+whoever connects to the address.
 
-以下兩者來自同一次針對健康部署的執行：
+Both of these came from the same run against the healthy deployment:
 
 ```text
 curl -H "Host: $DOMAIN" http://$VIP/   ->  200   (60 of 60)
 curl                     http://$VIP/   ->  404
 ```
 
-**裸 IP 的 404 正好證明路徑是通的**——請求抵達了 CE、CE 的 proxy 做出了回應，並因為沒有相符的已設定網域而拒絕。把它讀成服務中斷，只會讓你跑去查 BGP，而在那裡你什麼問題都找不到。
+**A bare-IP 404 is proof the path works** — the request reached the CE, the CE's proxy
+answered, and it declined because no configured domain matched. Reading it as an outage
+sends you looking at BGP, where you will find nothing wrong.
 
-同樣的情況也適用於示範過程：如果你直接在瀏覽器輸入位址，而不是把網域解析到該位址，你就會得到 404。
+The same applies during a demo: if you type the address into a browser rather than resolving
+the domain to it, you get the 404.
 
-## VIP 在最初的四十五分鐘內會丟棄請求，之後便停止
+## A fresh deployment can have a convergence transient
 
-在全新建置的堆疊上，自 CE 進入 `ONLINE` 起約前 45 分鐘內，VIP 會遺失一小部分請求，之後便乾淨地提供服務。以用戶端 VM 發出的 1,470 次請求量測，全部帶有 `Host` 標頭：
+The 2026-08-03 from-zero UAT sent 160 VIP requests in four time-separated batches. Three
+requests failed in the first two batches; the final 80 were clean. The origin control was
+80 of 80 throughout. That proves convergence for this rebuild without attributing the early
+loss to the origin.
 
-| 時段 | 請求數 | 失敗數 | 比率 |
+Earlier measurements on 2026-07-28 showed the longer shape: the VIP lost a small fraction of
+requests for roughly the first 45 minutes after the CEs reached `ONLINE`, then served cleanly.
+Measured over 1,470
+requests from the client VM, all with the `Host` header:
+
+| Window | Requests | Failures | Rate |
 | --- | --- | --- | --- |
-| ECMP 建立後最初約 45 分鐘 | 570 | 12 | **2.11 %** |
-| 接下來的 23 分鐘 | 900 | **0** | **0.00 %** |
+| First ~45 minutes after ECMP came up | 570 | 12 | **2.11 %** |
+| The following 23 minutes | 900 | **0** | **0.00 %** |
 
-每一次失敗都是 `curl: (28)`——逾時且未收到任何位元組——而非 HTTP 錯誤狀態碼。最後一次失敗發生在 ECMP 建立後約 43 分鐘。在 900 次乾淨請求中，有 400 次使用 30 秒逾時設定，且每一次都在 2 秒內完成，因此並沒有任何問題被過短的逾時所掩蓋。
+Every failure was `curl: (28)` — a timeout with zero bytes received — not an HTTP error
+status. The last one landed about 43 minutes after ECMP came up. Of the 900 clean requests,
+400 ran with a 30-second timeout and every one finished in under 2 seconds, so nothing was
+hidden by a short timeout.
 
-同一天稍後的一次重建中再度重現，而那次執行的樣貌更清楚，因為它是在視窗期間逐步取樣，而非在事後才取樣。360 次請求，全部帶有 `Host` 標頭，每一批都搭配一組直接打到來源端的對照組：
+It reproduced again on a later rebuild on 2026-07-28, and that run is the clearer picture
+because it was sampled as the window elapsed rather than after it. 360 requests, all with
+the `Host` header, each batch paired with a control straight to the origin:
 
-| 進入 `ONLINE` 後的時間 | 請求數 | 失敗數 | 比率 | 來源端對照 |
+| Time after `ONLINE` | Requests | Failures | Rate | Origin control |
 | --- | --- | --- | --- | --- |
-| 立即 | 60 | 8 | **13.3 %** | 30/30 乾淨 |
-| 約 25–40 分鐘（3 批） | 180 | 3 | **1.67 %** | 60/60 乾淨 |
-| 約 50 分鐘 | 120 | **0** | **0.00 %** | 40/40 乾淨 |
+| immediately | 60 | 8 | **13.3 %** | 30/30 clean |
+| ~25–40 min (3 batches) | 180 | 3 | **1.67 %** | 60/60 clean |
+| ~50 min | 120 | **0** | **0.00 %** | 40/40 clean |
 
-單調遞減至零，且每一批的來源端都是乾淨的——包括每八次 VIP 請求就失敗一次的那一批。
+Monotonically decreasing to zero, and the origin was clean in every batch — including the
+one where one VIP request in eight failed.
 
-**來源端並非成因。** 一組直接打到來源端（`terraform output -raw origin_ip`，繞過 VIP）的對照批次，在與失敗的 VIP 批次**同時**執行時，120 次全數乾淨。故障出在 VIP、ECMP 或 CE 路徑中的某處。
+**The origin was not the cause.** A control batch straight to the origin
+(`terraform output -raw origin_ip`, bypassing the VIP) ran 120 of 120 clean *concurrently
+with* failing VIP batches. The fault is somewhere in the VIP, ECMP or CE path.
 
-有兩件事刻意不這樣稱呼：
+Two things this is deliberately not called:
 
-- **這不是穩態缺陷。** 它會完全消失並保持消失——在 50 分鐘時 120 次中 120 次成功，而在已運行數小時的堆疊上 60 次中 60 次成功。
-- **不要因為早期的小樣本就斷定它不存在。** 某次重建後立即取樣的 60 次批次回傳 60 次中 60 次成功，看起來像「沒有暫時性問題」；同一個部署在下一次重建的一小時後卻在 60 次中失敗了 8 次。60 次請求不足以看出突發性的丟失。請取樣 100 次以上，並分成在時間上彼此間隔的批次——上表需要 360 次才呈現出這個形狀。
-- **它無法歸咎於特定的某台 CE。** 此拓撲中沒有任何機制提供逐節點的 HTTP 監聽器，因此無法把被丟棄的請求綁定到丟棄它的節點。CE 的對外介面完全沒有 HTTP 監聽器——只有 VIP `/32` 會回應。
+- **It is not a steady-state defect.** It clears completely and stays clear — 120 of 120 at
+  the 50-minute mark, and 60 of 60 on a stack that had been up for hours.
+- **Do not conclude it is absent from a small early sample.** A 60-request batch taken
+  immediately after one rebuild returned 60 of 60, which read as "no transient"; the same
+  deployment lost 8 of 60 an hour later on the next rebuild. Sixty requests is not enough
+  to see a bursty loss. Sample 100 or more, in batches separated in time — the table above
+  needed 360 to show the shape.
+- **It is not attributable to a particular CE.** Nothing in this topology gives a per-node
+  HTTP listener, so there is no way to bind a dropped request to the node that dropped it.
+  The CE outside interfaces have no HTTP listener at all — only the VIP `/32` answers.
 
-它在不同租戶的一次乾淨重建中也重現了，因此它跟隨的是拓撲，而非環境。
-
-<Aside type="caution" title="不要只取樣 40 次請求就斷定沒問題">
-即使在會失敗的視窗內，40 到 50 次的批次多半也會顯示為 100 %。這正是此問題一開始先被誤判為持續性的低比率故障，接著又被誤判為完全沒有故障的原因。請取樣 100 次以上，並分成在時間上彼此間隔的批次。
+<Aside type="caution" title="Do not sample 40 requests and conclude it is fine">
+Batches of 40 to 50 read as 100 % most of the time even inside the failing window. That is
+how this was first mischaracterised as an ongoing low-rate fault and then as no fault at
+all. Sample 100 or more, in batches separated in time.
 </Aside>
 
-## 另外兩個量測陷阱
+## Two more measurement traps
 
-兩者都在此環境中產生過令人深信不疑的錯誤答案，而且都不明顯。
+Both produced confident wrong answers in this environment, and neither is obvious.
 
-- **從 VNet 內部探測，而不是從你的工作站。** 企業 proxy 可能會在常見連接埠上自行完成 TCP 交握，因此工作站的探測會把實際上已關閉的連接埠回報為**開啟**。從工作站探測 CE 的公有位址時，連接埠 80 與 443 顯示為開啟；從 VNet 內部探測時則是關閉的。請使用用戶端 VM。
-- **CE 上的連接埠 22 只在內部（SLI）位址上回應。** 從用戶端 VM 探測時，每台 CE 的內部位址都會回傳 OpenSSH banner，而其管理與外部位址則會逾時——作為對照的未使用位址亦然。eth0 被重新命名為 `a-i-eth0` 且不帶主機 IP，因為資料路徑掌握著它。因此，探測你所熟知的那個節點位址，並不能告訴你該節點的 SSH 狀態。
+- **Probe from inside the VNet, not from your workstation.** A corporate proxy can complete
+  the TCP handshake itself on common ports, so a workstation probe reports a port **open**
+  that is actually closed. Ports 80 and 443 read as open on the CE public addresses from a
+  workstation and are closed when probed from inside the VNet. Use the client VM.
+- **Port 22 on a CE answers on the internal (SLI) address only.** Probed from the client VM,
+  each CE's internal address returns an OpenSSH banner, while its management and external
+  addresses time out — as does an unused address used as a control. eth0 is renamed
+  `a-i-eth0` and carries no host IP, because the datapath owns it. So probing the address
+  you know the node by tells you nothing about the node's SSH state.
 
-<Aside type="danger" title="切勿寫死 CE 內部位址——它們在每次重建時都會重新指派">
-Azure 不會保留哪台 CE 取得內部子網中的哪個位址，而且這些位址也不依節點順序排列。2026-07-28 觀測到三台 CE 分別持有 `10.0.3.7`、`10.0.3.5` 與 `10.0.3.4`——既非連續，也與該次重建之前所持有的不同。
+<Aside type="danger" title="Never hardcode a CE internal address — they are reassigned on every rebuild">
+Azure does not preserve which CE gets which address in the internal subnet, and the
+addresses are not in node order. Observed 2026-07-28: the three addresses were not
+sequential and differed from the previous rebuild. Read the current mapping from Terraform;
+published documentation deliberately does not carry the deployment's values.
 
-決定它們是否會變動的是 **NIC**，而不是 VM。只更換 CE VM 會讓 NIC 留在原處，所有位址都得以保留：同一天已驗證，當採用衍生的物件名稱而替換了全部三台 CE VM 後，三個內部位址完全相同地回來了。若拆除作業移除了 NIC，位址就會從子網的可用位址池重新指派，順序則取決於 Azure 如何填入。
+What decides whether they move is the **NIC**, not the VM. Replacing the CE VMs alone
+leaves the NICs in place and every address survives: verified the same day, when adopting
+the derived object names replaced all three CE VMs and the three internal addresses came
+back identical. A teardown that removes the NICs reassigns them from the subnet's free
+pool, in whatever order Azure fills it.
 
-測試用戶端的 NIC 位於同一個子網，因此你記憶中屬於某台 CE 的位址，現在可能屬於用戶端——在此部署中它持有 `10.0.3.6`，而某台 CE 在更早的重建之前曾持有該位址。
+The test client's NIC sits in that same subnet, so an address you remember as a CE's may
+now belong to the client.
 
-請讀取它們，而不要憑記憶：
+Read them instead of remembering them:
 
 ```bash
 terraform output -json ce_sli_private_ips
 ```
 
-若手邊沒有 Terraform state，可依 NIC 名稱向 Azure 查詢，NIC 名稱**是**穩定的：
+Without Terraform state to hand, ask Azure by NIC name, which *is* stable:
 
 ```bash
 az network nic show -g "$RG" -n "<vm-name>-internal-nic" \
   --query ipConfigurations[0].privateIPAddress -o tsv
 ```
 
-連到記憶中的位址會讓你落在錯誤的節點、落在一台不是 CE 的 VM 上，或哪裡都到不了——而最後這種情況看起來與「SSH 未啟用」一模一樣。
+Connecting to a remembered address lands you on the wrong node, on a VM that is not a CE,
+or nowhere — and the last of those looks identical to "SSH is not enabled".
 </Aside>
 
-## 確認機上指令介面仍與文件相符
+## Confirm the on-box command surface still matches the docs
 
 ```bash
 bash scripts/capture-sitecli.sh --check \
@@ -223,7 +296,38 @@ bash scripts/capture-sitecli.sh --check \
   --node "$(terraform output -json ce_vm_names | jq -r '.eastus01')"
 ```
 
-`--check` 不會寫入任何內容，因此對正在運行的示範環境是安全的。
+`--check` writes nothing, so it is safe against the live demo.
+
+## On-Premise KVM & FRR BGP Verification
+
+When the On-Premise KVM extension is deployed, verify hypervisor domain state, ToR router eBGP peering status, and local network reachability:
+
+1. **Verify KVM virtual machine domain state**:
+
+   ```bash
+   virsh list --all
+   ```
+
+   Confirm all three KVM Customer Edge nodes (`onprem-ce-01`, `onprem-ce-02`, `onprem-ce-03`) are in `running` state.
+
+2. **Verify FRR ToR BGP Router peering status**:
+
+   ```bash
+   docker exec frr-router vtysh -c "show ip bgp summary"
+   ```
+
+   Confirm active eBGP sessions with all three On-Prem CEs (ASN `64512`) on local bridge network `ce-bgp-net` (`10.100.0.0/24`), showing established prefixes.
+
+3. **Verify network reachability**:
+
+   ```bash
+   ping -c 3 10.100.0.1
+   for ip in 10.100.0.10 10.100.0.11 10.100.0.12; do
+     ping -c 2 "$ip"
+   done
+   ```
+
+   Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
 
 ## Automated UAT verification script
 
@@ -245,13 +349,13 @@ The script executes all checks against the live deployment, writes `summary.json
 
 <CardGrid>
   <LinkCard
-    title="連線至 Customer Edge"
-    description="適用哪一種存取路徑、各自需要的憑證，以及為何這個選擇不是偏好問題。"
+    title="Reaching a Customer Edge"
+    description="Which access route applies, the credentials each needs, and why the choice is not a preference."
     href="../../customer-edge/access/"
   />
   <LinkCard
-    title="BGP 指令"
-    description="來自 FRR 的機上檢視——peering 狀態、完整路由表，以及此節點所通告的內容。"
+    title="BGP commands"
+    description="The on-box view from FRR — peering state, the full table, and what this node advertises."
     href="../../customer-edge/commands/network/bgp/"
   />
 </CardGrid>


### PR DESCRIPTION
## Summary

Update documentation set across English source and 12 localized locale directories for On-Premise KVM SecureMesh Site v2 with FRR ToR BGP router integration.

Closes #887

## Test plan

- [x] Pre-commit lint gates pass
- [x] i18n locale output validation passes
- [x] CI checks pass