### PR TITLE
fix(terraform): use count instead of for_each for aws site registration approval (#914)

### DIFF
--- a/docs/_includes/terraform/aws_ce.tf
+++ b/docs/_includes/terraform/aws_ce.tf
@@ -157,12 +157,8 @@ data "xcsh_site_registration" "aws" {
 }
 
 resource "xcsh_registration_approval" "aws" {
-  for_each = {
-    for idx, reg in data.xcsh_site_registration.aws :
-    idx => reg if var.enable_aws && reg.found
-  }
-
+  count     = var.enable_aws && length(data.xcsh_site_registration.aws) > 0 && try(data.xcsh_site_registration.aws[0].found, false) ? var.aws_ce_count : 0
   namespace = "system"
-  name      = each.value.name
+  name      = data.xcsh_site_registration.aws[count.index].name
   state     = "APPROVED"
 }

--- a/terraform/aws_ce.tf
+++ b/terraform/aws_ce.tf
@@ -157,12 +157,8 @@ data "xcsh_site_registration" "aws" {
 }
 
 resource "xcsh_registration_approval" "aws" {
-  for_each = {
-    for idx, reg in data.xcsh_site_registration.aws :
-    idx => reg if var.enable_aws && reg.found
-  }
-
+  count     = var.enable_aws && length(data.xcsh_site_registration.aws) > 0 && try(data.xcsh_site_registration.aws[0].found, false) ? var.aws_ce_count : 0
   namespace = "system"
-  name      = each.value.name
+  name      = data.xcsh_site_registration.aws[count.index].name
   state     = "APPROVED"
 }


### PR DESCRIPTION
Closes #914

### Summary
Replaces `for_each` with `count` on `xcsh_registration_approval.aws` in `terraform/aws_ce.tf`. This eliminates the `for_each map includes keys derived from resource attributes that cannot be determined until apply` error on fresh plans, imports, and destroyed states.