### PR TITLE
fix(sitecli): avoid mawk interval regex panic

### DIFF
--- a/scripts/sitecli-scrub.sh
+++ b/scripts/sitecli-scrub.sh
@@ -169,7 +169,9 @@ function scrub_ipv6(line,   out, rest, tok, pre, post, first) {
     tok  = substr(rest, RSTART, RLENGTH)
     post = substr(rest, RSTART + RLENGTH)
 
-    if (tok !~ /::/ && tok !~ /(^|:)[0-9A-Fa-f]{3,4}(:|$)/) {
+    # Spell out the 3-or-4-hextet width: runner mawk panics on {3,4} here.
+    if (tok !~ /::/ && \
+        tok !~ /(^|:)[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]?(:|$)/) {
       out = out pre tok                     # a MAC, or a plain colon list
       rest = post
       continue


### PR DESCRIPTION
## Summary

- replace the failing `{3,4}` awk interval with an equivalent POSIX ERE
- preserve public IPv6 detection and MAC-address exclusion behavior
- document the managed-runner `mawk` compatibility constraint
- stack this content-only repair on the exact managed-caller branch from #945 so the protected caller remains automation-owned and both changes are tested together

## Verification

- `bash -n scripts/sitecli-scrub.sh`
- `bash tests/test-sitecli-scrub.sh`
- focused suite in `ghcr.io/f5-sales-demo/actions-runner@sha256:8fa760afed6b45cf4508b350f3899e7604c53e5e8288491025927f159781387a`
- complete governed consumer shell suite
- `git diff --check`
- exact-HEAD `bash scripts/agy-pre-push-review.sh` (reviewer and verifier: no blocking findings)

Closes #943