### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   validate:
     name: validate
-    runs-on: [self-hosted, Linux, X64, mcn]
+    runs-on: [self-hosted, Linux, X64, mcn, ubuntu-24.04]
     defaults:
       run:
         working-directory: terraform
@@ -78,7 +78,7 @@ jobs:
   # against the dev_overrides build via verify.sh.
   coverage-smsv2:
     name: coverage-smsv2
-    runs-on: [self-hosted, Linux, X64, mcn]
+    runs-on: [self-hosted, Linux, X64, mcn, ubuntu-24.04]
     defaults:
       run:
         working-directory: coverage/smsv2

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   validate:
     name: validate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, mcn]
     defaults:
       run:
         working-directory: terraform
@@ -78,7 +78,7 @@ jobs:
   # against the dev_overrides build via verify.sh.
   coverage-smsv2:
     name: coverage-smsv2
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, mcn]
     defaults:
       run:
         working-directory: coverage/smsv2

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null


### PR DESCRIPTION
Closes #938

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.