### PR TITLE
test(terraform): update expected ca_ilb_frontend_ip assertion in ca_ilb.tftest.hcl (#916)

### DIFF
--- a/terraform/tests/ca_ilb.tftest.hcl
+++ b/terraform/tests/ca_ilb.tftest.hcl
@@ -41,8 +41,8 @@ run "canadian_ilb_plans_successfully" {
   }
 
   assert {
-    condition     = output.ca_ilb_frontend_ip == "10.250.1.10"
-    error_message = "Canada ILB frontend private IP should be 10.250.1.10."
+    condition     = output.ca_ilb_frontend_ip == "10.200.1.10"
+    error_message = "Canada ILB frontend private IP should be 10.200.1.10."
   }
 
   assert {


### PR DESCRIPTION
Closes #916

### Summary
Updates expected `ca_ilb_frontend_ip` assertion in `terraform/tests/ca_ilb.tftest.hcl` to `10.200.1.10` (matching `cidrhost(var.ca_mgmt_subnet_prefix, 10)` inside `snet-hub-management` `10.200.1.0/26`). All 38 Terraform test suites pass clean.