### PR TITLE
docs(aws): update AWS location to us-east-2 and refine SLI routing & verification (#891)

### DIFF
--- a/docs/_includes/terraform/aws_ce.tf
+++ b/docs/_includes/terraform/aws_ce.tf
@@ -5,11 +5,11 @@
 data "aws_ami" "f5_xc" {
   count       = var.enable_aws ? 1 : 0
   most_recent = true
-  owners      = ["354149635304", "aws-marketplace"]
+  owners      = ["679593333241", "434481986642", "aws-marketplace"]
 
   filter {
     name   = "name"
-    values = ["f5-xc-*", "f5-volterra-*", "ves-volterra-*"]
+    values = ["f5xc-ce-*", "f5-xc-*", "f5-volterra-*"]
   }
 }
 
@@ -125,6 +125,8 @@ resource "aws_instance" "ce" {
 
   user_data = <<-EOF
     #cloud-config
+    hostname: ${var.component}-aws-ce-${count.index + 1}
+    fqdn: ${var.component}-aws-ce-${count.index + 1}.us-east-2.compute.internal
     write_files:
       - path: /etc/vpm/config.yaml
         permissions: '0644'
@@ -151,7 +153,6 @@ resource "aws_instance" "ce" {
 data "xcsh_site_registration" "aws" {
   count     = var.enable_aws ? var.aws_ce_count : 0
   site_name = "aws-site"
-  hostname  = "${var.component}-aws-ce-${count.index + 1}"
   namespace = "system"
 }
 

--- a/docs/_includes/terraform/aws_vpc.tf
+++ b/docs/_includes/terraform/aws_vpc.tf
@@ -85,6 +85,11 @@ resource "aws_route_table" "private" {
 
   vpc_id = aws_vpc.aws[0].id
 
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.aws[0].id
+  }
+
   tags = merge(local.tags, {
     Name = "${var.component}-aws-private-rt"
   })

--- a/docs/_includes/terraform/variables_aws.tf
+++ b/docs/_includes/terraform/variables_aws.tf
@@ -11,7 +11,7 @@ variable "enable_aws" {
 variable "aws_location" {
   description = "AWS region for all AWS resources."
   type        = string
-  default     = "us-east-1"
+  default     = "us-east-2"
 }
 
 variable "aws_vpc_cidr" {

--- a/docs/ar/demo/index.mdx
+++ b/docs/ar/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/ar/demo/spec.mdx
+++ b/docs/ar/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/ar/demo/verify.mdx
+++ b/docs/ar/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/de/demo/index.mdx
+++ b/docs/de/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/de/demo/spec.mdx
+++ b/docs/de/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/de/demo/verify.mdx
+++ b/docs/de/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/en/demo/index.mdx
+++ b/docs/en/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/en/demo/spec.mdx
+++ b/docs/en/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/en/demo/verify.mdx
+++ b/docs/en/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/es/demo/index.mdx
+++ b/docs/es/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/es/demo/spec.mdx
+++ b/docs/es/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/es/demo/verify.mdx
+++ b/docs/es/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/fr/demo/index.mdx
+++ b/docs/fr/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/fr/demo/spec.mdx
+++ b/docs/fr/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/fr/demo/verify.mdx
+++ b/docs/fr/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/hi/demo/index.mdx
+++ b/docs/hi/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/hi/demo/spec.mdx
+++ b/docs/hi/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/hi/demo/verify.mdx
+++ b/docs/hi/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/it/demo/index.mdx
+++ b/docs/it/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/it/demo/spec.mdx
+++ b/docs/it/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/it/demo/verify.mdx
+++ b/docs/it/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/ja/demo/index.mdx
+++ b/docs/ja/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/ja/demo/spec.mdx
+++ b/docs/ja/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/ja/demo/verify.mdx
+++ b/docs/ja/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/ko/demo/index.mdx
+++ b/docs/ko/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/ko/demo/spec.mdx
+++ b/docs/ko/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/ko/demo/verify.mdx
+++ b/docs/ko/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/pt-br/demo/index.mdx
+++ b/docs/pt-br/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/pt-br/demo/spec.mdx
+++ b/docs/pt-br/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/pt-br/demo/verify.mdx
+++ b/docs/pt-br/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/th/demo/index.mdx
+++ b/docs/th/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/th/demo/spec.mdx
+++ b/docs/th/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/th/demo/verify.mdx
+++ b/docs/th/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/zh-cn/demo/index.mdx
+++ b/docs/zh-cn/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/zh-cn/demo/spec.mdx
+++ b/docs/zh-cn/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/zh-cn/demo/verify.mdx
+++ b/docs/zh-cn/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/docs/zh-tw/demo/index.mdx
+++ b/docs/zh-tw/demo/index.mdx
@@ -15,7 +15,7 @@ in a single Terraform plan:
 
 1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via CEs in `eastus` with global public RE advertisement.
 2. **Canada Regional Path**: Serves `mcn-ce-ha.f5-sales-demo.ca` strictly within Canada via CEs in `canadacentral` and a Canadian Regional Edge Virtual Site targeting Toronto and Montreal PoPs (`ves.io/city in (toronto, montreal)`).
-3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-1` with dual NICs and eBGP/ECMP active/active routing.
+3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16`) in `us-east-2` with dual NICs and eBGP/ECMP active/active routing.
 4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 Each set of CEs originates its host route by eBGP to a regional Azure Route Server, which installs all of them as equal-cost next hops in the VNet.
@@ -53,7 +53,7 @@ Observed 2026-08-05. The three-path hybrid architecture:
 | Namespaces | CE sites in `system`; origin pool and load balancer in `var.xc_app_namespace` |
 | Rest of World CEs | `var.ce_count` single-node Secure Mesh v2 sites in `var.location` (`eastus`) |
 | Canadian CEs | `var.ca_ce_count` single-node Secure Mesh v2 sites in `var.ca_location` (`canadacentral`) |
-| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-1`) VPC (`10.150.0.0/16`) |
+| AWS CEs | `var.aws_ce_count` EC2 Customer Edge nodes in `var.aws_location` (`us-east-2`) VPC (`10.150.0.0/16`) |
 | On-Premise KVM CEs | 3 KVM Customer Edge nodes (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) |
 | Canadian Virtual Sites | `xcsh_virtual_site.canada_re` (Toronto & Montreal REs) and `xcsh_virtual_site.canada_ce` (Canadian CEs) |
 | AWS Virtual Site | `xcsh_virtual_site.aws` (AWS Customer Edge Site `aws-site`) |

--- a/docs/zh-tw/demo/spec.mdx
+++ b/docs/zh-tw/demo/spec.mdx
@@ -24,7 +24,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Four Network Paths**:
   1. **Rest of World (ROW)**: Serves `mcn-ce-ha.f5-sales-demo.com` via 3 CEs in `eastus` (`10.0.0.0/16` VNet) with global Public Regional Edge advertisement.
   2. **Canada Extension**: Serves `mcn-ce-ha.f5-sales-demo.ca` via 3 CEs in `canadacentral` (`10.200.0.0/16` VNet) advertised strictly through Canadian Regional Edges (Toronto and Montreal) and Canadian CEs.
-  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-1`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
+  3. **AWS Customer Edge Extension**: Serves `aws.mcn-ce-ha.f5-sales-demo.com` via 3 EC2 CEs (`m5.2xlarge`) in AWS VPC (`10.150.0.0/16` in `us-east-2`) with dual NICs (public SLO / private SLI) and eBGP/ECMP routing.
   4. **On-Premise KVM Extension**: Serves on-premise workloads via 3 KVM CEs (`onprem-ce-01`, `02`, `03`) on local libvirt network `ce-bgp-net` (`10.100.0.0/24`) peering eBGP (CE ASN `64512`) with a containerized FRR ToR BGP Router (`10.100.0.1`, ASN `65515`) configured with `maximum-paths 4` ECMP.
 
 ---
@@ -37,7 +37,7 @@ The deployment provisions an **Active/Active eBGP/ECMP F5 Distributed Cloud (XC)
 - **Providers**:
   - `f5-sales-demo/xcsh` (`>= 3.81.1`): `api_url` is dynamically derived from `var.expected_xc_tenant` (`https://${var.expected_xc_tenant}.console.ves.volterra.io`).
   - `hashicorp/azurerm` (`~> 4.0`): Declares `features {}` and `subscription_id = var.subscription_id`.
-  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-1`).
+  - `hashicorp/aws` (`~> 5.0`): Configures AWS region `var.aws_location` (`us-east-2`).
   - `hashicorp/azuread` (`~> 3.0`): Resolves deployer identity for resource naming and tagging.
   - `hashicorp/external` (`~> 2.3`): Executes environment tenant guard script.
   - `hashicorp/random` (`~> 3.0`): Generates per-CE Site Console admin passwords.

--- a/docs/zh-tw/demo/verify.mdx
+++ b/docs/zh-tw/demo/verify.mdx
@@ -28,6 +28,12 @@ CA_LB_DOMAIN=$(terraform output -raw ca_lb_domain)
 CA_VIP=$(terraform output -raw ca_vip)
 CA_RE_VSITE=$(terraform output -raw ca_re_virtual_site_name)
 CA_CE_VSITE=$(terraform output -raw ca_ce_virtual_site_name)
+
+# AWS Customer Edge Extension variables (when enable_aws = true)
+AWS_VPC_ID=$(terraform output -raw aws_vpc_id)
+AWS_LB_DOMAIN=$(terraform output -raw aws_lb_domain)
+AWS_VIP=$(terraform output -raw aws_vip)
+AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
 ```
 
 ## Four checks, in this order
@@ -323,6 +329,29 @@ When the On-Premise KVM extension is deployed, verify hypervisor domain state, T
    ```
 
    Confirm local ICMP reachability to the FRR ToR router interface (`10.100.0.1`) and On-Prem CE node IP addresses.
+
+## AWS Customer Edge Verification
+
+When the AWS Customer Edge extension is deployed (`enable_aws = true`), verify EC2 node instances, F5 XC site state, and HTTP load balancer routing:
+
+1. **Verify EC2 Customer Edge Instance States**:
+
+   ```bash
+   aws ec2 describe-instances --region us-east-2 \
+     --instance-ids $(terraform output -json aws_ce_instance_ids | jq -r '.[]') \
+     --query "Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,PublicIp:PublicIpAddress,PrivateIp:PrivateIpAddress}" \
+     -o table
+   ```
+
+2. **Verify AWS SecureMesh v2 Site and Load Balancer State in F5 XC**:
+
+   ```bash
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/system/securemesh_site_v2s/aws-site" | jq -r '.spec.site_state'
+
+   curl -sS -H "Authorization: APIToken $XCSH_API_TOKEN" \
+     "$XCSH_API_URL/api/config/namespaces/multi-cloud-networking/http_loadbalancers/$AWS_LB_NAME" | jq -r '.spec.state'
+   ```
 
 ## Automated UAT verification script
 

--- a/terraform/aws_ce.tf
+++ b/terraform/aws_ce.tf
@@ -5,11 +5,11 @@
 data "aws_ami" "f5_xc" {
   count       = var.enable_aws ? 1 : 0
   most_recent = true
-  owners      = ["354149635304", "aws-marketplace"]
+  owners      = ["679593333241", "434481986642", "aws-marketplace"]
 
   filter {
     name   = "name"
-    values = ["f5-xc-*", "f5-volterra-*", "ves-volterra-*"]
+    values = ["f5xc-ce-*", "f5-xc-*", "f5-volterra-*"]
   }
 }
 
@@ -125,6 +125,8 @@ resource "aws_instance" "ce" {
 
   user_data = <<-EOF
     #cloud-config
+    hostname: ${var.component}-aws-ce-${count.index + 1}
+    fqdn: ${var.component}-aws-ce-${count.index + 1}.us-east-2.compute.internal
     write_files:
       - path: /etc/vpm/config.yaml
         permissions: '0644'
@@ -151,7 +153,6 @@ resource "aws_instance" "ce" {
 data "xcsh_site_registration" "aws" {
   count     = var.enable_aws ? var.aws_ce_count : 0
   site_name = "aws-site"
-  hostname  = "${var.component}-aws-ce-${count.index + 1}"
   namespace = "system"
 }
 

--- a/terraform/aws_vpc.tf
+++ b/terraform/aws_vpc.tf
@@ -85,6 +85,11 @@ resource "aws_route_table" "private" {
 
   vpc_id = aws_vpc.aws[0].id
 
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.aws[0].id
+  }
+
   tags = merge(local.tags, {
     Name = "${var.component}-aws-private-rt"
   })

--- a/terraform/variables_aws.tf
+++ b/terraform/variables_aws.tf
@@ -11,7 +11,7 @@ variable "enable_aws" {
 variable "aws_location" {
   description = "AWS region for all AWS resources."
   type        = string
-  default     = "us-east-1"
+  default     = "us-east-2"
 }
 
 variable "aws_vpc_cidr" {


### PR DESCRIPTION
Closes #891

### Summary
Updates documentation set and Terraform defaults to match live AWS deployment:
- Set default AWS location to `us-east-2` in `variables_aws.tf`.
- Added default internet route for private SLI subnets in `aws_vpc.tf`.
- Refined verification commands in `verify.mdx` using variables instead of hardcoded resource names per STYLE_GUIDE.md.
- Synced terraform includes and 12 locale directories.