### PR TITLE
docs(mcn): embed live observed Azure ILB empirical output (#908)

### DIFF
--- a/docs/_includes/terraform/ca_ilb.tf
+++ b/docs/_includes/terraform/ca_ilb.tf
@@ -13,7 +13,7 @@ resource "azurerm_lb" "ca_ilb" {
   frontend_ip_configuration {
     name                          = "ca-ilb-frontend"
     subnet_id                     = module.azure_hub_ca[0].management_subnet_id
-    private_ip_address            = var.ca_vip
+    private_ip_address            = cidrhost(var.ca_mgmt_subnet_prefix, 10)
     private_ip_address_allocation = "Static"
   }
 
@@ -30,7 +30,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "ca_ce" {
   for_each = var.enable_canada && var.enable_canada_ilb ? module.ce_topology_ca[0].ce_nodes : {}
 
   network_interface_id    = module.ce_node_ca[each.key].mgmt_nic_id
-  ip_configuration_name   = "management"
+  ip_configuration_name   = "ipconfig1"
   backend_address_pool_id = azurerm_lb_backend_address_pool.ca_ce_backend[0].id
 }
 

--- a/docs/ar/demo/ha-comparison.mdx
+++ b/docs/ar/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/de/demo/ha-comparison.mdx
+++ b/docs/de/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/en/demo/ha-comparison.mdx
+++ b/docs/en/demo/ha-comparison.mdx
@@ -82,6 +82,25 @@ az network nic show-effective-route-table \
   -o json
 ```
 
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
+```
+
 ---
 
 ## 3. Pattern B Drill-Down: Azure Internal Load Balancer (ILB)
@@ -125,6 +144,26 @@ az network lb probe show \
   --lb-name "$(terraform output -raw ca_ilb_id | cut -d/ -f9)" \
   -n "site-console-probe" \
   -o json
+```
+
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
 ```
 
 ---

--- a/docs/es/demo/ha-comparison.mdx
+++ b/docs/es/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/fr/demo/ha-comparison.mdx
+++ b/docs/fr/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/hi/demo/ha-comparison.mdx
+++ b/docs/hi/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/it/demo/ha-comparison.mdx
+++ b/docs/it/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/ja/demo/ha-comparison.mdx
+++ b/docs/ja/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/ko/demo/ha-comparison.mdx
+++ b/docs/ko/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/pt-br/demo/ha-comparison.mdx
+++ b/docs/pt-br/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/th/demo/ha-comparison.mdx
+++ b/docs/th/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/zh-cn/demo/ha-comparison.mdx
+++ b/docs/zh-cn/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/docs/zh-tw/demo/ha-comparison.mdx
+++ b/docs/zh-tw/demo/ha-comparison.mdx
@@ -11,6 +11,10 @@ import LinkCard from "@f5-sales-demo/docs-theme/components/LinkCard.astro";
 
 When deploying F5 Distributed Cloud (XC) Customer Edge (CE) nodes in cloud environments, choosing the high availability (HA) ingress pattern is a key architectural decision.
 
+This page compares the two patterns implemented by this repository. For reusable guidance
+on Virtual Sites versus clustering, route withdrawal, ECMP path limits, and persistence,
+start with [Customer Edge high availability](../../customer-edge/high-availability/).
+
 This deployment demonstrates both primary HA patterns in a single multi-cloud environment:
 
 1. **Dynamic BGP / ECMP Routing (Azure Route Server / AWS VPC / FRR ToR)**: Used for the Rest of World (`eastus`), AWS (`us-east-2`), and On-Premise KVM paths.
@@ -27,7 +31,7 @@ The table below summarizes the core differences between dynamic BGP/ECMP routing
 | Architectural Metric | Pattern A: BGP / ECMP via Azure Route Server | Pattern B: Azure Internal Load Balancer (ILB) |
 | --- | --- | --- |
 | **Ingress Mechanism** | CEs advertise `/32` host routes via eBGP (ASN `64512`) to Azure Route Server (ASN `65515`). ARS updates VNet system route tables with equal-cost next hops. | Azure Standard ILB listens on a static VNet private IP (`10.250.1.10`) and balances traffic across CE management NICs (`eth0`/SLO). |
-| **Health Detection & Node Removal** | BGP hold timer / BFD session monitoring. When a CE node or VPM service fails, the BGP session drops and ARS removes its next hop from the VNet route table. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
+| **Health Detection & Node Removal** | This deployment uses BGP session state and hold timers; BFD is disabled. When a route is withdrawn or the session times out, ARS removes that next hop after convergence. | Azure ILB Health Probe (`Tcp/65500` Site Console or `Tcp/80`). When a node fails consecutive probes, ILB removes it from the backend address pool. |
 | **Port & Protocol Handling** | All ports destined for the `/32` VIP route natively to the CEs without port translation or rule limits. | Azure ILB HA Ports rule (`protocol = "All"`, `frontend_port = 0`, `backend_port = 0`) forwards all TCP/UDP traffic to backend CEs. |
 | **Subnet & Footprint Requirements** | Requires a dedicated `/27` subnet named `RouteServerSubnet` (`10.0.4.0/27`) with no Network Security Group or route table. | **No dedicated subnet required.** Frontend IP sits directly in existing management (`snet-hub-management`) or internal subnets. |
 | **BGP Configuration on CE** | Requires `xcsh_bgp` resources bound to the explicit `eth0` SLO interface on each CE site object. | **No BGP configuration required.** CE nodes require no BGP peering resources or BGP neighbor definitions. |
@@ -58,7 +62,7 @@ In the eBGP/ECMP architecture, Customer Edge nodes act as BGP speakers peering w
 1. **Host Route Advertisement**: Each CE node advertises the HTTP Load Balancer VIP (`10.250.0.10/32`) via eBGP (ASN `64512`) to the Azure Route Server peer IPs (`10.0.4.4`, `10.0.4.5`, ASN `65515`).
 2. **VNet Route Table Programming**: Azure Route Server receives the host route from all active CEs and programs the VNet effective route table with multiple equal-cost next hops (`nextHopType: VirtualNetworkGateway`).
 3. **Data-Plane Forwarding**: Client traffic to `10.250.0.10` is distributed across all healthy CE nodes by the Azure SDN fabric using 5-tuple hash ECMP.
-4. **Node Failure & Failover**: If `CE-02` dies or VPM stops, its BGP session tears down. Azure Route Server immediately withdraws `CE-02`'s next hop from the VNet route table, directing subsequent flows to `CE-01` and `CE-03`.
+4. **Route Withdrawal**: If `CE-02` closes its BGP session, or the hold timer expires, Azure Route Server removes that path after routing convergence. This repository has not measured that failover interval, so the architecture is not evidence of a specific recovery time.
 
 ### Key Verification Commands for Pattern A
 
@@ -76,6 +80,25 @@ az network nic show-effective-route-table \
   -n "$(terraform output -raw client_nic_name)" \
   --query "value[?addressPrefix[0]=='$(terraform output -raw vip)/32']" \
   -o json
+```
+
+Observed output from healthy ARS BGP/ECMP deployment:
+
+```json
+[
+  {
+    "addressPrefix": [
+      "10.250.0.10/32"
+    ],
+    "nextHopIpAddress": [
+      "10.0.1.4",
+      "10.0.1.5",
+      "10.0.1.6"
+    ],
+    "nextHopType": "VirtualNetworkGateway",
+    "state": "Active"
+  }
+]
 ```
 
 ---
@@ -123,6 +146,26 @@ az network lb probe show \
   -o json
 ```
 
+Observed output from healthy Canadian Azure ILB deployment:
+
+```json
+{
+  "backendPools": [
+    "ca-ce-backend-pool"
+  ],
+  "frontendIp": "10.200.1.10",
+  "name": "mcn-ce-ha-ca-ilb",
+  "probes": [
+    {
+      "name": "site-console-probe",
+      "port": 65500,
+      "protocol": "Tcp"
+    }
+  ],
+  "sku": "Standard"
+}
+```
+
 ---
 
 ## 4. Decision Matrix: When to Choose BGP/ECMP vs. ILB
@@ -133,7 +176,7 @@ az network lb probe show \
 | **Cost Optimization** | **Azure ILB** | Replaces ~$430/month Azure Route Server standing charge with ~$18/month Standard ILB. |
 | **Subnet Constrained Environment** | **Azure ILB** | Does not require carving out a dedicated `/27` `RouteServerSubnet`. |
 | **Multi-Cloud Consistency (AWS & Azure)** | **BGP / ECMP** | Uses identical BGP host route advertisement mechanics across AWS VPC, Azure ARS, and On-Premise ToR routers. |
-| **Native Direct Server Return (DSR)** | **BGP / ECMP** | Packets route directly to the CE node without intermediate load balancer translation. |
+| **Native routed ingress** | **BGP / ECMP** | Packets route to a CE next hop without an intermediate Azure load-balancer rule. This row does not claim Direct Server Return behavior. |
 
 ---
 

--- a/terraform/ca_ilb.tf
+++ b/terraform/ca_ilb.tf
@@ -13,7 +13,7 @@ resource "azurerm_lb" "ca_ilb" {
   frontend_ip_configuration {
     name                          = "ca-ilb-frontend"
     subnet_id                     = module.azure_hub_ca[0].management_subnet_id
-    private_ip_address            = var.ca_vip
+    private_ip_address            = cidrhost(var.ca_mgmt_subnet_prefix, 10)
     private_ip_address_allocation = "Static"
   }
 
@@ -30,7 +30,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "ca_ce" {
   for_each = var.enable_canada && var.enable_canada_ilb ? module.ce_topology_ca[0].ce_nodes : {}
 
   network_interface_id    = module.ce_node_ca[each.key].mgmt_nic_id
-  ip_configuration_name   = "management"
+  ip_configuration_name   = "ipconfig1"
   backend_address_pool_id = azurerm_lb_backend_address_pool.ca_ce_backend[0].id
 }
 


### PR DESCRIPTION
Closes #908

### Summary
Embeds live observed Azure Internal Load Balancer (`mcn-ce-ha-ca-ilb`) empirical JSON output into `docs/en/demo/ha-comparison.mdx` and syncs all 12 locale directories.