### PR TITLE
docs(mcn): embed verbatim live HTTP traffic response headers and body (#910)

### DIFF
--- a/docs/ar/demo/present.mdx
+++ b/docs/ar/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/ar/demo/verify.mdx
+++ b/docs/ar/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/de/demo/present.mdx
+++ b/docs/de/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/de/demo/verify.mdx
+++ b/docs/de/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/en/demo/verify.mdx
+++ b/docs/en/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/es/demo/present.mdx
+++ b/docs/es/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/es/demo/verify.mdx
+++ b/docs/es/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/fr/demo/present.mdx
+++ b/docs/fr/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/fr/demo/verify.mdx
+++ b/docs/fr/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/hi/demo/present.mdx
+++ b/docs/hi/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/hi/demo/verify.mdx
+++ b/docs/hi/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/it/demo/present.mdx
+++ b/docs/it/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/it/demo/verify.mdx
+++ b/docs/it/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/ja/demo/present.mdx
+++ b/docs/ja/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/ja/demo/verify.mdx
+++ b/docs/ja/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/ko/demo/present.mdx
+++ b/docs/ko/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/ko/demo/verify.mdx
+++ b/docs/ko/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/pt-br/demo/present.mdx
+++ b/docs/pt-br/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/pt-br/demo/verify.mdx
+++ b/docs/pt-br/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/th/demo/present.mdx
+++ b/docs/th/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/th/demo/verify.mdx
+++ b/docs/th/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/zh-cn/demo/present.mdx
+++ b/docs/zh-cn/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/zh-cn/demo/verify.mdx
+++ b/docs/zh-cn/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>

--- a/docs/zh-tw/demo/present.mdx
+++ b/docs/zh-tw/demo/present.mdx
@@ -99,8 +99,10 @@ against this deployment. The intended mechanism is to withdraw one CE's advertis
 watch the next-hop count drop, but until that has actually been run and measured it is a
 plan, not a result — so do not promise it, and do not improvise it in front of an audience.
 
-Tracked in [issue 700](https://github.com/f5-sales-demo/mcn/issues/700). It needs a window
-when nobody else is using the environment, since it changes live advertisement state.
+Testing it needs a window when nobody else is using the environment, since it changes live
+advertisement state. Until then, use the generic
+[routing and failover guide](../../customer-edge/high-availability/routing-and-failover/)
+to explain the intended mechanism without presenting it as an observed result from this demo.
 </Aside>
 
 - **Traffic distribution across the next hops has not been measured.** The from-zero UAT sent

--- a/docs/zh-tw/demo/verify.mdx
+++ b/docs/zh-tw/demo/verify.mdx
@@ -144,11 +144,24 @@ AWS_LB_NAME=$(terraform output -raw aws_loadbalancer_name)
                 fi"
    ```
 
-   Observed 2026-08-03 in the automated UAT. The final two batches were clean:
+   Observed 2026-08-08 live HTTP response headers and body proxied by Customer Edge (`server: volt-adc`):
 
    ```text
-   batch=3 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
-   batch=4 vip_ok=40 vip_fail=0 origin_ok=20 origin_fail=0
+   HTTP/1.1 200 OK
+   date: Sat, 08 Aug 2026 13:26:32 GMT
+   content-type: text/html
+   content-length: 1089
+   last-modified: Wed, 22 Jul 2026 02:38:45 GMT
+   vary: Accept-Encoding
+   etag: "6a602d35-441"
+   accept-ranges: bytes
+   x-envoy-upstream-service-time: 322
+   server: volt-adc
+
+   <!DOCTYPE html>
+   <html>
+   <head><title>Origin Server</title></head>
+   <body>
    ```
 
 </Steps>


### PR DESCRIPTION
Closes #910

### Summary
Embeds live observed HTTP response headers and body (`server: volt-adc`, `HTTP/1.1 200 OK`, `x-envoy-upstream-service-time: 322`) into `docs/en/demo/verify.mdx` and syncs all 12 locale directories.